### PR TITLE
Update Cursor rules for monorepo deployment flow

### DIFF
--- a/.cursor/rules/AGENT.mdc
+++ b/.cursor/rules/AGENT.mdc
@@ -15,6 +15,27 @@ alwaysApply: true
 
 ## Architecture (Critical Knowledge)
 
+### Repository: Monorepo
+
+- **Primary repository:** `Deadwood-ai/deadtrees`
+- **Frontend app:** `frontend/`
+- **Backend API:** `api/`
+- **Processor:** `processor/`
+- **Database migrations:** `supabase/`
+
+### Deployment Flow
+
+- **Frontend:** preview deploy on PR, live deploy on merge to `main` via GitHub Actions/Firebase
+- **API:** storage server pulls `main` and rebuilds `api`
+- **Processor:** processor server pulls `main` and rebuilds `processor`
+- **Database:** `supabase migration up --db-url ...` runs on merge to `main` when `supabase/**` changes
+
+### Delivery Policy
+
+- Expected workflow is: local development and testing → PR checks/reviews → merge to `main` → automatic deploy
+- Do not add PR-time workflows that mutate production services or the production database
+- Production changes should land through the existing merge-to-main deploy path unless the user explicitly asks for a manual production intervention
+
 ### Production: Two Separate Physical Machines
 
 | Machine | Services | Has /data? |

--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -16,6 +16,7 @@ alwaysApply: true
 - Sync tests only: test functions must be synchronous
 - Containers as source of truth: run services inside Docker Compose
 - Ask-first: if something is unclear, ask clarifying questions
+- Monorepo-aware: backend, frontend, and Supabase changes now live in the same repo but deploy through different paths
 
 ## QUICK START
 ```bash
@@ -47,6 +48,14 @@ deadtrees dev run-dev
 - processor-test: debug 5678 (GPU)
 - nginx: HTTP 8080, SSH 2222 (test reverse proxy)
 - CLI debugging (local): default 5680
+
+## MONOREPO DELIVERY FLOW
+- Frontend code lives in `frontend/`
+- Frontend preview deploy runs on PRs that touch `frontend/**`
+- Frontend live deploy runs on merge to `main`
+- API and processor production deploys are server-side pull/rebuild flows triggered by new commits on `main`
+- Supabase production migrations run on merge to `main` only when `supabase/**` changes
+- Expected workflow is local development/testing first, then PR review, then merge-driven deployment
 
 ## PORTS & ENDPOINTS
 - Nginx test endpoints:
@@ -116,6 +125,7 @@ make symlinks
 - Do not introduce async tests
 - Avoid class-based tests; prefer functions (existing classes are legacy)
 - Do not hardcode absolute file paths; derive from `shared.settings.settings`
+- Do not add PR-time database workflows that apply migrations to production; production DB mutation belongs only to the merge-to-main deploy path
 
 ## NOTES
 - If any step or assumption is unclear, ask questions before proceeding

--- a/.cursor/rules/project-structure.mdc
+++ b/.cursor/rules/project-structure.mdc
@@ -134,6 +134,16 @@ api/
     └── routers/
 ```
 
+### **Frontend Structure**
+```
+frontend/
+├── src/                     # React application source
+├── public/                  # Static assets
+├── docs/                    # Frontend-specific plans/changelogs
+├── test/                    # Frontend fixtures/tests
+└── firebase.json            # Firebase Hosting config
+```
+
 ### **Processor Service Structure**  
 ```
 processor/
@@ -150,6 +160,18 @@ processor/
 └── tests/                     # 🧪 Mirror src/ structure
     ├── utils/
     └── processors/
+```
+
+### **Repository Top Level**
+```
+.
+├── api/                     # FastAPI backend service
+├── processor/               # Processing pipeline
+├── shared/                  # Shared utilities and models
+├── supabase/                # Database migrations and Supabase config
+├── frontend/                # React frontend application
+├── deadtrees-cli/           # CLI and dev tooling
+└── .cursor/rules/           # Agent guidance
 ```
 
 ## 🎯 **NAMING CONVENTIONS**


### PR DESCRIPTION
## Summary
- update Cursor agent/context rules for the new monorepo layout
- document the current deployment split for frontend, api, processor, and supabase
- capture the expected workflow of local dev/test -> PR review -> merge-driven deploy

## Why
These rule files still described the old backend-only repo shape and did not reflect the new monorepo or merge-to-main deployment path.

## Testing
- documentation/context-only change
