### PR TITLE
Add COG processing queue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       BASE_DIR: /data
       SUPABASE_URL: ${SUPABASE_URL}
       SUPABASE_KEY: ${SUPABASE_KEY}
+      PROCESSOR_USERNAME: processor@deadtrees.earth
+      PROCESSOR_PASSWORD: ${SUPABASE_PASSWORD}
       UVICORN_PORT: 8762
       UVICORN_HOST: 0.0.0.0
   

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,24 +14,24 @@ services:
       UVICORN_PORT: 8762
       UVICORN_HOST: 0.0.0.0
   
-  # migrate:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #   volumes:
-  #     - ./data:/data
-  #     - ./src:/app/src
-  #   links:
-  #     - api
-  #   command: echo "Run migration service as 'docker compose run --rm migrate bash'"
-  #   environment:
-  #     BASE_DIR: /data
-  #     SUPABASE_URL: ${SUPABASE_URL}
-  #     SUPABASE_KEY: ${SUPABASE_KEY}
-  #     SUPABASE_USER: processor@deadtrees.earth
-  #     SUPABASE_PASSWORD: ${SUPABASE_PASSWORD}
-  #     OLD_ARCHIVE_PATH: /data/to_migrate
-  #     API_URL: http://api:8762
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./data:/data
+      - ./src:/app/src
+    links:
+      - api
+    command: echo "Run migration service as 'docker compose run --rm migrate bash'"
+    environment:
+      BASE_DIR: /data
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_KEY: ${SUPABASE_KEY}
+      PROCESSOR_USERNAME: processor@deadtrees.earth
+      PROCESSOR_PASSWORD: ${SUPABASE_PASSWORD}
+      OLD_ARCHIVE_PATH: /data/to_migrate
+      API_URL: http://api:8762
 
-  #     # migration metadata
-  #     MIGRATION_TABLE: migrate_v1
+      # migration metadata
+      MIGRATION_TABLE: migrate_v1

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -12,7 +12,7 @@ import httpx
 from .supabase import login, use_client
 from .logger import logger
 from .models import MetadataPayloadData, LabelPayloadData, Dataset
-from .settings import settings
+
 
 @cache
 def get_old_env(**kwargs) -> dict:
@@ -28,8 +28,8 @@ def get_old_env(**kwargs) -> dict:
     archive_path = kwargs.get('archive_path', os.environ.get('OLD_ARCHIVE_PATH', '/apps/storage-server/dev-data/archive'))
 
     # new user
-    supabase_user = kwargs.get('supabase_user', os.environ.get('SUPABASE_USER'))
-    supabase_password = kwargs.get('supabase_password', os.environ.get('SUPABASE_PASSWORD'))
+    supabase_user = kwargs.get('processor_user', os.environ.get('PROCESSOR_USER'))
+    supabase_password = kwargs.get('processor_password', os.environ.get('PROCESSOR_PASSWORD'))
     token = kwargs.get('token')
 
     # set the API url

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -28,7 +28,7 @@ def get_old_env(**kwargs) -> dict:
     archive_path = kwargs.get('archive_path', os.environ.get('OLD_ARCHIVE_PATH', '/apps/storage-server/dev-data/archive'))
 
     # new user
-    supabase_user = kwargs.get('processor_user', os.environ.get('PROCESSOR_USER'))
+    supabase_user = kwargs.get('processor_user', os.environ.get('PROCESSOR_USERNAME'))
     supabase_password = kwargs.get('processor_password', os.environ.get('PROCESSOR_PASSWORD'))
     token = kwargs.get('token')
 
@@ -92,16 +92,13 @@ def migrate_file(old_metadata: dict) -> None:
         msg = f"Cannot migrage file {origin_path}. File does not exist."
         logger.error(msg, extra={'token': conf['token']})
         return
-    # else:
-    #     new_file_name = Path(conf['archive_path']) / old_metadata['file_name']
-    #     origin_path.rename(new_file_name)
-        # print(new_file_name)
     
     # start the timer
     t1 = time.time()
 
     # for all the requests build a header
     header = {'Authorization': f"Bearer {conf['token']}"}
+    
     # upload the new file
     try:
         # set the file object
@@ -131,32 +128,33 @@ def migrate_file(old_metadata: dict) -> None:
     # send the metadata
     try:
         response = httpx.put(f"{conf['api_url']}/datasets/{dataset.id}/metadata", json=metadata.model_dump(), headers=header, timeout=10)
-        print(response.json())
+        print(f"Saved metadata: {response.json()}")
     except Exception as e:
         logger.exception(f"An error occurred while trying to upload the metadata: {str(e)}", extra={'token': conf['token']})
         return
     
     # build the new label
-    label = LabelPayloadData(
-        aoi=old_metadata['aoi']['features'][0]['geometry'],
-        label=merge_multipolygon_geometries(old_metadata['standing_deadwood']),
-        label_source=old_metadata['label_source'],
-        label_quality=int(float(old_metadata['label_quality'])),
-        label_type=old_metadata['label_type']
-    )
+    if 'features' not in old_metadata['aoi'] or len(old_metadata['aoi']['features']) == 0:
+        logger.warning(f"No AOI found for dataset {dataset.id}. Skipping label creation.", extra={'token': conf['token']})
+    else:
+        label = LabelPayloadData(
+            aoi=old_metadata['aoi']['features'][0]['geometry'],
+            label=merge_multipolygon_geometries(old_metadata['standing_deadwood']),
+            label_source=old_metadata['label_source'],
+            label_quality=int(float(old_metadata['label_quality'])),
+            label_type=old_metadata['label_type']
+        )
 
-    # send the label
-    try:
-        response = httpx.post(f"{conf['api_url']}/datasets/{dataset.id}/labels", json=label.model_dump(), headers=header, timeout=10)
-        print(response.json())
-    except Exception as e:
-        logger.exception(f"An error occurred while trying to upload the label: {str(e)}", extra={'token': conf['token']})
-        return
+        # send the label
+        try:
+            response = httpx.post(f"{conf['api_url']}/datasets/{dataset.id}/labels", json=label.model_dump(), headers=header, timeout=10)
+        except Exception as e:
+            logger.exception(f"An error occurred while trying to upload the label: {str(e)}", extra={'token': conf['token']})
 
     # build the new cog
     try:
         response = httpx.put(f"{conf['api_url']}/datasets/{dataset.id}/build-cog", json=dict(), headers=header, timeout=None)
-        print(response.json())
+        print(f"COG build response: {response.json()}")
     except Exception as e:
         logger.exception(f"An error occurred while trying to build the COG: {str(e)}", extra={'token': conf['token']})
         return

--- a/src/models.py
+++ b/src/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, field_serializer, field_validator
 from pydantic_geojson import MultiPolygonModel, PolygonModel
 from pydantic_partial import PartialModelMixin
+from pydantic_settings import BaseSettings
 from rasterio.coords import BoundingBox
 
 
@@ -39,6 +40,29 @@ class LabelTypeEnum(str, Enum):
     segmentation = "segmentation"
     instance_segmentation = "instance_segmentation"
     semantic_segmentation = "semantic_segmentation"
+
+
+class ProcessOptions(BaseSettings):
+    overviews: Optional[int] = 8
+    resolution: Optional[float] = 0.04
+    profile: Optional[str] = "jpeg"
+    quality: Optional[int] = 75
+    force_recreate: Optional[bool] = False
+
+
+class TaskPayload(BaseModel):
+    id: Optional[int] = None
+    dataset_id: int
+    user_id: int
+    priority: int = 2
+    build_args: ProcessOptions = ProcessOptions()
+    is_processing: bool = False
+    created_at: Optional[datetime] = None
+
+
+class QueueTask(TaskPayload):
+    estimated_time: float
+    current_position: int
 
 
 class Dataset(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -53,7 +53,7 @@ class ProcessOptions(BaseSettings):
 class TaskPayload(BaseModel):
     id: Optional[int] = None
     dataset_id: int
-    user_id: int
+    user_id: str
     priority: int = 2
     build_args: ProcessOptions = ProcessOptions()
     is_processing: bool = False

--- a/src/processing.py
+++ b/src/processing.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+import time
+
+from .supabase import use_client, login
+from .settings import settings
+from .models import StatusEnum, Dataset, QueueTask, Cog
+from .logger import logger
+from . import monitoring
+from .deadwood.cog import calculate_cog
+
+
+def update_status(token: str, dataset_id: int, status: StatusEnum):
+    with use_client(token) as client:
+        client.table(settings.datasets_table).update({
+            'status': status.value,
+        }).eq('id', dataset_id).execute()
+
+
+def process_cog(task: QueueTask):
+    # login with the processor
+    token = login(settings.processor_username, settings.processor_password).session.access_token
+
+    # load the dataset
+    try:
+        with use_client(token) as client:
+            # filter using the given dataset_id
+            response = client.table(settings.datasets_table).select('*').eq('id', task.dataset_id).execute()
+            
+            # create the dataset
+            dataset = Dataset(**response.data[0])
+    except Exception as e:
+        # log the error to the database
+        msg = f"PROCESSOR error loading dataset {task.dataset_id}: {str(e)}"
+        logger.error(msg, extra={"token": token, "user_id": task.user_id, "dataset_id": task.dataset_id})
+    
+    # update the status to processing
+    update_status(token, dataset_id=dataset.id, status=StatusEnum.processing)
+
+    # get the input path
+    input_path = settings.archive_path / dataset.file_name
+
+    # get the options
+    options = task.build_args
+
+    # get the output settings
+    cog_folder = Path(dataset.file_name).stem
+    file_name = f"{cog_folder}_cog_{options.profile}_ovr{options.overviews}_q{options.quality}.tif"
+
+    # output path is the cog folder, then a folder for the dataset, then the cog file
+    output_path = settings.cog_path / cog_folder / file_name
+
+    # crete if not exists
+    if not output_path.parent.exists():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    t1 = time.time()
+    try:
+        info = calculate_cog(
+            str(input_path), 
+            str(output_path), 
+            profile=options.profile, 
+            overviews=options.overviews, 
+            quality=options.quality,
+            skip_recreate=not options.force_recreate
+        )
+        logger.info(f"COG profile returned for dataset {dataset.id}: {info}", extra={"token": token, "dataset_id": dataset.id, "user_id": task.user_id})
+    except Exception as e:
+        msg = f"Error processing COG for dataset {dataset.id}: {str(e)}"
+
+        # set the status
+        update_status(token, dataset.id, StatusEnum.errored)
+
+        # log the error to the database
+        logger.error(msg, extra={"token": token, "user_id": task.user_id, "dataset_id": dataset.id})
+        return
+    
+    # get the size of the output file
+    pass
+    # stop the timer
+    t2 = time.time()
+
+    # fill the metadata
+    meta = dict(
+        dataset_id=dataset.id,
+        cog_folder=cog_folder,
+        cog_name=file_name,
+        cog_url=f"{cog_folder}/{file_name}",
+        cog_size=output_path.stat().st_size,
+        runtime=t2 - t1,
+        user_id=task.user_id,
+        compression=options.profile,
+        overviews=options.overviews,
+        # !! This is not correct!! 
+        resolution=int(options.resolution * 100),
+        blocksize=info.IFD[0].Blocksize[0],
+    )
+
+    # dev
+    cog = Cog(**meta)
+
+    with use_client(token) as client:
+        try:
+            # filter out the None data
+            send_data = {k: v for k, v in cog.model_dump().items() if k != 'id' and v is not None}
+            response = client.table(settings.cogs_table).insert(send_data).execute()
+        except Exception as e:
+            msg = f"An error occured while trying to save the COG metadata for dataset {dataset.id}: {str(e)}"
+
+            logger.error(msg, extra={"token": token, "user_id": task.user_id, "dataset_id": dataset.id})
+            update_status(token, dataset.id, StatusEnum.errored)
+    
+    # if there was no error, update the status
+    update_status(token, dataset.id, StatusEnum.processed)
+
+    # monitoring
+    monitoring.cog_counter.inc()
+    monitoring.cog_time.observe(cog.runtime)
+    monitoring.cog_size.observe(cog.cog_size)
+
+    logger.info(f"Finished creating new COG <profile: {cog.compression}> for dataset {dataset.id}.", extra={"token": token, "dataset_id": dataset.id, "user_id": task.user_id})
+
+

--- a/src/queue.py
+++ b/src/queue.py
@@ -1,0 +1,74 @@
+from threading import Timer
+
+from .models import QueueTask
+from .settings import settings
+from .supabase import use_client, login
+from .processing import process_cog
+from .logger import logger
+
+
+
+def current_running_tasks(token: str) -> int:
+    with use_client(token) as client:
+        response = client.table(settings.queue_table).select("id").eq("is_processing", True).execute()
+        num_of_tasks = len(response.data)
+    
+    return num_of_tasks
+
+
+def get_next_task(token: str) -> QueueTask:
+    with use_client(token) as client:
+        response = client.table(settings.queue_position_table).select("*").limit(1).execute()
+    
+    if not response.data or len(response.data) == 0:
+        return None
+    return QueueTask(**response.data[0])
+
+
+def process_task(task: QueueTask, token: str):
+
+    # mark this task as processing
+    with use_client(token) as client:
+        client.table(settings.queue_table).update({"is_processing": True}).eq("id", task.id).execute()
+    
+    # Do the main processing here
+    try:
+        process_cog(task)
+
+    except Exception as e:
+        # log the error to the database
+        msg = f"PROCESSOR error processing task {task.id}: {str(e)}"
+        logger.error(msg, extra={"token": token, "task_id": task.id})
+    finally:
+        # delete the task from the queue in any case
+        with use_client(token) as client:
+            client.table(settings.queue_table).delete().eq("id", task.id).execute()
+
+
+def background_process():
+    """
+    This process checks if there is anything to in the queue. 
+    If so, it checks the currently running tasks against the maximum allowed tasks.
+    If another task can be started, it will do so, if not, the background_process is 
+    added to the FastAPI background tasks with a configured delay.
+
+    """
+    # use the processor to log in
+    token = login(settings.processor_username, settings.processor_password).session.access_token
+
+    # get the number of currently running tasks
+    num_of_tasks = current_running_tasks(token)
+
+    # check if we can start another task
+    if num_of_tasks < settings.concurrent_tasks:
+        # get the next task
+        task = get_next_task(token)
+        if task is not None:
+            process_task(task, token=token)
+        else:
+            # we expected a task here, but there was None
+            logger.error("Expected a task to process, but none was in the queue.", extra={"token": token})
+    else:
+        # restart this process after the configured delay
+        Timer(interval=settings.task_retry_delay, function=background_process).start()
+        

--- a/src/queue.py
+++ b/src/queue.py
@@ -84,6 +84,8 @@ def background_process():
             # we expected a task here, but there was None
             logger.error("Expected a task to process, but none was in the queue.", extra={"token": token})
     else:
+        # inform no spot available
+        logger.debug(f"No spot available for new task. Retry in {settings.task_retry_delay} seconds.", extra={"token": token})
         # restart this process after the configured delay
         Timer(interval=settings.task_retry_delay, function=background_process).start()
         

--- a/src/routers/cog.py
+++ b/src/routers/cog.py
@@ -76,7 +76,7 @@ def create_cog(dataset_id: int, options: Optional[ProcessOptions], token: Annota
             response = (
                 client.table(settings.queue_position_table)
                 .select('*')
-                .filter('id', payload.id)
+                .eq('id', payload.id)
                 .execute()
             )
             task = QueueTask(**response.data[0])

--- a/src/routers/cog.py
+++ b/src/routers/cog.py
@@ -1,17 +1,14 @@
 from typing import Optional, Annotated
-from pathlib import Path
-import time
 
-from pydantic_settings import BaseSettings
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from fastapi.security import OAuth2PasswordBearer
 
 from ..supabase import verify_token, use_client
 from ..settings import settings
-from ..models import Dataset, Cog, StatusEnum
+from ..models import Dataset, ProcessOptions, TaskPayload, QueueTask
 from ..logger import logger
-from ..deadwood.cog import calculate_cog
 from .. import monitoring
+from ..queue import background_process
 
 
 # create the router for the processing
@@ -20,23 +17,9 @@ router = APIRouter()
 # create the OAuth2 password scheme for supabase login
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
-def update_status(token: str, dataset_id: int, status: StatusEnum):
-    with use_client(token) as client:
-        client.table(settings.datasets_table).update({
-            'status': status.value,
-        }).eq('id', dataset_id).execute()
-
-
-class ProcessOptions(BaseSettings):
-    overviews: Optional[int] = 8
-    resolution: Optional[float] = 0.04
-    profile: Optional[str] = "jpeg"
-    quality: Optional[int] = 75
-    force_recreate: Optional[bool] = False
-
 
 @router.put("/datasets/{dataset_id}/build-cog")
-def create_cog(dataset_id: int, options: Optional[ProcessOptions], token: Annotated[str, Depends(oauth2_scheme)]):
+def create_cog(dataset_id: int, options: Optional[ProcessOptions], token: Annotated[str, Depends(oauth2_scheme)], background_tasks: BackgroundTasks):
     """
     
     """
@@ -63,93 +46,52 @@ def create_cog(dataset_id: int, options: Optional[ProcessOptions], token: Annota
         
         return HTTPException(status_code=500, detail=msg)
 
-    # from here on we have a dataset object
-    update_status(token, dataset.id, StatusEnum.processing)
-
-    # get the input path
-    input_path = settings.archive_path / dataset.file_name
-
     # get the options
     options = options or ProcessOptions()
 
-    # get the output settings
-    cog_folder = Path(dataset.file_name).stem
-    file_name = f"{cog_folder}_cog_{options.profile}_ovr{options.overviews}_q{options.quality}.tif"
-
-    # output path is the cog folder, then a folder for the dataset, then the cog file
-    output_path = settings.cog_path / cog_folder / file_name
-
-    # crete if not exists
-    if not output_path.parent.exists():
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # start the timer
-    t1 = time.time()
+    # add a new task to the queue
     try:
-        info = calculate_cog(
-            str(input_path), 
-            str(output_path), 
-            profile=options.profile, 
-            overviews=options.overviews, 
-            quality=options.quality,
-            skip_recreate=not options.force_recreate
+        payload = TaskPayload(
+            dataset_id=dataset.id,
+            user_id=user.id,
+            build_args=options,
+            priority=2,
+            is_processing=False
         )
-        logger.info(f"COG profile returned for dataset {dataset_id}: {info}", extra={"token": token, "dataset_id": dataset_id, "user_id": user.id})
+
+        with use_client(token) as client:
+            send_data = {k: v for k, v in payload.model_dump().items() if v is not None and k != 'id'}
+            response = client.table(settings.queue_table).insert(send_data).execute()
+            payload = TaskPayload(**response.data[0])
     except Exception as e:
-        msg = f"Error processing COG for dataset {dataset_id}: {str(e)}"
-
-        # set the status
-        update_status(token, dataset.id, StatusEnum.errored)
-
         # log the error to the database
+        msg = f"Error adding task to queue: {str(e)}"
         logger.error(msg, extra={"token": token, "user_id": user.id, "dataset_id": dataset_id})
+        
+        return HTTPException(status_code=500, detail=msg)
+        
+    # load the current position assigned to this task
+    try:
+        with use_client(token) as client:
+            response = (
+                client.table(settings.queue_position_table)
+                .select('*')
+                .filter('id', payload.id)
+                .execute()
+            )
+            task = QueueTask(**response.data[0])
+    except Exception as e:
+        # log the error to the database
+        msg = f"Error loading task position: {str(e)}"
+        logger.error(msg, extra={"token": token, "user_id": user.id, "dataset_id": dataset_id})
+        
         return HTTPException(status_code=500, detail=msg)
     
-    # get the size of the output file
-    pass
-    # stop the timer
-    t2 = time.time()
+    # start the background task
+    background_tasks.add_task(background_process)
 
-    # fill the metadata
-    meta = dict(
-        dataset_id=dataset_id,
-        cog_folder=cog_folder,
-        cog_name=file_name,
-        cog_url=f"{cog_folder}/{file_name}",
-        cog_size=output_path.stat().st_size,
-        runtime=t2 - t1,
-        user_id=user.id,
-        compression=options.profile,
-        overviews=options.overviews,
-        # !! This is not correct!! 
-        resolution=int(options.resolution * 100),
-        blocksize=info.IFD[0].Blocksize[0],
-    )
+    # return the task
+    return task
 
-    # dev
-    print(meta)
-    cog = Cog(**meta)
 
-    with use_client(token) as client:
-        try:
-            # filter out the None data
-            send_data = {k: v for k, v in cog.model_dump().items() if k != 'id' and v is not None}
-            response = client.table(settings.cogs_table).insert(send_data).execute()
-        except Exception as e:
-            msg = f"An error occured while trying to save the COG metadata for dataset {dataset_id}: {str(e)}"
 
-            logger.error(msg, extra={"token": token, "user_id": user.id, "dataset_id": dataset_id})
-            update_status(token, dataset.id, StatusEnum.errored)
-            return HTTPException(status_code=500, detail=msg)
-    
-    # if there was no error, update the status
-    update_status(token, dataset.id, StatusEnum.processed)
-
-    # monitoring
-    monitoring.cog_counter.inc()
-    monitoring.cog_time.observe(cog.runtime)
-    monitoring.cog_size.observe(cog.cog_size)
-
-    logger.info(f"Finished creating new COG <profile: {cog.compression}> for dataset {dataset_id}.", extra={"token": token, "dataset_id": dataset_id, "user_id": user.id})
-
-    return cog

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,6 +40,12 @@ class Settings(BaseSettings):
     cogs_table: str = 'v1_cogs'
     labels_table: str = 'v1_labels'
 
+    # queue settings
+    queue_table: str = 'v1_queue'
+    queue_position_table: str = 'v1_queue_positions'
+    concurrent_tasks: int = 2
+    task_retry_delay: int = 60
+
     @property
     def base_path(self) -> Path:
         path = Path(self.base_dir)


### PR DESCRIPTION
This PR introduces the new queueing functionality. Now, the `/datasets/<dataset_id>/build-cog` adds a * task* to the `v1_queue` table and starts a background task.

This background task checks each minute if there are less tasks marked as `IS_PROCESSING` in the queue, than configured in the settings (defaults to 2 concurrent jobs). If there is capacity, the COG is processed. 
With each finishing background task, the process checks if there are still positions in the `v1_queue_positions` view. This is filtered for non-processing tasks only, along with their position and estimated wait time. 
That means, that a background task will switch to another task, if a new task with higher priority has been added to the queue, while the background process waits for a minute. If the queue is empty, the process exits.

@JesJehle I might need to walk you through the logic, before you implement this into the frontend