### PR TITLE
adding preview channel to the FastAPI configuration

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -17,7 +17,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=['https://deadtrees.earth', 'https://www.deadtrees.earth'],
-    allow_origin_regex="http://(127\\.0\\.0\\.1|localhost)(:\\d+)?",
+    allow_origin_regex='https://deadwood-d4a4b.*|http://(127\\.0\\.0\\.1|localhost)(:\\d+)?',
     allow_credentials=True,
     allow_methods=['OPTIONS', 'GET', 'POST', 'PUT'],
     allow_headers=['Content-Type', 'Authorization', 'Origin', 'Accept'],


### PR DESCRIPTION
To have the API working on the preview channels use by Firebase. 
I would also include: `https://deadwood-d4a4b.*` to `allow_origin_regex` 
All preview channels start with this: 
`https://deadwood-d4a4b--update-deadwood-api-tr30x927.web.app/dataset/79`
