### PR TITLE
Implemented Chunked upload mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cursorrules
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/routers/upload.py
+++ b/src/routers/upload.py
@@ -139,8 +139,8 @@ async def upload_geotiff_chunk(
 
         # Process the combined file (similar to the original upload endpoint)
         uid = str(uuid.uuid4())
-        file_name = f"{uid}_{Path(filename).stem}.tif"
-        target_path = settings.archive_path / file_name
+        filename_uid = f"{uid}_{Path(filename).stem}.tif"
+        target_path = settings.archive_path / filename_uid
 
         # Move the combined file to the target path
         shutil.move(str(combined_file), str(target_path))

--- a/src/routers/upload.py
+++ b/src/routers/upload.py
@@ -249,7 +249,6 @@ async def upload_geotiff(
         file_size=target_path.stat().st_size,
         copy_time=t2 - t1,
         sha256=sha256,
-        # bbox=f"BOX({bounds.bottom} {bounds.left}, {bounds.top} {bounds.right})",
         bbox=transformed_bounds,
         status=StatusEnum.pending,
         user_id=user.id,

--- a/src/settings.py
+++ b/src/settings.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     archive_dir: str = "archive"
     cog_dir: str = "cogs"
     thumbnails_dir: str = "thumbnails"
+    tmp_upload_dir: Path = Path("tmp")
 
     # supabase settings for supabase authentication
     supabase_url: Optional[str] = None
@@ -46,6 +47,14 @@ class Settings(BaseSettings):
     queue_position_table: str = "v1_queue_positions"
     concurrent_tasks: int = 2
     task_retry_delay: int = 60
+
+    @property
+    def tmp_upload_path(self) -> Path:
+        path = self.base_path / self.tmp_upload_dir
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+
+        return path
 
     @property
     def base_path(self) -> Path:

--- a/src/settings.py
+++ b/src/settings.py
@@ -19,7 +19,6 @@ class Settings(BaseSettings):
     archive_dir: str = "archive"
     cog_dir: str = "cogs"
     thumbnails_dir: str = "thumbnails"
-    tmp_upload_dir: Path = Path("tmp")
 
     # supabase settings for supabase authentication
     supabase_url: Optional[str] = None
@@ -47,14 +46,6 @@ class Settings(BaseSettings):
     queue_position_table: str = "v1_queue_positions"
     concurrent_tasks: int = 2
     task_retry_delay: int = 60
-
-    @property
-    def tmp_upload_path(self) -> Path:
-        path = self.base_path / self.tmp_upload_dir
-        if not path.exists():
-            path.mkdir(parents=True, exist_ok=True)
-
-        return path
 
     @property
     def base_path(self) -> Path:


### PR DESCRIPTION
The previous upload mechanism was unable to handle large files because the entire image had to be loaded into memory at several stages of the upload process, both on the client and server sides.

This PR introduces a chunked upload mechanism through an additional API route, enabling the frontend application to upload files of any size. With this approach, the server no longer loads the entire file into memory. Instead, the upload is processed in chunks, and the hash is computed incrementally.

Chunks are temporarily stored in a new tmp folder and are combined once the final chunk is uploaded. After successful assembly, the chunks are cleared. Currently, in case of an error, chunks are not deleted to allow for potential future implementation of upload resumption. For now, manual cleanup of chunks is acceptable in case of failure.
I have tested this feature extensively in a local environment, and it has proven to be reliable.

Next Steps:
This PR will be followed by another with the same name, implementing the chunked upload mechanism on the frontend. The old upload routes remain functional for now. If the route is online, I can make a preview channel of the site and you can test the upload.