### PR TITLE
[codex] Add reference vector geopackage export

### DIFF
--- a/api/src/export/export_reference_patches.py
+++ b/api/src/export/export_reference_patches.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import Optional
 import os
 
+import geopandas as gpd
 import numpy as np
 import rasterio
 from rasterio.enums import Resampling
@@ -47,7 +48,7 @@ from rasterio.features import rasterize
 from rasterio.transform import from_bounds as transform_from_bounds
 from rasterio.vrt import WarpedVRT
 from tqdm import tqdm
-from shapely.geometry import shape, box
+from shapely.geometry import MultiPolygon, shape, box
 from shapely.ops import transform as shapely_transform
 from pyproj import Transformer
 from PIL import Image
@@ -313,6 +314,267 @@ def fetch_geometries_by_label(token: str, label_id: int, table_name: str, bbox: 
 		return []
 
 
+def fetch_vector_features_by_label(token: str, patch_id: int, label_id: Optional[int], table_name: str) -> list[dict]:
+	"""Fetch stored reference geometries for a root patch as EPSG:4326 GeoJSON features."""
+	if label_id is None:
+		return []
+
+	try:
+		with use_client(token) as client:
+			response = (
+				client.from_(table_name)
+				.select('geometry, area_m2, properties')
+				.eq('patch_id', patch_id)
+				.eq('label_id', label_id)
+				.execute()
+			)
+			return response.data if response.data else []
+	except Exception as e:
+		print(f'❌ Error fetching vector features for patch {patch_id}: {e}')
+		return []
+
+
+def build_filename_base(patch: dict) -> str:
+	"""Build the common filename base used by raster and vector exports."""
+	dataset_id = patch['dataset_id']
+	resolution_cm = patch['resolution_cm']
+	patch_index = patch['patch_index']
+
+	tile_id = patch_index.split('_')[-2:] if '_' in patch_index else [patch_index]
+	tile_id = '_'.join(tile_id) if len(tile_id) > 1 else tile_id[0]
+	return f'{dataset_id}_{tile_id}_{resolution_cm}cm'
+
+
+def patch_has_deadwood_reference(patch: dict) -> bool:
+	"""Return whether this patch has a deadwood reference label in its effective chain."""
+	return bool(
+		patch.get('effective_deadwood_label_id')
+		or patch.get('reference_deadwood_label_id')
+		or patch.get('parent_deadwood_label_id')
+	)
+
+
+def patch_has_forestcover_reference(patch: dict) -> bool:
+	"""Return whether this patch has a forest cover reference label in its effective chain."""
+	return bool(
+		patch.get('effective_forestcover_label_id')
+		or patch.get('reference_forest_cover_label_id')
+		or patch.get('parent_forestcover_label_id')
+	)
+
+
+def is_vector_export_eligible_patch(patch: dict) -> bool:
+	"""Return whether a patch should produce a vector export."""
+	return (
+		patch.get('resolution_cm') == 20
+		and patch.get('parent_tile_id') is None
+		and (bool(patch.get('deadwood_validated')) or bool(patch.get('forest_cover_validated')))
+	)
+
+
+def get_vector_export_candidates(patches: list[dict], resolution_cm: Optional[int] = None) -> list[dict]:
+	"""Return root/base patches that should be considered for GeoPackage export."""
+	if resolution_cm in (5, 10):
+		return []
+	return [patch for patch in patches if is_vector_export_eligible_patch(patch)]
+
+
+def vector_export_needs_export(output_dir: Path, filename_base: str, patch_updated_at: datetime) -> bool:
+	"""Check if a root patch vector export needs refresh."""
+	gpkg_path = output_dir / 'gpkg' / f'{filename_base}.gpkg'
+	metadata_path = output_dir / 'metadata' / f'{filename_base}_vector.json'
+
+	if not gpkg_path.exists() or not metadata_path.exists():
+		return True
+
+	file_mtime = datetime.fromtimestamp(metadata_path.stat().st_mtime, tz=timezone.utc)
+	return patch_updated_at > file_mtime
+
+
+def normalize_polygon_geometry(geometry: dict) -> MultiPolygon:
+	"""Normalize polygonal GeoJSON to MultiPolygon for stable GeoPackage schemas."""
+	geom = shape(geometry)
+	if geom.geom_type == 'Polygon':
+		return MultiPolygon([geom])
+	if geom.geom_type == 'MultiPolygon':
+		return geom
+	raise ValueError(f'Expected polygonal geometry, got {geom.geom_type}')
+
+
+def build_base_patch_geodataframe(patch: dict) -> gpd.GeoDataFrame:
+	"""Build the base_patch GeoDataFrame for a root patch boundary."""
+	rows = [
+		{
+			'dataset_id': patch['dataset_id'],
+			'patch_id': patch['id'],
+			'patch_index': patch['patch_index'],
+			'resolution_cm': patch['resolution_cm'],
+			'layer_name': 'base_patch',
+			'geometry': normalize_polygon_geometry(patch['geometry']),
+		}
+	]
+	return gpd.GeoDataFrame(rows, geometry='geometry', crs='EPSG:4326')
+
+
+def build_vector_layer_geodataframe(
+	patch: dict,
+	layer_name: str,
+	label_id: Optional[int],
+	rows: list[dict],
+) -> gpd.GeoDataFrame:
+	"""Build a GeoDataFrame for a validated reference layer."""
+	features = []
+	for row in rows:
+		try:
+			features.append(
+				{
+					'dataset_id': patch['dataset_id'],
+					'patch_id': patch['id'],
+					'patch_index': patch['patch_index'],
+					'resolution_cm': patch['resolution_cm'],
+					'label_id': label_id,
+					'layer_name': layer_name,
+					'validated': 1,
+					'area_m2': row.get('area_m2'),
+					'properties_json': json.dumps(row.get('properties') or {}, sort_keys=True),
+					'geometry': normalize_polygon_geometry(row['geometry']),
+				}
+			)
+		except Exception:
+			continue
+
+	if not features:
+		return gpd.GeoDataFrame(
+			columns=[
+				'dataset_id',
+				'patch_id',
+				'patch_index',
+				'resolution_cm',
+				'label_id',
+				'layer_name',
+				'validated',
+				'area_m2',
+				'properties_json',
+				'geometry',
+			],
+			geometry='geometry',
+			crs='EPSG:4326',
+		)
+
+	return gpd.GeoDataFrame(features, geometry='geometry', crs='EPSG:4326')
+
+
+def write_geopackage_layer(gpkg_path: Path, layer_name: str, gdf: gpd.GeoDataFrame, schema: Optional[dict] = None):
+	"""Write a new GeoPackage layer, including empty layers with explicit schema."""
+	kwargs = {'driver': 'GPKG', 'layer': layer_name, 'engine': 'fiona'}
+	if schema is not None:
+		kwargs['schema'] = schema
+	gdf.to_file(gpkg_path, **kwargs)
+
+
+def export_vector_geopackage(token: str, patch: dict, output_dir: Path) -> Optional[Path]:
+	"""Export a root/base patch as a GeoPackage in EPSG:4326."""
+	filename_base = build_filename_base(patch)
+	gpkg_dir = output_dir / 'gpkg'
+	gpkg_dir.mkdir(parents=True, exist_ok=True)
+	metadata_dir = output_dir / 'metadata'
+	metadata_dir.mkdir(parents=True, exist_ok=True)
+
+	gpkg_path = gpkg_dir / f'{filename_base}.gpkg'
+	temp_gpkg_path = gpkg_dir / f'{filename_base}.tmp.gpkg'
+	metadata_path = metadata_dir / f'{filename_base}_vector.json'
+
+	if temp_gpkg_path.exists():
+		temp_gpkg_path.unlink()
+
+	label_layer_schema = {
+		'geometry': 'MultiPolygon',
+		'properties': {
+			'dataset_id': 'int',
+			'patch_id': 'int',
+			'patch_index': 'str',
+			'resolution_cm': 'int',
+			'label_id': 'int',
+			'layer_name': 'str',
+			'validated': 'int',
+			'area_m2': 'float',
+			'properties_json': 'str',
+		},
+	}
+	base_patch_schema = {
+		'geometry': 'MultiPolygon',
+		'properties': {
+			'dataset_id': 'int',
+			'patch_id': 'int',
+			'patch_index': 'str',
+			'resolution_cm': 'int',
+			'layer_name': 'str',
+		},
+	}
+
+	try:
+		write_geopackage_layer(temp_gpkg_path, 'base_patch', build_base_patch_geodataframe(patch), schema=base_patch_schema)
+
+		layer_counts = {'base_patch': 1, 'deadwood': 0, 'forest_cover': 0}
+		exported_layers = {'deadwood': False, 'forest_cover': False}
+
+		if bool(patch.get('deadwood_validated')):
+			deadwood_label_id = patch.get('reference_deadwood_label_id')
+			deadwood_rows = fetch_vector_features_by_label(
+				token,
+				patch['id'],
+				deadwood_label_id,
+				'reference_patch_deadwood_geometries',
+			)
+			deadwood_gdf = build_vector_layer_geodataframe(patch, 'deadwood', deadwood_label_id, deadwood_rows)
+			write_geopackage_layer(temp_gpkg_path, 'deadwood', deadwood_gdf, schema=label_layer_schema)
+			layer_counts['deadwood'] = len(deadwood_gdf.index)
+			exported_layers['deadwood'] = True
+
+		if bool(patch.get('forest_cover_validated')):
+			forest_label_id = patch.get('reference_forest_cover_label_id')
+			forest_rows = fetch_vector_features_by_label(
+				token,
+				patch['id'],
+				forest_label_id,
+				'reference_patch_forest_cover_geometries',
+			)
+			forest_gdf = build_vector_layer_geodataframe(patch, 'forest_cover', forest_label_id, forest_rows)
+			write_geopackage_layer(temp_gpkg_path, 'forest_cover', forest_gdf, schema=label_layer_schema)
+			layer_counts['forest_cover'] = len(forest_gdf.index)
+			exported_layers['forest_cover'] = True
+
+		if gpkg_path.exists():
+			gpkg_path.unlink()
+		temp_gpkg_path.replace(gpkg_path)
+
+		metadata = {
+			'dataset_id': patch['dataset_id'],
+			'patch_id': patch['id'],
+			'patch_index': patch['patch_index'],
+			'resolution_cm': patch['resolution_cm'],
+			'crs': 'EPSG:4326',
+			'layers': exported_layers,
+			'validation': {
+				'deadwood_validated': bool(patch.get('deadwood_validated')),
+				'forest_cover_validated': bool(patch.get('forest_cover_validated')),
+			},
+			'feature_counts': layer_counts,
+		}
+		with open(metadata_path, 'w') as f:
+			json.dump(metadata, f, indent=2)
+
+		return gpkg_path
+	except Exception as e:
+		print(f"❌ Error exporting vector GeoPackage for patch {patch['patch_index']}: {e}")
+		import traceback
+
+		traceback.print_exc()
+		if temp_gpkg_path.exists():
+			temp_gpkg_path.unlink()
+		return None
+
+
 def patch_needs_export(
 	output_dir: Path,
 	filename_base: str,
@@ -560,11 +822,7 @@ def export_patch(
 		# Note: We only export reference (human-validated) masks, not ML predictions
 
 		# Create output filenames with simplified naming
-		# Extract grid coordinates from patch_index if available (e.g., "20_1760951000108_0_0" -> "0_0")
-		# Otherwise use the full patch_index
-		tile_id = patch_index.split('_')[-2:] if '_' in patch_index else [patch_index]
-		tile_id = '_'.join(tile_id) if len(tile_id) > 1 else tile_id[0]
-		filename_base = f'{dataset_id}_{tile_id}_{resolution_cm}cm'
+		filename_base = build_filename_base(patch)
 
 		# Export GeoTIFF
 		if export_geotiff:
@@ -793,28 +1051,19 @@ def main():
 
 	# Pre-filter patches that actually need export. This keeps no-change cron runs
 	# compact and avoids printing the full dataset breakdown every time.
-	export_candidates = []
-	skipped_count = 0
+	raster_export_candidates = []
+	raster_skipped_count = 0
+	vector_candidates = get_vector_export_candidates(patches, resolution_cm=args.resolution)
+	vector_export_candidates = []
+	vector_skipped_count = 0
+
 	for patch in patches:
 		dataset_id = patch['dataset_id']
-		resolution_cm = patch['resolution_cm']
-		patch_index = patch['patch_index']
-
 		dataset_output_dir = output_base_dir / str(dataset_id)
-		tile_id = patch_index.split('_')[-2:] if '_' in patch_index else [patch_index]
-		tile_id = '_'.join(tile_id) if len(tile_id) > 1 else tile_id[0]
-		filename_base = f'{dataset_id}_{tile_id}_{resolution_cm}cm'
+		filename_base = build_filename_base(patch)
 
-		has_deadwood_ref = bool(
-			patch.get('effective_deadwood_label_id')
-			or patch.get('reference_deadwood_label_id')
-			or patch.get('parent_deadwood_label_id')
-		)
-		has_forestcover_ref = bool(
-			patch.get('effective_forestcover_label_id')
-			or patch.get('reference_forest_cover_label_id')
-			or patch.get('parent_forestcover_label_id')
-		)
+		has_deadwood_ref = patch_has_deadwood_reference(patch)
+		has_forestcover_ref = patch_has_forestcover_reference(patch)
 
 		patch_updated_at = parse_optional_datetime(patch.get('updated_at'))
 		if patch_updated_at is None:
@@ -829,24 +1078,39 @@ def main():
 			has_forestcover_ref,
 			effective_reference_updated_at=effective_reference_updated_at,
 		):
-			skipped_count += 1
-			continue
+			raster_skipped_count += 1
+		else:
+			raster_export_candidates.append(patch)
 
-		export_candidates.append(patch)
+	for patch in vector_candidates:
+		dataset_output_dir = output_base_dir / str(patch['dataset_id'])
+		filename_base = build_filename_base(patch)
+		patch_updated_at = parse_optional_datetime(patch.get('updated_at'))
+		if patch_updated_at is None:
+			patch_updated_at = datetime.fromtimestamp(0, tz=timezone.utc)
 
-	if not export_candidates:
+		if not args.force and not vector_export_needs_export(dataset_output_dir, filename_base, patch_updated_at):
+			vector_skipped_count += 1
+		else:
+			vector_export_candidates.append(patch)
+
+	if not raster_export_candidates and not vector_export_candidates:
 		print('✅ No patch changes detected; export skipped.')
-		print('   Newly exported: 0 patches')
-		print(f'   Skipped (already exist): {skipped_count} patches')
+		print('   Newly exported (raster): 0 patches')
+		print(f'   Skipped raster (already exist): {raster_skipped_count} patches')
+		print('   Newly exported (vector): 0 geopackages')
+		print(f'   Skipped vector (already exist): {vector_skipped_count} geopackages')
 		return 0
 
 	print(f'✓ Found {len(patches)} validated patches in database')
-	print(f'   Need export: {len(export_candidates)} patches')
-	print(f'   Already up-to-date: {skipped_count} patches\n')
+	print(f'   Need raster export: {len(raster_export_candidates)} patches')
+	print(f'   Raster already up-to-date: {raster_skipped_count} patches')
+	print(f'   Need vector export: {len(vector_export_candidates)} geopackages')
+	print(f'   Vector already up-to-date: {vector_skipped_count} geopackages\n')
 
 	# Group only export candidates by dataset/resolution for readable change summary.
 	by_dataset = {}
-	for patch in export_candidates:
+	for patch in raster_export_candidates:
 		dataset_id = patch['dataset_id']
 		resolution = patch['resolution_cm']
 
@@ -861,6 +1125,14 @@ def main():
 		resolutions = by_dataset[dataset_id]
 		res_str = ', '.join([f'{count}x{res}cm' for res, count in sorted(resolutions.items())])
 		print(f'  Dataset {dataset_id}: {res_str}')
+	if vector_export_candidates:
+		vector_by_dataset = {}
+		for patch in vector_export_candidates:
+			vector_by_dataset.setdefault(patch['dataset_id'], 0)
+			vector_by_dataset[patch['dataset_id']] += 1
+		print('📦 Root patch GeoPackages to export:')
+		for dataset_id in sorted(vector_by_dataset.keys()):
+			print(f"  Dataset {dataset_id}: {vector_by_dataset[dataset_id]}x gpkg")
 	print()
 
 	# Export patches
@@ -872,10 +1144,9 @@ def main():
 
 	success_count = 0
 	failed_count = 0
-	for patch in tqdm(export_candidates, desc='Exporting patches'):
+	for patch in tqdm(raster_export_candidates, desc='Exporting raster patches'):
 		dataset_id = patch['dataset_id']
 		resolution_cm = patch['resolution_cm']
-		patch_index = patch['patch_index']
 
 		# GSD mapping
 		gsd_map = {20: 0.20, 10: 0.10, 5: 0.05}
@@ -883,11 +1154,6 @@ def main():
 
 		# Dataset-specific output directory structure
 		dataset_output_dir = output_base_dir / str(dataset_id)
-
-		# Generate filename for existence check
-		tile_id = patch_index.split('_')[-2:] if '_' in patch_index else [patch_index]
-		tile_id = '_'.join(tile_id) if len(tile_id) > 1 else tile_id[0]
-		filename_base = f'{dataset_id}_{tile_id}_{resolution_cm}cm'
 
 		# Get COG URL (fetch from DB if not cached)
 		if dataset_id not in cog_cache:
@@ -926,18 +1192,33 @@ def main():
 		else:
 			failed_count += 1
 
+	vector_success_count = 0
+	vector_failed_count = 0
+	for patch in tqdm(vector_export_candidates, desc='Exporting vector GeoPackages'):
+		dataset_output_dir = output_base_dir / str(patch['dataset_id'])
+		result = export_vector_geopackage(token, patch, dataset_output_dir)
+		if result:
+			vector_success_count += 1
+		else:
+			vector_failed_count += 1
+
 	# Print summary
 	print('\n✅ Export complete!')
-	print(f'   Newly exported: {success_count} patches')
-	print(f'   Skipped (already exist): {skipped_count} patches')
+	print(f'   Newly exported raster: {success_count} patches')
+	print(f'   Skipped raster (already exist): {raster_skipped_count} patches')
 	if failed_count > 0:
-		print(f'   Failed: {failed_count} patches')
+		print(f'   Failed raster: {failed_count} patches')
+	print(f'   Newly exported vector: {vector_success_count} geopackages')
+	print(f'   Skipped vector (already exist): {vector_skipped_count} geopackages')
+	if vector_failed_count > 0:
+		print(f'   Failed vector: {vector_failed_count} geopackages')
 	print('\n📁 Output structure:')
 	print(f'   {output_base_dir.absolute()}/<dataset_id>/geotiff/')
 	print(f'   {output_base_dir.absolute()}/<dataset_id>/png/')
+	print(f'   {output_base_dir.absolute()}/<dataset_id>/gpkg/')
 	print(f'   {output_base_dir.absolute()}/<dataset_id>/metadata/')
 
-	return 0 if failed_count == 0 else 1
+	return 0 if failed_count == 0 and vector_failed_count == 0 else 1
 
 
 if __name__ == '__main__':

--- a/api/src/export/export_reference_patches.py
+++ b/api/src/export/export_reference_patches.py
@@ -379,7 +379,25 @@ def get_vector_export_candidates(patches: list[dict], resolution_cm: Optional[in
 	return [patch for patch in patches if is_vector_export_eligible_patch(patch)]
 
 
-def vector_export_needs_export(output_dir: Path, filename_base: str, patch_updated_at: datetime) -> bool:
+def fetch_latest_reference_geometry_created_at(token: str, patch_id: int) -> Optional[datetime]:
+	"""Return the latest geometry creation timestamp for a reference patch."""
+	latest_created_at = None
+
+	try:
+		with use_client(token) as client:
+			for table_name in ('reference_patch_deadwood_geometries', 'reference_patch_forest_cover_geometries'):
+				response = client.from_(table_name).select('created_at').eq('patch_id', patch_id).execute()
+				for row in response.data or []:
+					created_at = parse_optional_datetime(row.get('created_at'))
+					if created_at and (latest_created_at is None or created_at > latest_created_at):
+						latest_created_at = created_at
+	except Exception as e:
+		print(f'⚠️  Error fetching latest geometry timestamp for patch {patch_id}: {e}')
+
+	return latest_created_at
+
+
+def vector_export_needs_export(output_dir: Path, filename_base: str, latest_source_updated_at: datetime) -> bool:
 	"""Check if a root patch vector export needs refresh."""
 	gpkg_path = output_dir / 'gpkg' / f'{filename_base}.gpkg'
 	metadata_path = output_dir / 'metadata' / f'{filename_base}_vector.json'
@@ -388,7 +406,7 @@ def vector_export_needs_export(output_dir: Path, filename_base: str, patch_updat
 		return True
 
 	file_mtime = datetime.fromtimestamp(metadata_path.stat().st_mtime, tz=timezone.utc)
-	return patch_updated_at > file_mtime
+	return latest_source_updated_at > file_mtime
 
 
 def normalize_polygon_geometry(geometry: dict) -> MultiPolygon:
@@ -424,24 +442,35 @@ def build_vector_layer_geodataframe(
 ) -> gpd.GeoDataFrame:
 	"""Build a GeoDataFrame for a validated reference layer."""
 	features = []
-	for row in rows:
+	for index, row in enumerate(rows, start=1):
 		try:
-			features.append(
-				{
-					'dataset_id': patch['dataset_id'],
-					'patch_id': patch['id'],
-					'patch_index': patch['patch_index'],
-					'resolution_cm': patch['resolution_cm'],
-					'label_id': label_id,
-					'layer_name': layer_name,
-					'validated': 1,
-					'area_m2': row.get('area_m2'),
-					'properties_json': json.dumps(row.get('properties') or {}, sort_keys=True),
-					'geometry': normalize_polygon_geometry(row['geometry']),
-				}
-			)
-		except Exception:
-			continue
+			properties_json = json.dumps(row.get('properties') or {}, sort_keys=True)
+		except TypeError as exc:
+			raise ValueError(
+				f'Failed to serialize properties for {layer_name} feature {index} on patch {patch["patch_index"]}'
+			) from exc
+
+		try:
+			geometry = normalize_polygon_geometry(row['geometry'])
+		except (KeyError, TypeError, ValueError) as exc:
+			raise ValueError(
+				f'Invalid geometry for {layer_name} feature {index} on patch {patch["patch_index"]}'
+			) from exc
+
+		features.append(
+			{
+				'dataset_id': patch['dataset_id'],
+				'patch_id': patch['id'],
+				'patch_index': patch['patch_index'],
+				'resolution_cm': patch['resolution_cm'],
+				'label_id': label_id,
+				'layer_name': layer_name,
+				'validated': 1,
+				'area_m2': row.get('area_m2'),
+				'properties_json': properties_json,
+				'geometry': geometry,
+			}
+		)
 
 	if not features:
 		return gpd.GeoDataFrame(
@@ -544,8 +573,6 @@ def export_vector_geopackage(token: str, patch: dict, output_dir: Path) -> Optio
 			layer_counts['forest_cover'] = len(forest_gdf.index)
 			exported_layers['forest_cover'] = True
 
-		if gpkg_path.exists():
-			gpkg_path.unlink()
 		temp_gpkg_path.replace(gpkg_path)
 
 		metadata = {
@@ -1088,8 +1115,16 @@ def main():
 		patch_updated_at = parse_optional_datetime(patch.get('updated_at'))
 		if patch_updated_at is None:
 			patch_updated_at = datetime.fromtimestamp(0, tz=timezone.utc)
+		geometry_created_at = fetch_latest_reference_geometry_created_at(token, patch['id'])
+		latest_vector_source_updated_at = patch_updated_at
+		if geometry_created_at and geometry_created_at > latest_vector_source_updated_at:
+			latest_vector_source_updated_at = geometry_created_at
 
-		if not args.force and not vector_export_needs_export(dataset_output_dir, filename_base, patch_updated_at):
+		if not args.force and not vector_export_needs_export(
+			dataset_output_dir,
+			filename_base,
+			latest_vector_source_updated_at,
+		):
 			vector_skipped_count += 1
 		else:
 			vector_export_candidates.append(patch)

--- a/api/tests/test_export_reference_patches.py
+++ b/api/tests/test_export_reference_patches.py
@@ -213,6 +213,24 @@ def test_vector_export_needs_export_checks_gpkg_and_metadata(tmp_path):
 	assert export_module.vector_export_needs_export(output_dir, filename_base, patch_updated_at) is False
 
 
+def test_fetch_latest_reference_geometry_created_at_uses_latest_geometry_table_timestamp(monkeypatch):
+	tables = {
+		'reference_patch_deadwood_geometries': [
+			{'patch_id': 1, 'created_at': '2026-04-09T10:00:00+00:00'},
+			{'patch_id': 1, 'created_at': '2026-04-09T11:00:00+00:00'},
+		],
+		'reference_patch_forest_cover_geometries': [
+			{'patch_id': 1, 'created_at': '2026-04-09T12:00:00+00:00'},
+			{'patch_id': 2, 'created_at': '2026-04-09T13:00:00+00:00'},
+		],
+	}
+	install_fake_db(monkeypatch, tables)
+
+	latest_created_at = export_module.fetch_latest_reference_geometry_created_at('token', 1)
+
+	assert latest_created_at == datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc)
+
+
 def test_export_vector_geopackage_writes_validated_layers_only(monkeypatch, tmp_path):
 	patch = make_patch(
 		1,
@@ -339,3 +357,35 @@ def test_export_vector_geopackage_creates_empty_validated_layer(monkeypatch, tmp
 
 	forest_cover_gdf = gpd.read_file(gpkg_path, layer='forest_cover')
 	assert len(forest_cover_gdf) == 0
+
+
+def test_export_vector_geopackage_fails_on_invalid_validated_geometry(monkeypatch, tmp_path):
+	patch = make_patch(
+		1,
+		'20_1760951000108',
+		deadwood_validated=True,
+		forest_cover_validated=False,
+		reference_deadwood_label_id=9001,
+	)
+	tables = {
+		'reference_patch_deadwood_geometries': [
+			{
+				'patch_id': 1,
+				'label_id': 9001,
+				'geometry': {
+					'type': 'Point',
+					'coordinates': [7.01, 47.01],
+				},
+				'area_m2': 12.5,
+				'properties': {'source': 'test'},
+			}
+		],
+		'reference_patch_forest_cover_geometries': [],
+	}
+	install_fake_db(monkeypatch, tables)
+
+	gpkg_path = export_module.export_vector_geopackage('token', patch, tmp_path / '10')
+	filename_base = export_module.build_filename_base(patch)
+
+	assert gpkg_path is None
+	assert not (tmp_path / '10' / 'gpkg' / f'{filename_base}.gpkg').exists()

--- a/api/tests/test_export_reference_patches.py
+++ b/api/tests/test_export_reference_patches.py
@@ -1,4 +1,9 @@
+import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+
+import fiona
+import geopandas as gpd
 
 from api.src.export import export_reference_patches as export_module
 
@@ -70,6 +75,7 @@ def make_patch(
 	reference_deadwood_label_id=None,
 	reference_forest_cover_label_id=None,
 	updated_at='2026-04-07T13:57:22+00:00',
+	geometry=None,
 ):
 	return {
 		'id': patch_id,
@@ -82,6 +88,11 @@ def make_patch(
 		'reference_deadwood_label_id': reference_deadwood_label_id,
 		'reference_forest_cover_label_id': reference_forest_cover_label_id,
 		'updated_at': updated_at,
+		'geometry': geometry
+		or {
+			'type': 'Polygon',
+			'coordinates': [[[7.0, 47.0], [7.1, 47.0], [7.1, 47.1], [7.0, 47.1], [7.0, 47.0]]],
+		},
 	}
 
 
@@ -152,3 +163,179 @@ def test_fetch_validated_patches_resolves_effective_labels_for_single_validation
 
 	assert child_patch['effective_deadwood_label_id'] == 9001
 	assert child_patch['effective_forestcover_label_id'] == 9102
+
+
+def test_get_vector_export_candidates_only_includes_root_20cm_patches():
+	patches = [
+		make_patch(1, '20_root_valid', resolution_cm=20, deadwood_validated=True),
+		make_patch(2, '20_child_valid', resolution_cm=20, parent_tile_id=1, deadwood_validated=True),
+		make_patch(3, '10_child_valid', resolution_cm=10, parent_tile_id=1, forest_cover_validated=True),
+		make_patch(4, '20_root_unvalidated', resolution_cm=20, deadwood_validated=False, forest_cover_validated=False),
+	]
+
+	candidates = export_module.get_vector_export_candidates(patches)
+
+	assert [patch['id'] for patch in candidates] == [1]
+
+
+def test_get_vector_export_candidates_skips_when_resolution_filter_is_not_20():
+	patches = [make_patch(1, '20_root_valid', resolution_cm=20, deadwood_validated=True)]
+
+	assert export_module.get_vector_export_candidates(patches, resolution_cm=5) == []
+	assert export_module.get_vector_export_candidates(patches, resolution_cm=10) == []
+
+
+def test_vector_export_needs_export_checks_gpkg_and_metadata(tmp_path):
+	output_dir = tmp_path / '10'
+	(output_dir / 'gpkg').mkdir(parents=True)
+	(output_dir / 'metadata').mkdir(parents=True)
+
+	filename_base = '10_0_0_20cm'
+	patch_updated_at = datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc)
+
+	assert export_module.vector_export_needs_export(output_dir, filename_base, patch_updated_at) is True
+
+	gpkg_path = output_dir / 'gpkg' / f'{filename_base}.gpkg'
+	metadata_path = output_dir / 'metadata' / f'{filename_base}_vector.json'
+	gpkg_path.write_text('gpkg')
+	metadata_path.write_text('{}')
+
+	old_mtime = (patch_updated_at - timedelta(hours=1)).timestamp()
+	metadata_path.touch()
+	gpkg_path.touch()
+	import os
+
+	os.utime(metadata_path, (old_mtime, old_mtime))
+	assert export_module.vector_export_needs_export(output_dir, filename_base, patch_updated_at) is True
+
+	new_mtime = (patch_updated_at + timedelta(hours=1)).timestamp()
+	os.utime(metadata_path, (new_mtime, new_mtime))
+	assert export_module.vector_export_needs_export(output_dir, filename_base, patch_updated_at) is False
+
+
+def test_export_vector_geopackage_writes_validated_layers_only(monkeypatch, tmp_path):
+	patch = make_patch(
+		1,
+		'20_1760951000108',
+		deadwood_validated=True,
+		forest_cover_validated=False,
+		reference_deadwood_label_id=9001,
+		reference_forest_cover_label_id=9002,
+	)
+	tables = {
+		'reference_patch_deadwood_geometries': [
+			{
+				'patch_id': 1,
+				'label_id': 9001,
+				'geometry': {
+					'type': 'Polygon',
+					'coordinates': [[[7.01, 47.01], [7.02, 47.01], [7.02, 47.02], [7.01, 47.02], [7.01, 47.01]]],
+				},
+				'area_m2': 12.5,
+				'properties': {'source': 'test'},
+			}
+		],
+		'reference_patch_forest_cover_geometries': [
+			{
+				'patch_id': 1,
+				'label_id': 9002,
+				'geometry': {
+					'type': 'Polygon',
+					'coordinates': [[[7.03, 47.03], [7.04, 47.03], [7.04, 47.04], [7.03, 47.04], [7.03, 47.03]]],
+				},
+				'area_m2': 8.0,
+				'properties': {'source': 'test'},
+			}
+		],
+	}
+	install_fake_db(monkeypatch, tables)
+
+	gpkg_path = export_module.export_vector_geopackage('token', patch, tmp_path / '10')
+
+	assert gpkg_path is not None
+	assert gpkg_path.exists()
+
+	layers = fiona.listlayers(gpkg_path)
+	assert layers == ['base_patch', 'deadwood']
+
+	base_patch_gdf = gpd.read_file(gpkg_path, layer='base_patch')
+	deadwood_gdf = gpd.read_file(gpkg_path, layer='deadwood')
+
+	assert len(base_patch_gdf) == 1
+	assert len(deadwood_gdf) == 1
+	assert deadwood_gdf.iloc[0]['label_id'] == 9001
+	assert deadwood_gdf.iloc[0]['layer_name'] == 'deadwood'
+	assert json.loads(deadwood_gdf.iloc[0]['properties_json']) == {'source': 'test'}
+
+	filename_base = export_module.build_filename_base(patch)
+	metadata_path = tmp_path / '10' / 'metadata' / f'{filename_base}_vector.json'
+	metadata = json.loads(metadata_path.read_text())
+	assert metadata['layers'] == {'deadwood': True, 'forest_cover': False}
+	assert metadata['feature_counts']['deadwood'] == 1
+	assert metadata['feature_counts']['forest_cover'] == 0
+
+
+def test_export_vector_geopackage_writes_both_layers_when_both_validated(monkeypatch, tmp_path):
+	patch = make_patch(
+		1,
+		'20_1760951000108',
+		deadwood_validated=True,
+		forest_cover_validated=True,
+		reference_deadwood_label_id=9001,
+		reference_forest_cover_label_id=9002,
+	)
+	tables = {
+		'reference_patch_deadwood_geometries': [
+			{
+				'patch_id': 1,
+				'label_id': 9001,
+				'geometry': {
+					'type': 'Polygon',
+					'coordinates': [[[7.01, 47.01], [7.02, 47.01], [7.02, 47.02], [7.01, 47.02], [7.01, 47.01]]],
+				},
+				'area_m2': 12.5,
+				'properties': {},
+			}
+		],
+		'reference_patch_forest_cover_geometries': [
+			{
+				'patch_id': 1,
+				'label_id': 9002,
+				'geometry': {
+					'type': 'Polygon',
+					'coordinates': [[[7.03, 47.03], [7.04, 47.03], [7.04, 47.04], [7.03, 47.04], [7.03, 47.03]]],
+				},
+				'area_m2': 8.0,
+				'properties': {},
+			}
+		],
+	}
+	install_fake_db(monkeypatch, tables)
+
+	gpkg_path = export_module.export_vector_geopackage('token', patch, tmp_path / '10')
+
+	assert gpkg_path is not None
+	assert fiona.listlayers(gpkg_path) == ['base_patch', 'deadwood', 'forest_cover']
+
+
+def test_export_vector_geopackage_creates_empty_validated_layer(monkeypatch, tmp_path):
+	patch = make_patch(
+		1,
+		'20_1760951000108',
+		deadwood_validated=False,
+		forest_cover_validated=True,
+		reference_forest_cover_label_id=9002,
+	)
+	tables = {
+		'reference_patch_deadwood_geometries': [],
+		'reference_patch_forest_cover_geometries': [],
+	}
+	install_fake_db(monkeypatch, tables)
+
+	gpkg_path = export_module.export_vector_geopackage('token', patch, tmp_path / '10')
+
+	assert gpkg_path is not None
+	assert fiona.listlayers(gpkg_path) == ['base_patch', 'forest_cover']
+
+	forest_cover_gdf = gpd.read_file(gpkg_path, layer='forest_cover')
+	assert len(forest_cover_gdf) == 0


### PR DESCRIPTION
## What changed
- added root-patch vector export to the reference export job
- wrote one EPSG:4326 GeoPackage per validated 20 cm base patch with `base_patch`, `deadwood`, and `forest_cover` layers as applicable
- added vector export metadata/staleness handling so raster and vector exports can refresh independently
- extended the API test file with root-patch candidate, incremental export, validated-layer, and empty-layer coverage

## Why
The reference export already handled raster outputs, but we also need vector exports for the full base-patch area so downstream users can work with the validated deadwood and forest cover layers directly in GeoPackage format.

## Impact
- reference export now produces GeoPackages for validated root patches
- export semantics align with layer-specific validation flags
- no child-tile GeoPackages are emitted

## Validation
- `deadtrees dev test api api/tests/test_export_reference_patches.py`
  - 9 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoPackage vector export for patch polygons with conditional deadwood and forest-cover layers
  * Export selection split between raster and vector paths with root/resolution-based vector eligibility
  * Incremental vector refresh using per-patch vector metadata (skips unchanged exports, supports force re-export)
  * Separate reporting and exit status for raster vs vector exports, with per-type counts

* **Tests**
  * Added comprehensive tests covering vector candidate selection, refresh logic, metadata timestamps, and GeoPackage outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->