### PR TITLE
added numeric version of localhost to regex

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -17,7 +17,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=['https://deadtrees.earth', 'https://www.deadtrees.earth'],
-    allow_origin_regex='http://localhost:.*',
+    allow_origin_regex="http://(127\\.0\\.0\\.1|localhost)(:\\d+)?",
     allow_credentials=True,
     allow_methods=['OPTIONS', 'GET', 'POST', 'PUT'],
     allow_headers=['Content-Type', 'Authorization', 'Origin', 'Accept'],


### PR DESCRIPTION
next to the fixed `allow_methods` I also needed to check for the numeric version of localhost. 
so i updated `allow_origin_regex`: 
`+ allow_origin_regex="http://(127\\.0\\.0\\.1|localhost)(:\\d+)?"`


now the CORS errors are fixed.