### PR TITLE
Use logfire Logfire

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,7 +6,6 @@ pydantic_partial
 python-dotenv
 python-multipart
 supabase
-prometheus-client
 rasterio==1.4.2
 rio-cogeo
 fire
@@ -22,3 +21,4 @@ pytest-mock
 pytest-cov
 debugpy
 fastapi[testclient]
+logfire[fastapi,system-metrics]

--- a/api/src/routers/download.py
+++ b/api/src/routers/download.py
@@ -13,7 +13,6 @@ from shared.__version__ import __version__
 from shared.models import Dataset, Label, Metadata
 from shared.settings import settings
 from api.src.download.downloads import bundle_dataset, label_to_geopackage
-from shared import monitoring
 
 # first approach to implement a rate limit
 CONNECTED_IPS = {}
@@ -96,8 +95,7 @@ async def download_dataset(dataset_id: str, background_tasks: BackgroundTasks):
 	if metadata is None:
 		raise HTTPException(status_code=404, detail=f'Dataset <ID={dataset_id}> has no associated Metadata entry.')
 
-	# here we can add the monitoring
-	monitoring.download_dataset.inc()
+
 
 	# load the label
 	# TODO: this loads immer nur das erste Label!!!

--- a/api/src/routers/labels.py
+++ b/api/src/routers/labels.py
@@ -8,7 +8,6 @@ from shared.settings import settings
 from shared.logger import logger
 from shared.models import Dataset, Label, LabelPayloadData, UserLabelObject
 from ..labels.labels import verify_labels
-from shared import monitoring
 
 # create the router for the labels
 router = APIRouter()
@@ -20,9 +19,6 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token')
 @router.post('/datasets/{dataset_id}/labels')
 def create_new_labels(dataset_id: int, data: LabelPayloadData, token: Annotated[str, Depends(oauth2_scheme)]):
 	""" """
-	# count an invoke
-	monitoring.label_invoked.inc()
-
 	# first thing we do is verify the token
 	user = verify_token(token)
 	if not user:
@@ -88,7 +84,6 @@ def create_new_labels(dataset_id: int, data: LabelPayloadData, token: Annotated[
 	label = Label(**response.data[0])
 
 	# do some monitoring
-	monitoring.label_counter.inc()
 	logger.info(
 		f'Created new label <ID={label.id}> for dataset {dataset_id}.',
 		extra={'token': token, 'dataset_id': dataset_id, 'user_id': user.id},

--- a/api/src/routers/upload.py
+++ b/api/src/routers/upload.py
@@ -11,7 +11,6 @@ from shared.models import Metadata, MetadataPayloadData
 from shared.supabase import use_client, verify_token
 from shared.settings import settings
 from shared.logger import logger
-from shared import monitoring
 
 from ..upload.upload import create_initial_dataset_entry, get_transformed_bounds, get_file_identifier
 
@@ -120,9 +119,6 @@ async def upload_geotiff_chunk(
 # 	```
 
 # 	"""
-# 	# count an invoke
-# 	monitoring.uploads_invoked.inc()
-
 # 	# first thing we do is verify the token
 # 	user = verify_token(token)
 # 	if not user:
@@ -195,11 +191,6 @@ async def upload_geotiff_chunk(
 
 # 	# update the dataset with the id
 # 	dataset = Dataset(**response.data[0])
-
-# 	# do some monitoring
-# 	monitoring.uploads_counter.inc()
-# 	monitoring.upload_time.observe(dataset.copy_time)
-# 	monitoring.upload_size.observe(dataset.file_size)
 
 # 	logger.info(
 # 		f'Created new dataset <ID={dataset.id}> with file {dataset.file_alias}. ({format_size(dataset.file_size)}). Took {dataset.copy_time:.2f}s.',

--- a/api/src/server.py
+++ b/api/src/server.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI, Response
 from starlette.middleware.cors import CORSMiddleware
 
+from shared import monitoring
+import logfire
 
+# TODO: refactor this
 import prometheus_client
 
 from shared.__version__ import __version__
@@ -12,6 +15,8 @@ app = FastAPI(
 	description='This is the Deadwood-AI API. It is used to manage files uploads to the Deadwood-AI backend and the preprocessing of uploads. Note that the download is managed by a sub-application at `/download/`.',
 	version=__version__,
 )
+
+logfire.instrument_fastapi(app)
 
 # add CORS middleware
 app.add_middleware(

--- a/api/src/server.py
+++ b/api/src/server.py
@@ -2,10 +2,6 @@ from fastapi import FastAPI, Response
 from starlette.middleware.cors import CORSMiddleware
 
 from shared import monitoring
-import logfire
-
-# TODO: refactor this
-import prometheus_client
 
 from shared.__version__ import __version__
 from .routers import process, upload, info, auth, labels, download, metadata
@@ -16,7 +12,8 @@ app = FastAPI(
 	version=__version__,
 )
 
-logfire.instrument_fastapi(app)
+monitoring.logfire.instrument_fastapi(app)
+
 
 # add CORS middleware
 app.add_middleware(
@@ -27,15 +24,6 @@ app.add_middleware(
 	allow_methods=['OPTIONS', 'GET', 'POST', 'PUT'],
 	allow_headers=['Content-Type', 'Authorization', 'Origin', 'Accept'],
 )
-
-
-# add the prometheus metrics route
-@app.get('/metrics')
-def get_metrics():
-	"""
-	Supplys Prometheus metrics for the storage API.
-	"""
-	return Response(prometheus_client.generate_latest(), media_type='text/plain')
 
 
 # add the info route to the app

--- a/docker-compose.api.yaml
+++ b/docker-compose.api.yaml
@@ -28,6 +28,7 @@ services:
       PROCESSOR_PASSWORD: ${PROCESSOR_PASSWORD}
       UVICORN_PORT: 8762
       UVICORN_HOST: 0.0.0.0
+      LOGFIRE_TOKEN: ${LOGFIRE_TOKEN}
 
   migrate:
     build:

--- a/requirements.local.txt
+++ b/requirements.local.txt
@@ -4,7 +4,6 @@ pydantic_partial
 python-dotenv
 python-multipart
 supabase
-prometheus-client
 rasterio==1.4.2
 rio-cogeo
 fire
@@ -29,3 +28,4 @@ aiofiles
 httpx
 pytest-mock
 pyyaml
+logfire[fastapi,system-metrics]

--- a/shared/monitoring.py
+++ b/shared/monitoring.py
@@ -1,3 +1,11 @@
+import logfire
+
+# first thing we to is configure logfire
+logfire.configure()
+
+# TODO: anything down here needs to be removed and all references to it need to be checked.
+# if there are any references that log or measure something that logfire does not catch
+# we need to log it in similar fashion.
 from prometheus_client import Counter, Histogram
 
 

--- a/shared/monitoring.py
+++ b/shared/monitoring.py
@@ -3,11 +3,11 @@ import logfire
 
 # get the dev mode from the environment
 dev_mode = os.environ.get('DEV_MODE', 'false').lower() == 'true'
-# first thing we to is configure logfire
+# first thing we do is configure logfire
 logfire.configure(environment='development' if dev_mode else 'production')
 
 # uncomment here to disable system-metrics logging
-# I am not enirely sure, what exactly this measures inside a docker container
+# I am not entirely sure, what exactly this measures inside a docker container
 logfire.instrument_system_metrics({
     'process.runtime.memory': ['rss', 'vms'],
     'process.runtime.cpu.utilization': None,

--- a/shared/monitoring.py
+++ b/shared/monitoring.py
@@ -1,37 +1,20 @@
+import os
 import logfire
 
+# get the dev mode from the environment
+dev_mode = os.environ.get('DEV_MODE', 'false').lower() == 'true'
 # first thing we to is configure logfire
-logfire.configure()
+logfire.configure(environment='development' if dev_mode else 'production')
 
-# TODO: anything down here needs to be removed and all references to it need to be checked.
-# if there are any references that log or measure something that logfire does not catch
-# we need to log it in similar fashion.
-from prometheus_client import Counter, Histogram
+# uncomment here to disable system-metrics logging
+# I am not enirely sure, what exactly this measures inside a docker container
+logfire.instrument_system_metrics({
+    'process.runtime.memory': ['rss', 'vms'],
+    'process.runtime.cpu.utilization': None,
+    'system.disk.io': ['read', 'write'],
+    'system.disk.time': ['read', 'write'],
+    'system.memory.usage': ['available', 'used'] 
+}, base=None)
 
-
-# create metrics for the upload route
-# create a number of prometheus metrics
-uploads_invoked = Counter('uploads_invoked', 'Number of uploads invoked')
-uploads_counter = Counter('uploads_counter', 'Number of uploads, finishing without error.')
-upload_time = Histogram('upload_seconds', 'Time spent in dataset uploads')
-upload_size = Histogram('upload_bytes', 'Size of dataset uploads in bytes')
-
-# create metrics for the cog route
-cog_invoked = Counter('cog_invoked', 'Number of cogs invoked')
-cog_counter = Counter('cog_counter', 'Number of cogs, finishing without error.')
-cog_time = Histogram('cog_seconds', 'Time spent in cog creation')
-cog_size = Histogram('cog_bytes', 'Size of cog files in bytes')
-
-# create metrics for the metadata routes
-metadata_invoked = Counter('metadata_invoked', 'Number of metadata upserting invoked')
-metadata_counter = Counter('metadata_counter', 'Number of metadata upserting, finishing without error.')
-
-# create metrics for the label routes
-label_invoked = Counter('label_invoked', 'Number of label upserting invoked')
-label_counter = Counter('label_counter', 'Number of label upserting, finishing without error.')
-
-# create metrics for the download routes
-download_dataset = Counter('download_dataset', 'Number of dataset downloads invoked')
-download_ortho = Counter('download_ortho', 'Number of ortho downloads invoked')
-download_label = Counter('download_label', 'Number of label downloads invoked')
-download_metadata = Counter('download_metadata', 'Number of metadata downloads invoked')
+# instrument pydantic model validation
+logfire.instrument_pydantic()

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
 
 	_processing_path: Optional[Path] = None
 
+	# monitoring
+	LOGFIRE_TOKEN: str = None
+
 	@property
 	def processing_path(self) -> Path:
 		if self._processing_path is None:

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
 
 	# monitoring
 	LOGFIRE_TOKEN: str = None
+	LOGFIRE_PYDANTIC_PLUGIN_RECORD: str = 'all'
 
 	@property
 	def processing_path(self) -> Path:


### PR DESCRIPTION
This adds logfire to **the API only**. It is not yet implemented for the process server.

I need to read about namespaces first, then we can send info along the instrumentation, so that the logs can be told apart again (in the dashboard).

But feel free to merge, @JesJehle, and test the logging. The amount of information if you force the API into a couple of errors is amazing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced rate limiting for concurrent downloads, enhancing server performance and user experience.
  - Added a new endpoint for chunked uploads of GeoTIFF files, improving upload efficiency.

- **Bug Fixes**
  - Improved error handling and logging for label creation and user label uploads, ensuring better traceability.

- **Chores**
  - Updated dependencies by removing `prometheus-client` and adding `logfire` and `pyyaml` for improved monitoring capabilities.
  - Enhanced monitoring configuration by transitioning from Prometheus metrics to logging with `logfire`. 

- **Documentation**
  - Updated environment variables in the Docker configuration to support new monitoring features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->