### PR TITLE
[codex] Fix processor logging auth refresh

### DIFF
--- a/processor/src/deadwood_segmentation/predict_deadwood.py
+++ b/processor/src/deadwood_segmentation/predict_deadwood.py
@@ -91,11 +91,12 @@ def predict_deadwood(dataset_id: int, file_path: Path, user_id: str, token: str)
 		# Delete existing deadwood prediction labels
 		# Refresh token before DB ops to avoid expiry after long inference
 		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
-		deleted_count = delete_model_prediction_labels(
-			dataset_id=dataset_id, label_data=LabelDataEnum.deadwood, token=token
-		)
+		deleted_count = delete_model_prediction_labels(dataset_id=dataset_id, label_data=LabelDataEnum.deadwood, token=token)
 		if deleted_count > 0:
-			logger.info(f'Deleted {deleted_count} existing deadwood prediction labels')
+			logger.info(
+				f'Deleted {deleted_count} existing deadwood prediction labels',
+				LogContext(category=LogCategory.DEADWOOD, dataset_id=dataset_id, user_id=user_id, token=token),
+			)
 
 		# Create label with geometries
 		logger.info(

--- a/processor/src/geotiff/standardise_geotiff.py
+++ b/processor/src/geotiff/standardise_geotiff.py
@@ -83,7 +83,7 @@ def _check_if_already_standardized(
 		return {'is_standardized': False, 'has_alpha': False, 'is_lossy': False, 'compression': '', 'details': {}}
 
 
-def find_nodata_value(src, num_bands):
+def find_nodata_value(src, num_bands, token: str = None, dataset_id: int = None, user_id: str = None):
 	"""Helper function to determine current nodata value from the source image"""
 	try:
 		# First check if nodata is explicitly set
@@ -92,7 +92,13 @@ def find_nodata_value(src, num_bands):
 				# This is our main problem case - NaN nodata
 				logger.info(
 					'Detected NaN nodata in source file',
-					LogContext(category=LogCategory.ORTHO, extra={'nodata_type': 'nan'}),
+					LogContext(
+						category=LogCategory.ORTHO,
+						dataset_id=dataset_id,
+						user_id=user_id,
+						token=token,
+						extra={'nodata_type': 'nan'},
+					),
 				)
 				return 'nan'  # Return string to distinguish from numeric values
 			else:
@@ -110,7 +116,14 @@ def find_nodata_value(src, num_bands):
 					return 0
 			except Exception as e:
 				logger.warning(
-					f'Error reading alpha band: {e}', LogContext(category=LogCategory.ORTHO, extra={'error': str(e)})
+					f'Error reading alpha band: {e}',
+					LogContext(
+						category=LogCategory.ORTHO,
+						dataset_id=dataset_id,
+						user_id=user_id,
+						token=token,
+						extra={'error': str(e)},
+					),
 				)
 
 		# Sample edges to detect nodata, being careful with NaN values
@@ -130,7 +143,13 @@ def find_nodata_value(src, num_bands):
 			if nan_percentage > 0.5:  # If more than 50% of edges are NaN
 				logger.info(
 					f'High NaN percentage in edges: {nan_percentage * 100:.1f}%',
-					LogContext(category=LogCategory.ORTHO, extra={'nan_percentage': nan_percentage}),
+					LogContext(
+						category=LogCategory.ORTHO,
+						dataset_id=dataset_id,
+						user_id=user_id,
+						token=token,
+						extra={'nan_percentage': nan_percentage},
+					),
 				)
 				return 'nan'
 
@@ -148,14 +167,28 @@ def find_nodata_value(src, num_bands):
 
 		except Exception as e:
 			logger.warning(
-				f'Error reading image edges: {e}', LogContext(category=LogCategory.ORTHO, extra={'error': str(e)})
+				f'Error reading image edges: {e}',
+				LogContext(
+					category=LogCategory.ORTHO,
+					dataset_id=dataset_id,
+					user_id=user_id,
+					token=token,
+					extra={'error': str(e)},
+				),
 			)
 
 		return None
 
 	except Exception as e:
 		logger.error(
-			f'Error in find_nodata_value: {e}', LogContext(category=LogCategory.ORTHO, extra={'error': str(e)})
+			f'Error in find_nodata_value: {e}',
+			LogContext(
+				category=LogCategory.ORTHO,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'error': str(e)},
+			),
 		)
 		return None
 
@@ -289,7 +322,7 @@ def _get_source_properties(input_path: str, token: str, dataset_id: int = None, 
 				'dtype': src.profile['dtype'],
 				'num_bands': src.count,
 				'crs': src.crs,
-				'nodata': find_nodata_value(src, src.count),
+				'nodata': find_nodata_value(src, src.count, token=token, dataset_id=dataset_id, user_id=user_id),
 			}
 
 			if not properties['crs']:
@@ -375,7 +408,13 @@ def _handle_bit_depth_conversion(
 		else:
 			# No alpha band - detect nodata for creating alpha from it
 			with rasterio.open(input_path) as src:
-				detected_nodata = find_nodata_value(src, src.count)
+				detected_nodata = find_nodata_value(
+					src,
+					src.count,
+					token=token,
+					dataset_id=dataset_id,
+					user_id=user_id,
+				)
 				explicit_nodata = src.nodata
 
 				# Return the original nodata value for transparency handling
@@ -394,7 +433,7 @@ def _handle_bit_depth_conversion(
 
 	# Get nodata information and calculate proper scaling
 	with rasterio.open(input_path) as src:
-		detected_nodata = find_nodata_value(src, src.count)
+		detected_nodata = find_nodata_value(src, src.count, token=token, dataset_id=dataset_id, user_id=user_id)
 		explicit_nodata = src.nodata
 
 		# Calculate scaling parameters by reading from center of image

--- a/processor/src/process_metadata.py
+++ b/processor/src/process_metadata.py
@@ -71,14 +71,24 @@ def process_metadata(task: QueueTask, temp_dir: Path):
 			),
 		)
 
-		admin_levels = get_admin_tags(bbox_centroid)
+		admin_levels = get_admin_tags(
+			bbox_centroid,
+			token=token,
+			dataset_id=task.dataset_id,
+			user_id=task.user_id,
+		)
 
 		admin_metadata = AdminBoundariesMetadata(
 			admin_level_1=admin_levels[0], admin_level_2=admin_levels[1], admin_level_3=admin_levels[2]
 		)
 
 		# Get biome data
-		biome_name, biome_id = get_biome_data(bbox_centroid)
+		biome_name, biome_id = get_biome_data(
+			bbox_centroid,
+			token=token,
+			dataset_id=task.dataset_id,
+			user_id=task.user_id,
+		)
 		biome_metadata = BiomeMetadata(biome_name=biome_name, biome_id=biome_id)
 
 		# Get phenology data
@@ -96,6 +106,9 @@ def process_metadata(task: QueueTask, temp_dir: Path):
 		phenology_metadata = get_phenology_metadata(
 			lat=bbox_centroid[1],  # latitude
 			lon=bbox_centroid[0],  # longitude
+			token=token,
+			dataset_id=task.dataset_id,
+			user_id=task.user_id,
 		)
 
 		# Create metadata entry with GADM, biome, and phenology data

--- a/processor/src/process_odm.py
+++ b/processor/src/process_odm.py
@@ -177,7 +177,12 @@ def process_odm(task: QueueTask, temp_dir: Path):
 			LogContext(category=LogCategory.ODM, token=token, dataset_id=dataset_id),
 		)
 
-		_run_odm_container(images_dir=extraction_dir, output_dir=odm_host_temp_dir, token=token, dataset_id=dataset_id)
+		token = _run_odm_container(
+			images_dir=extraction_dir,
+			output_dir=odm_host_temp_dir,
+			token=token,
+			dataset_id=dataset_id,
+		)
 
 		# Step 7: Move generated orthomosaic to standard location
 		project_name = f'dataset_{dataset_id}'
@@ -521,7 +526,7 @@ def _update_camera_metadata(dataset_id: int, exif_metadata: dict, token: str):
 			)
 
 
-def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_id: int):
+def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_id: int) -> str:
 	"""
 	Execute ODM Docker container using shared named volumes for file sharing.
 	This approach eliminates host path complexity and works identically in test and production.
@@ -734,6 +739,7 @@ def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_i
 
 				# Copy results from shared volume to output directory
 				copy_results_from_shared_volume(volume_name, output_dir, project_name, dataset_id, token)
+				return token
 			else:
 				# ODM failed - log detailed error information
 				logger.error(

--- a/processor/src/process_thumbnail.py
+++ b/processor/src/process_thumbnail.py
@@ -82,7 +82,13 @@ def process_thumbnail(task: QueueTask, temp_dir: Path):
 			'Starting thumbnail generation',
 			LogContext(category=LogCategory.THUMBNAIL, dataset_id=task.dataset_id, user_id=task.user_id, token=token),
 		)
-		calculate_thumbnail(str(input_path), str(output_path))
+		calculate_thumbnail(
+			str(input_path),
+			str(output_path),
+			token=token,
+			dataset_id=task.dataset_id,
+			user_id=task.user_id,
+		)
 		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 		logger.info(
 			'Thumbnail generated successfully',

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -33,6 +33,16 @@ PIPELINE_STAGE_MAP = [
 ]
 
 
+def refresh_processor_token(task: QueueTask, fallback_token: str | None = None) -> str:
+	"""Best-effort token refresh for stage-boundary logging and updates."""
+	try:
+		return login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
+	except Exception:
+		if fallback_token is not None:
+			return fallback_token
+		raise AuthenticationError('Invalid processor token', token=fallback_token, task_id=task.id)
+
+
 def detect_crashed_stage(status_data: dict, task_types: list) -> str:
 	"""Determine which pipeline stage a previous crash occurred during.
 
@@ -156,19 +166,21 @@ def process_task(task: QueueTask, token: str):
 		# Process ODM first if it's in the list (generates orthomosaic for ZIP uploads)
 		if TaskTypeEnum.odm_processing in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					'Starting ODM processing',
 					LogContext(category=LogCategory.ODM, dataset_id=task.dataset_id, user_id=task.user_id, token=token),
 				)
 				process_odm(task, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'ODM processing failed: {str(e)}',
 					LogContext(
 						category=LogCategory.ODM,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=token,
+						token=error_token,
 						extra={'error': str(e)},
 					),
 				)
@@ -177,6 +189,7 @@ def process_task(task: QueueTask, token: str):
 		# Process convert_geotiff if it's in the list (handles ortho creation for both upload types)
 		if TaskTypeEnum.geotiff in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					'Starting GeoTIFF conversion',
 					LogContext(
@@ -185,13 +198,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_geotiff(task, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'GeoTIFF conversion failed: {str(e)}',
 					LogContext(
 						category=LogCategory.ORTHO,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=token,
+						token=error_token,
 						extra={'error': str(e)},
 					),
 				)
@@ -200,6 +214,7 @@ def process_task(task: QueueTask, token: str):
 		# Process metadata if requested
 		if TaskTypeEnum.metadata in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					'processing metadata',
 					LogContext(
@@ -208,10 +223,11 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_metadata(task, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'Metadata processing failed: {str(e)}',
 					LogContext(
-						category=LogCategory.METADATA, dataset_id=task.dataset_id, user_id=task.user_id, token=token
+						category=LogCategory.METADATA, dataset_id=task.dataset_id, user_id=task.user_id, token=error_token
 					),
 				)
 				raise ProcessingError(str(e), task_type='metadata', task_id=task.id, dataset_id=task.dataset_id)
@@ -219,21 +235,26 @@ def process_task(task: QueueTask, token: str):
 		# Process cog if requested
 		if TaskTypeEnum.cog in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					f'processing cog to {settings.processing_path}',
 					LogContext(category=LogCategory.COG, dataset_id=task.dataset_id, user_id=task.user_id, token=token),
 				)
 				process_cog(task, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'COG processing failed: {str(e)}',
-					LogContext(category=LogCategory.COG, dataset_id=task.dataset_id, user_id=task.user_id, token=token),
+					LogContext(
+						category=LogCategory.COG, dataset_id=task.dataset_id, user_id=task.user_id, token=error_token
+					),
 				)
 				raise ProcessingError(str(e), task_type='cog', task_id=task.id, dataset_id=task.dataset_id)
 
 		# Process thumbnail if requested
 		if TaskTypeEnum.thumbnail in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					f'processing thumbnail to {settings.processing_path}',
 					LogContext(
@@ -242,10 +263,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_thumbnail(task, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'Thumbnail processing failed: {str(e)}',
 					LogContext(
-						category=LogCategory.THUMBNAIL, dataset_id=task.dataset_id, user_id=task.user_id, token=token
+						category=LogCategory.THUMBNAIL,
+						dataset_id=task.dataset_id,
+						user_id=task.user_id,
+						token=error_token,
 					),
 				)
 				raise ProcessingError(str(e), task_type='thumbnail', task_id=task.id, dataset_id=task.dataset_id)
@@ -253,6 +278,7 @@ def process_task(task: QueueTask, token: str):
 		# Process deadwood_segmentation if requested
 		if TaskTypeEnum.deadwood in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					'processing deadwood segmentation',
 					LogContext(
@@ -261,10 +287,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_deadwood_segmentation(task, token, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'Deadwood segmentation failed: {str(e)}',
 					LogContext(
-						category=LogCategory.DEADWOOD, dataset_id=task.dataset_id, user_id=task.user_id, token=token
+						category=LogCategory.DEADWOOD,
+						dataset_id=task.dataset_id,
+						user_id=task.user_id,
+						token=error_token,
 					),
 				)
 				raise ProcessingError(
@@ -274,6 +304,7 @@ def process_task(task: QueueTask, token: str):
 		# Process treecover_segmentation if requested (runs after deadwood)
 		if TaskTypeEnum.treecover in task.task_types:
 			try:
+				token = refresh_processor_token(task, token)
 				logger.info(
 					'processing tree cover segmentation',
 					LogContext(
@@ -282,10 +313,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_treecover_segmentation(task, token, settings.processing_path)
 			except Exception as e:
+				error_token = refresh_processor_token(task, token)
 				logger.error(
 					f'Tree cover segmentation failed: {str(e)}',
 					LogContext(
-						category=LogCategory.TREECOVER, dataset_id=task.dataset_id, user_id=task.user_id, token=token
+						category=LogCategory.TREECOVER,
+						dataset_id=task.dataset_id,
+						user_id=task.user_id,
+						token=error_token,
 					),
 				)
 				raise ProcessingError(

--- a/processor/src/thumbnail/thumbnail.py
+++ b/processor/src/thumbnail/thumbnail.py
@@ -4,9 +4,17 @@ import numpy as np
 from PIL import Image
 
 from shared.logger import logger
+from shared.logging import LogContext, LogCategory
 
 
-def calculate_thumbnail(tiff_file_path: str, thumbnail_file_path: str, size=(256, 256)):
+def calculate_thumbnail(
+	tiff_file_path: str,
+	thumbnail_file_path: str,
+	size=(256, 256),
+	token: str = None,
+	dataset_id: int = None,
+	user_id: str = None,
+):
 	"""
 	Creates a thumbnail from a GeoTIFF file using rasterio.
 
@@ -18,7 +26,10 @@ def calculate_thumbnail(tiff_file_path: str, thumbnail_file_path: str, size=(256
 	Returns:
 	    None
 	"""
-	logger.info(f'Starting thumbnail calculation with paths - input: {tiff_file_path}, output: {thumbnail_file_path}')
+	logger.info(
+		f'Starting thumbnail calculation with paths - input: {tiff_file_path}, output: {thumbnail_file_path}',
+		LogContext(category=LogCategory.THUMBNAIL, dataset_id=dataset_id, user_id=user_id, token=token),
+	)
 
 	try:
 		with rasterio.open(tiff_file_path) as src:
@@ -61,13 +72,25 @@ def calculate_thumbnail(tiff_file_path: str, thumbnail_file_path: str, size=(256
 			thumb.paste(img, offset)
 
 			# Save the thumbnail
-			logger.info(f'Saving thumbnail to: {thumbnail_file_path}')
+			logger.info(
+				f'Saving thumbnail to: {thumbnail_file_path}',
+				LogContext(category=LogCategory.THUMBNAIL, dataset_id=dataset_id, user_id=user_id, token=token),
+			)
 			thumb.save(thumbnail_file_path, 'JPEG', quality=85)
-			logger.info(f'Thumbnail saved successfully to: {thumbnail_file_path}')
+			logger.info(
+				f'Thumbnail saved successfully to: {thumbnail_file_path}',
+				LogContext(category=LogCategory.THUMBNAIL, dataset_id=dataset_id, user_id=user_id, token=token),
+			)
 
 	except Exception as e:
 		logger.error(
 			f'Error creating thumbnail: {str(e)}',
-			extra={'tiff_file': tiff_file_path, 'thumbnail_file': thumbnail_file_path},
+			LogContext(
+				category=LogCategory.THUMBNAIL,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'tiff_file': tiff_file_path, 'thumbnail_file': thumbnail_file_path},
+			),
 		)
 		raise

--- a/processor/src/utils/admin_levels.py
+++ b/processor/src/utils/admin_levels.py
@@ -6,6 +6,7 @@ from shared.logger import logger
 from shared.db import use_client
 from shared.settings import settings
 from shared.models import Dataset
+from shared.logging import LogContext, LogCategory
 
 # Define the path to the GADM database
 GADM_PATH = Path(settings.GADM_DATA_PATH)
@@ -21,7 +22,9 @@ def get_gadm_path():
 	return GADM_PATH
 
 
-def get_admin_tags(point: Tuple[float, float]) -> List[Optional[str]]:
+def get_admin_tags(
+	point: Tuple[float, float], token: str = None, dataset_id: int = None, user_id: str = None
+) -> List[Optional[str]]:
 	"""
 	Returns administrative names for levels 0 (country), 1 (state/province),
 	and 2 (municipality/district).
@@ -62,7 +65,16 @@ def get_admin_tags(point: Tuple[float, float]) -> List[Optional[str]]:
 		return [None, None, None]
 
 	except Exception as e:
-		logger.error(f'Error getting GADM admin tags: {str(e)}')
+		logger.error(
+			f'Error getting GADM admin tags: {str(e)}',
+			LogContext(
+				category=LogCategory.METADATA,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'error': str(e)},
+			),
+		)
 		return [None, None, None]
 
 
@@ -84,7 +96,7 @@ def update_metadata_admin_level(dataset_id: int, token: str):
 			data = Dataset(**response.data[0])
 
 		# Get admin tags using GADM data
-		admin_levels = get_admin_tags(data.centroid)
+		admin_levels = get_admin_tags(data.centroid, token=token, dataset_id=dataset_id)
 		metadata_update = {
 			'admin_level_1': admin_levels[0],  # country
 			'admin_level_2': admin_levels[1],  # state/province

--- a/processor/src/utils/biome.py
+++ b/processor/src/utils/biome.py
@@ -4,6 +4,7 @@ import geopandas as gpd
 from shapely.geometry import Point
 from shared.logger import logger
 from shared.settings import settings
+from shared.logging import LogContext, LogCategory
 
 # Define the path to the biome database
 BIOME_PATH = Path(settings.BIOME_DATA_PATH)
@@ -20,7 +21,9 @@ def get_biome_path():
 	return BIOME_PATH
 
 
-def get_biome_data(point: Tuple[float, float]) -> Tuple[Optional[str], Optional[int]]:
+def get_biome_data(
+	point: Tuple[float, float], token: str = None, dataset_id: int = None, user_id: str = None
+) -> Tuple[Optional[str], Optional[int]]:
 	"""
 	Returns biome name and ID for a given point.
 
@@ -67,5 +70,14 @@ def get_biome_data(point: Tuple[float, float]) -> Tuple[Optional[str], Optional[
 		return None, None
 
 	except Exception as e:
-		logger.error(f'Error getting biome data: {str(e)}')
+		logger.error(
+			f'Error getting biome data: {str(e)}',
+			LogContext(
+				category=LogCategory.METADATA,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'error': str(e)},
+			),
+		)
 		return None, None

--- a/processor/src/utils/phenology.py
+++ b/processor/src/utils/phenology.py
@@ -6,6 +6,7 @@ from rasterio import crs, warp
 from shared.logger import logger
 from shared.models import PhenologyMetadata
 from shared.settings import settings
+from shared.logging import LogContext, LogCategory
 
 # Dataset path
 
@@ -33,7 +34,9 @@ def get_phenology_path() -> Path:
 	return Path(settings.PHENOLOGY_DATA_PATH)
 
 
-def get_phenology_curve(lat: float, lon: float) -> Optional[List[int]]:
+def get_phenology_curve(
+	lat: float, lon: float, token: str = None, dataset_id: int = None, user_id: str = None
+) -> Optional[List[int]]:
 	"""
 	Get the phenology curve for a given latitude and longitude.
 
@@ -59,24 +62,41 @@ def get_phenology_curve(lat: float, lon: float) -> Optional[List[int]]:
 		is_nan = ds_nearest.nan_mask.values[0][0]
 
 		if is_nan:
-			logger.debug(f'No phenology data available for coordinates ({lat}, {lon})')
+			logger.debug(
+				f'No phenology data available for coordinates ({lat}, {lon})',
+				LogContext(category=LogCategory.METADATA, dataset_id=dataset_id, user_id=user_id, token=token),
+			)
 			return None
 
 		# Convert to list of integers
 		phenology_curve = pheno.astype(int).tolist()
 
 		if len(phenology_curve) != 366:
-			logger.warning(f'Unexpected phenology curve length: {len(phenology_curve)}')
+			logger.warning(
+				f'Unexpected phenology curve length: {len(phenology_curve)}',
+				LogContext(category=LogCategory.METADATA, dataset_id=dataset_id, user_id=user_id, token=token),
+			)
 			return None
 
 		return phenology_curve
 
 	except Exception as e:
-		logger.error(f'Error getting phenology data for ({lat}, {lon}): {str(e)}')
+		logger.error(
+			f'Error getting phenology data for ({lat}, {lon}): {str(e)}',
+			LogContext(
+				category=LogCategory.METADATA,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'error': str(e)},
+			),
+		)
 		return None
 
 
-def get_phenology_metadata(lat: float, lon: float) -> Optional[PhenologyMetadata]:
+def get_phenology_metadata(
+	lat: float, lon: float, token: str = None, dataset_id: int = None, user_id: str = None
+) -> Optional[PhenologyMetadata]:
 	"""
 	Get phenology metadata for a location.
 
@@ -89,7 +109,7 @@ def get_phenology_metadata(lat: float, lon: float) -> Optional[PhenologyMetadata
 	"""
 	try:
 		# Get phenology curve
-		curve = get_phenology_curve(lat, lon)
+		curve = get_phenology_curve(lat, lon, token=token, dataset_id=dataset_id, user_id=user_id)
 		if curve is None:
 			return None
 
@@ -97,5 +117,14 @@ def get_phenology_metadata(lat: float, lon: float) -> Optional[PhenologyMetadata
 		return PhenologyMetadata(phenology_curve=curve)
 
 	except Exception as e:
-		logger.error(f'Error creating phenology metadata: {str(e)}')
+		logger.error(
+			f'Error creating phenology metadata: {str(e)}',
+			LogContext(
+				category=LogCategory.METADATA,
+				dataset_id=dataset_id,
+				user_id=user_id,
+				token=token,
+				extra={'error': str(e)},
+			),
+		)
 		return None

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 
+import processor.src.processor as processor_module
 from shared.db import use_client
 from shared.settings import settings
 from shared.models import TaskTypeEnum, QueueTask, StatusEnum
@@ -67,6 +68,65 @@ def test_background_process_no_tasks():
 	# Verify it completes without error
 	# (The function should return None when no tasks are found)
 	assert background_process() is None
+
+
+def test_process_task_success_path_with_refresh(monkeypatch):
+	"""Successful stage execution should not fall into an error path."""
+
+	task = QueueTask(
+		id=123,
+		dataset_id=456,
+		user_id='test-user',
+		task_types=[TaskTypeEnum.metadata],
+		priority=1,
+		is_processing=False,
+		current_position=1,
+		estimated_time=0.0,
+	)
+	stage_calls = []
+	deleted_task_ids = []
+
+	class _DeleteQuery:
+		def eq(self, field, value):
+			assert field == 'id'
+			deleted_task_ids.append(value)
+			return self
+
+		def execute(self):
+			return None
+
+	class _TableQuery:
+		def delete(self):
+			return _DeleteQuery()
+
+	class _FakeClient:
+		def table(self, name):
+			assert name == settings.queue_table
+			return _TableQuery()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	monkeypatch.setattr(processor_module, 'verify_token', lambda token: {'id': 'processor-user'})
+	monkeypatch.setattr(processor_module, 'refresh_processor_token', lambda task, token=None: 'refreshed-token')
+	monkeypatch.setattr(processor_module, 'login', lambda username, password: 'final-token')
+	monkeypatch.setattr(processor_module, 'use_client', lambda token: _FakeClient())
+	monkeypatch.setattr(processor_module.logger, 'info', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'error', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'warning', lambda *args, **kwargs: None)
+	monkeypatch.setattr(
+		processor_module,
+		'process_metadata',
+		lambda current_task, processing_path: stage_calls.append((current_task.id, str(processing_path))),
+	)
+
+	process_task(task, 'initial-token')
+
+	assert stage_calls == [(task.id, str(settings.processing_path))]
+	assert deleted_task_ids == [task.id]
 
 
 def test_pipeline_stage_map_is_stable_and_ordered():

--- a/shared/labels.py
+++ b/shared/labels.py
@@ -16,6 +16,7 @@ from shared.models import (
 from shared.db import use_client
 from shared.settings import settings
 from shared.logger import logger
+from shared.logging import LogContext, LogCategory
 
 MAX_CHUNK_SIZE = 1024 * 1024 * 5  # 5MB per chunk
 
@@ -214,7 +215,10 @@ def delete_model_prediction_labels(dataset_id: int, label_data: LabelDataEnum, t
 			# Delete the labels themselves
 			client.table(settings.labels_table).delete().in_('id', label_ids).execute()
 
-			logger.info(f'Deleted {deleted_count} existing model prediction labels for dataset {dataset_id}')
+			logger.info(
+				f'Deleted {deleted_count} existing model prediction labels for dataset {dataset_id}',
+				LogContext(category=LogCategory.LABEL, dataset_id=dataset_id, token=token),
+			)
 			return deleted_count
 
 		except Exception as e:


### PR DESCRIPTION
## What changed
- refresh the processor token at stage boundaries so long-running processing keeps authenticated logging and status updates
- propagate the refreshed ODM token through post-ODM steps instead of continuing with a stale outer token
- pass auth context into thumbnail, label cleanup, GeoTIFF, and metadata helper logging paths that were hitting `v2_logs` RLS failures
- restore the correct `process_task()` success/error control flow and add a regression test for the success path

## Why
The processor pipeline was running, but long stages could outlive the original JWT and then continue logging or updating status with stale or missing auth context. That caused `JWT expired` and `v2_logs` RLS errors, and one follow-up change briefly regressed `process_task()` into an invalid success path.

## Validation
- `PYTHONPATH=/home/jj1049/dev/deadtrees ./venv/bin/pytest processor/tests/test_processor.py -k 'process_task_success_path_with_refresh or background_process_no_tasks or pipeline_stage_map_is_stable_and_ordered or detect_crashed_stage or get_completed_stages'`
- `PYTHONPATH=/home/jj1049/dev/deadtrees ./venv/bin/pytest shared/tests/test_db.py processor/tests/test_process_odm.py`

## Notes
- the broader processor integration tests in this local environment still depend on the SSH-backed fixture key at `~/.ssh/deadwood_id_rsa`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication failures in long-running processing tasks by implementing automatic token refresh mechanism.

* **Refactor**
  * Enhanced diagnostic logging with structured metadata context across all processing stages for improved troubleshooting and audit trails.

* **Tests**
  * Added test coverage for token refresh in processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->