### PR TITLE
Skip frontend preview deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/frontend-hosting-pull-request.yml
+++ b/.github/workflows/frontend-hosting-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
 
   frontend-preview:
     name: frontend-preview
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     needs:
       - frontend-ci


### PR DESCRIPTION
## Summary
- change the preview deploy guard to check the PR author instead of the triggering actor

## Why
Using  is not stable for Dependabot PRs because a maintainer updating the branch changes the actor and can accidentally re-enable the Firebase preview deploy. The PR author is the correct signal.

## Testing
- workflow-only change
