### PR TITLE
Add Supabase migration workflow on main merges

### DIFF
--- a/.github/workflows/supabase-migrate-on-merge.yml
+++ b/.github/workflows/supabase-migrate-on-merge.yml
@@ -1,0 +1,38 @@
+name: Supabase Migrate On Merge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "supabase/**"
+      - ".github/workflows/supabase-migrate-on-merge.yml"
+
+concurrency:
+  group: supabase-prod-migrate
+  cancel-in-progress: false
+
+jobs:
+  supabase-migrate:
+    name: supabase-migrate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      PGSSLMODE: disable
+      SUPABASE_DB_URL_PROD: ${{ secrets.SUPABASE_DB_URL_PROD }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.40.7
+
+      - name: Show Supabase CLI version
+        run: supabase --version
+
+      - name: Apply production migrations
+        run: supabase migration up --db-url "$SUPABASE_DB_URL_PROD"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Supabase production migrations on push to `main`
- scope it to `supabase/**` changes and serialize runs with a concurrency group
- use the same command used for manual production migration, including `PGSSLMODE=disable`

## Details
- secret added in repo settings: `SUPABASE_DB_URL_PROD`
- workflow uses `supabase/setup-cli@v1`
- CLI version pinned to `2.40.7` to match the current known-good local workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated database migration workflow to streamline the deployment process. Database schema changes are now automatically applied when relevant code changes are merged to the main branch, reducing manual deployment steps and improving deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->