### PR TITLE
Date to year month day

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -194,7 +194,9 @@ class Metadata(MetadataPayloadData):
     name: str
     license: LicenseEnum
     platform: PlatformEnum
-    aquisition_date: datetime
+    year: int
+    month: int
+    day: int
 
 
 class LabelPayloadData(PartialModelMixin, BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -166,6 +166,9 @@ class MetadataPayloadData(PartialModelMixin, BaseModel):
     gadm_name_3: Optional[str] = None
 
     aquisition_date: Optional[datetime] = None
+    year: Optional[int] = None
+    month: Optional[int] = None
+    day: Optional[int] = None
     
     @field_serializer('aquisition_date', mode='plain')
     def datetime_to_isoformat(field: datetime | None) -> str | None:

--- a/src/models.py
+++ b/src/models.py
@@ -165,16 +165,9 @@ class MetadataPayloadData(PartialModelMixin, BaseModel):
     gadm_name_2: Optional[str] = None
     gadm_name_3: Optional[str] = None
 
-    aquisition_date: Optional[datetime] = None
     aquisition_year: Optional[int] = None
     aquisition_month: Optional[int] = None
     aquisition_day: Optional[int] = None
-    
-    @field_serializer('aquisition_date', mode='plain')
-    def datetime_to_isoformat(field: datetime | None) -> str | None:
-        if field is None:
-            return None
-        return field.isoformat()
 
 
 class Metadata(MetadataPayloadData):
@@ -194,9 +187,8 @@ class Metadata(MetadataPayloadData):
     name: str
     license: LicenseEnum
     platform: PlatformEnum
-    year: int
-    month: int
-    day: int
+    # only the aquisition_year is necessary
+    aquisition_year: int
 
 
 class LabelPayloadData(PartialModelMixin, BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -166,9 +166,9 @@ class MetadataPayloadData(PartialModelMixin, BaseModel):
     gadm_name_3: Optional[str] = None
 
     aquisition_date: Optional[datetime] = None
-    year: Optional[int] = None
-    month: Optional[int] = None
-    day: Optional[int] = None
+    aquisition_year: Optional[int] = None
+    aquisition_month: Optional[int] = None
+    aquisition_day: Optional[int] = None
     
     @field_serializer('aquisition_date', mode='plain')
     def datetime_to_isoformat(field: datetime | None) -> str | None:


### PR DESCRIPTION
Added fields for year month and day to the metadata model.

- [x] fields need to be created in supabase
- [x] existing aquisition_date datetime values need to be migrated to the new fields
- [ ] after that aquisition_date field can be deleted in supabase 
- [x] also in the metadata model in the routes
- [x] function datetime_to_isoformat can be deleted as well