### PR TITLE
Split frontend CI from preview deploy

### DIFF
--- a/.github/workflows/frontend-hosting-pull-request.yml
+++ b/.github/workflows/frontend-hosting-pull-request.yml
@@ -13,10 +13,23 @@ permissions:
   pull-requests: write
 
 jobs:
+  frontend-ci:
+    name: frontend-ci
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+
   frontend-preview:
     name: frontend-preview
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    needs:
+      - frontend-ci
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
## Summary
- add a secretless frontend CI job for PRs
- make Firebase preview deploy wait on that CI job
- skip Firebase preview deploy for Dependabot PRs that do not receive repo secrets

## Why
Dependabot PRs currently fail in the preview deploy step because GitHub does not expose the Firebase service account secret to those bot-triggered runs. This change keeps a useful CI signal while avoiding a known secret-related failure mode.

## Testing
- local 
> deadtrees-frontend-react@0.0.0 test
> vitest run


 RUN  v3.2.4 /home/jj1049/dev/deadtrees/frontend

 ✓ src/utils/fileValidation.test.ts (6 tests) 12ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  13:34:38
   Duration  418ms (transform 39ms, setup 0ms, collect 71ms, tests 12ms, environment 0ms, prepare 187ms)
