### PR TITLE
[codex] add processor token refresh fallback

### DIFF
--- a/processor/src/process_cog.py
+++ b/processor/src/process_cog.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import time
 import uuid
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified
 from shared.settings import settings
 from shared.models import StatusEnum, QueueTask, Cog, Ortho
 from shared.logger import logger
@@ -16,9 +16,7 @@ from shared.logging import LogContext, LogCategory
 
 def process_cog(task: QueueTask, temp_dir: Path):
 	# login with the processor
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		raise AuthenticationError('Invalid processor token', token=token, task_id=task.id)
 
@@ -92,8 +90,7 @@ def process_cog(task: QueueTask, temp_dir: Path):
 	# Save metadata to database
 	try:
 		# Refresh token before database operation
-		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-		user = verify_token(token)
+		token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 		if not user:
 			raise AuthenticationError('Token refresh failed', token=token, task_id=task.id)
 

--- a/processor/src/process_deadwood_segmentation.py
+++ b/processor/src/process_deadwood_segmentation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified
 from shared.settings import settings
 from shared.models import StatusEnum, Ortho, QueueTask
 from shared.logger import logger
@@ -17,9 +17,7 @@ def process_deadwood_segmentation(task: QueueTask, token: str, temp_dir: Path):
 	import torch
 
 	# login with the processor
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		logger.error(
 			'Invalid processor token',

--- a/processor/src/process_geotiff.py
+++ b/processor/src/process_geotiff.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import time
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login_verified
 from shared.status import update_status
 from shared.settings import settings
 from shared.models import StatusEnum, Ortho, QueueTask
@@ -16,8 +16,7 @@ from shared.logging import LogContext, LogCategory
 
 
 def process_geotiff(task: QueueTask, temp_dir: Path):
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		raise AuthenticationError('Invalid processor token', token=token, task_id=task.id)
 

--- a/processor/src/process_metadata.py
+++ b/processor/src/process_metadata.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import time
 from typing import Dict, Any
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified
 from shared.status import update_status
 from shared.settings import settings
 from shared.models import (
@@ -25,9 +25,7 @@ from .utils.phenology import get_phenology_metadata
 
 def process_metadata(task: QueueTask, temp_dir: Path):
 	"""Process and store metadata for a dataset"""
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		logger.error(
 			'Invalid processor token',

--- a/processor/src/process_thumbnail.py
+++ b/processor/src/process_thumbnail.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import time
 import uuid
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified
 from shared.settings import settings
 from shared.models import StatusEnum, Ortho, QueueTask, Thumbnail
 from shared.logger import logger
@@ -16,9 +16,7 @@ from shared.logging import LogContext, LogCategory
 
 def process_thumbnail(task: QueueTask, temp_dir: Path):
 	# login with the processor
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		logger.error(
 			'Invalid processor token',
@@ -130,8 +128,7 @@ def process_thumbnail(task: QueueTask, temp_dir: Path):
 	# Save thumbnail metadata to database
 	try:
 		# Refresh token before database operation
-		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-		user = verify_token(token)
+		token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 		if not user:
 			logger.error(
 				'Token refresh failed',

--- a/processor/src/process_treecover_segmentation.py
+++ b/processor/src/process_treecover_segmentation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified
 from shared.settings import settings
 from shared.models import StatusEnum, Ortho, QueueTask
 from shared.logger import logger
@@ -28,9 +28,7 @@ def process_treecover_segmentation(task: QueueTask, token: str, temp_dir: Path):
 	    temp_dir (Path): Temporary directory for processing
 	"""
 	# Login with the processor
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		logger.error(
 			'Invalid processor token',

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -4,7 +4,7 @@ from processor.src.process_geotiff import process_geotiff
 from processor.src.process_odm import process_odm
 from shared.models import QueueTask, TaskTypeEnum, StatusEnum
 from shared.settings import settings
-from shared.db import use_client, login, verify_token
+from shared.db import use_client, login, login_verified, verify_token
 from shared.status import update_status
 from .process_thumbnail import process_thumbnail
 from .process_cog import process_cog
@@ -355,14 +355,9 @@ def background_process():
 	so no is_processing flag or concurrency guard is needed.
 	"""
 	# use the processor to log in
-	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-	user = verify_token(token)
+	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
-		# Token verification failed, try fresh login without cache
-		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)
-		user = verify_token(token)
-		if not user:
-			raise Exception(status_code=401, detail='Invalid token after fresh login')
+		raise Exception(status_code=401, detail='Invalid token after fresh login')
 
 	while True:
 		task = get_next_task(token)

--- a/shared/db.py
+++ b/shared/db.py
@@ -64,6 +64,21 @@ def login(user: str, password: str, use_cached_session: bool = True) -> str:
 		raise Exception(f'Login failed: {str(e)}')
 
 
+def login_verified(user: str, password: str) -> tuple[str, Union[Literal[False], Any]]:
+	"""
+	Log in and verify the resulting token, retrying once without using the cached
+	session if the first token is stale or invalid.
+	"""
+	token = login(user, password)
+	user_obj = verify_token(token)
+	if user_obj:
+		return token, user_obj
+
+	token = login(user, password, use_cached_session=False)
+	user_obj = verify_token(token)
+	return token, user_obj
+
+
 def verify_token(jwt: str) -> Union[Literal[False], Any]:
 	"""Verifies a user jwt token string against the active supabase sessions
 

--- a/shared/tests/test_db.py
+++ b/shared/tests/test_db.py
@@ -1,0 +1,43 @@
+import shared.db as db
+
+
+def test_login_verified_falls_back_to_uncached_login(monkeypatch):
+	attempts = []
+
+	def fake_login(user, password, use_cached_session=True):
+		attempts.append(use_cached_session)
+		return 'cached-token' if use_cached_session else 'fresh-token'
+
+	def fake_verify(token):
+		if token == 'cached-token':
+			return False
+		return {'id': 'processor-user'}
+
+	monkeypatch.setattr(db, 'login', fake_login)
+	monkeypatch.setattr(db, 'verify_token', fake_verify)
+
+	token, user = db.login_verified('processor@deadtrees.earth', 'secret')
+
+	assert attempts == [True, False]
+	assert token == 'fresh-token'
+	assert user == {'id': 'processor-user'}
+
+
+def test_login_verified_returns_first_valid_token(monkeypatch):
+	attempts = []
+
+	def fake_login(user, password, use_cached_session=True):
+		attempts.append(use_cached_session)
+		return 'cached-token'
+
+	def fake_verify(token):
+		return {'id': 'processor-user'}
+
+	monkeypatch.setattr(db, 'login', fake_login)
+	monkeypatch.setattr(db, 'verify_token', fake_verify)
+
+	token, user = db.login_verified('processor@deadtrees.earth', 'secret')
+
+	assert attempts == [True]
+	assert token == 'cached-token'
+	assert user == {'id': 'processor-user'}


### PR DESCRIPTION
## What changed
- added `login_verified(...)` in `shared/db.py` to retry once with `use_cached_session=False` when a cached processor token fails verification
- updated processor stage entrypoints to use the verified login flow before starting work
- added focused tests covering the cached-token fallback path

## Why this changed
A recent processor failure showed ODM and GeoTIFF finishing successfully, then metadata failing because the processor reused a stale cached auth session after a long-running job. That left the dataset stuck without a clean stage transition.

## Impact
- processor stages are less likely to fail at startup because of stale cached auth
- long-running processing runs should recover by forcing one fresh login before surfacing an auth error
- the behavior is covered by targeted unit tests

## Root cause
The processor cached Supabase sessions across stages. After a long ODM run, the cached token could fail verification even though the stage code expected `login(...)` to provide a usable token.

## Validation
- `deadtrees dev test processor`
- `./venv/bin/python -m pytest shared/tests/test_db.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication reliability with enhanced fallback mechanisms for login verification failures.

* **Refactor**
  * Consolidated internal authentication flow across processing modules for greater consistency and reduced code duplication.

* **Tests**
  * Added comprehensive test coverage for unified authentication verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->