### PR TITLE
[codex] Fix download bundle metadata and test CLI startup

### DIFF
--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -106,9 +106,9 @@ def build_dataset_metadata_row(
 
 	admin_levels = {
 		'admin_level_0': gadm.get('admin_level_1'),  # Country (GADM naming is off-by-one)
-		'admin_level_1': gadm.get('admin_level_1'),
-		'admin_level_2': gadm.get('admin_level_2'),
-		'admin_level_3': gadm.get('admin_level_3'),
+		'admin_level_1': gadm.get('admin_level_2'),
+		'admin_level_2': gadm.get('admin_level_3'),
+		'admin_level_3': gadm.get('admin_level_4'),
 	}
 	
 	# Extract centroid from ortho bbox

--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -2,6 +2,7 @@ import zipfile
 import io
 import hashlib
 import tempfile
+import json
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple, Set
 
@@ -96,16 +97,19 @@ def build_dataset_metadata_row(
 	Returns:
 		Dict with all metadata fields for this dataset
 	"""
-	# Extract admin levels from metadata
-	admin_levels = {}
-	if metadata and 'metadata' in metadata:
-		gadm = metadata['metadata'].get('gadm', {})
-		admin_levels = {
-			'admin_level_0': gadm.get('admin_level_1'),  # Country (GADM naming is off-by-one)
-			'admin_level_1': gadm.get('admin_level_1'),
-			'admin_level_2': gadm.get('admin_level_2'),
-			'admin_level_3': gadm.get('admin_level_3'),
-		}
+	# Extract structured metadata fields for download bundles.
+	metadata_blob = metadata.get('metadata') if isinstance(metadata, dict) else None
+	metadata_blob = metadata_blob if isinstance(metadata_blob, dict) else {}
+	gadm = metadata_blob.get('gadm') if isinstance(metadata_blob.get('gadm'), dict) else {}
+	biome = metadata_blob.get('biome') if isinstance(metadata_blob.get('biome'), dict) else {}
+	phenology = metadata_blob.get('phenology') if isinstance(metadata_blob.get('phenology'), dict) else {}
+
+	admin_levels = {
+		'admin_level_0': gadm.get('admin_level_1'),  # Country (GADM naming is off-by-one)
+		'admin_level_1': gadm.get('admin_level_1'),
+		'admin_level_2': gadm.get('admin_level_2'),
+		'admin_level_3': gadm.get('admin_level_3'),
+	}
 	
 	# Extract centroid from ortho bbox
 	centroid_lat = None
@@ -155,10 +159,41 @@ def build_dataset_metadata_row(
 		'admin_level_1': admin_levels.get('admin_level_1'),
 		'admin_level_2': admin_levels.get('admin_level_2'),
 		'admin_level_3': admin_levels.get('admin_level_3'),
+		'gadm_source': gadm.get('source'),
+		'gadm_version': gadm.get('version'),
+		'biome_id': biome.get('biome_id'),
+		'biome_name': biome.get('biome_name'),
+		'biome_source': biome.get('source'),
+		'biome_version': biome.get('version'),
+		'phenology_source': phenology.get('source'),
+		'phenology_version': phenology.get('version'),
+		'has_phenology_curve': isinstance(phenology.get('phenology_curve'), list)
+		and len(phenology['phenology_curve']) > 0,
+		'metadata_version': metadata.get('version') if isinstance(metadata, dict) else None,
+		'metadata_created_at': metadata.get('created_at') if isinstance(metadata, dict) else None,
 		'centroid_lat': centroid_lat,
 		'centroid_lon': centroid_lon,
 		'additional_information': dataset.additional_information,
 	}
+
+
+def build_single_dataset_metadata_row(
+	dataset: Dataset,
+	ortho: Optional[Dict],
+	metadata: Optional[Dict],
+) -> Dict:
+	"""Build the METADATA row for a single-dataset ZIP bundle."""
+	row = dataset.model_dump(exclude={'created_at'})
+	row.update(build_dataset_metadata_row(dataset, ortho or {}, metadata))
+
+	# Keep the raw metadata blob accessible without forcing callers to query the DB separately.
+	metadata_blob = metadata.get('metadata') if isinstance(metadata, dict) else None
+	if metadata_blob is not None:
+		row['metadata_json'] = json.dumps(metadata_blob, sort_keys=True)
+	else:
+		row['metadata_json'] = None
+
+	return row
 
 
 def generate_bundle_job_id(dataset_ids: List[int], include_labels: bool, include_parquet: bool) -> str:
@@ -580,6 +615,8 @@ def bundle_dataset(
 	target_path: str,
 	archive_file_path: str,
 	dataset: Dataset,
+	ortho: Optional[Dict] = None,
+	metadata: Optional[Dict] = None,
 	include_parquet: bool = True,
 	include_labels: bool = True,
 	use_original_filename: bool = False,
@@ -597,8 +634,8 @@ def bundle_dataset(
 		# Add the ortho file
 		archive.write(archive_file_path, arcname=f'{base_filename}.tif')
 
-		# Convert dataset to DataFrame for metadata
-		df = pd.DataFrame([dataset.model_dump(exclude={'id', 'created_at'})])
+		# Include both dataset columns and extracted v2_metadata fields in the bundle metadata.
+		df = pd.DataFrame([build_single_dataset_metadata_row(dataset, ortho, metadata)])
 
 		# Create temporary files for metadata formats
 		with tempfile.NamedTemporaryFile(suffix='.csv') as csv_file:

--- a/api/src/routers/download.py
+++ b/api/src/routers/download.py
@@ -248,12 +248,17 @@ async def download_dataset(
 		allow_viewonly_full_download=False,
 	)
 
+	with use_client(token) as client:
+		metadata_response = client.table(settings.metadata_table).select('*').eq('dataset_id', dataset_id_int).execute()
+	metadata = metadata_response.data[0] if metadata_response.data else None
+
 	if not ortho:
 		raise HTTPException(status_code=404, detail=f'Dataset <ID={dataset_id}> has no ortho file.')
 
 	# Build the file paths
 	download_dir = settings.downloads_path / dataset_id
 	download_file = download_dir / get_bundle_filename(dataset_id_int, include_labels, include_parquet)
+	error_file = download_file.with_suffix(f'{download_file.suffix}.error')
 
 	# Check if file already exists
 	if download_file.exists():
@@ -271,12 +276,17 @@ async def download_dataset(
 	# Create download directory if it doesn't exist
 	download_dir.mkdir(parents=True, exist_ok=True)
 
+	# Clear stale failure marker from prior failed attempt
+	if error_file.exists():
+		error_file.unlink()
+
 	# Start background task to create the archive
 	background_tasks.add_task(
 		create_dataset_bundle_background,
 		dataset_id=dataset_id,
 		dataset=dataset,
 		ortho=ortho,
+		metadata=metadata,
 		include_labels=include_labels,
 		include_parquet=include_parquet,
 		use_original_filename=use_original_filename,
@@ -307,6 +317,7 @@ async def check_download_status(
 
 	download_dir = settings.downloads_path / dataset_id
 	download_file = download_dir / get_bundle_filename(dataset_id_int, include_labels, include_parquet)
+	error_file = download_file.with_suffix(f'{download_file.suffix}.error')
 
 	# Check dataset exists and access policy allows full download
 	dataset, ortho = await get_accessible_dataset(
@@ -315,7 +326,14 @@ async def check_download_status(
 		allow_viewonly_full_download=False,
 	)
 
-	if download_file.exists() and download_file.stat().st_size > 0:
+	if error_file.exists():
+		error_message = error_file.read_text(encoding='utf-8').strip()
+		return DownloadStatus(
+			status=DownloadStatusEnum.FAILED,
+			job_id=dataset_id,
+			message=error_message or 'Dataset bundle generation failed',
+		)
+	elif download_file.exists() and download_file.stat().st_size > 0:
 		return DownloadStatus(
 			status=DownloadStatusEnum.COMPLETED,
 			job_id=dataset_id,
@@ -352,6 +370,11 @@ async def download_dataset_file(
 	)
 
 	download_file = settings.downloads_path / dataset_id / get_bundle_filename(dataset_id_int, include_labels, include_parquet)
+	error_file = download_file.with_suffix(f'{download_file.suffix}.error')
+
+	if error_file.exists():
+		error_message = error_file.read_text(encoding='utf-8').strip()
+		raise HTTPException(status_code=500, detail=error_message or 'Dataset bundle generation failed')
 
 	if not download_file.exists() or download_file.stat().st_size == 0:
 		raise HTTPException(status_code=404, detail=f'Download file for dataset <ID={dataset_id}> not found')
@@ -363,6 +386,7 @@ def create_dataset_bundle_background(
 	dataset_id: str,
 	dataset: Dataset,
 	ortho: dict,
+	metadata: Optional[dict] = None,
 	include_labels: bool = True,
 	include_parquet: bool = True,
 	use_original_filename: bool = False,
@@ -376,16 +400,24 @@ def create_dataset_bundle_background(
 	download_dir = settings.downloads_path / dataset_id
 	download_file = download_dir / get_bundle_filename(int(dataset_id), include_labels, include_parquet)
 	temp_file = download_file.with_suffix('.zip.part')
+	error_file = download_file.with_suffix(f'{download_file.suffix}.error')
 
 	try:
 		# Build the file paths
 		archive_file_name = (settings.archive_path / ortho['ortho_file_name']).resolve()
+
+		# Clear stale state from prior attempts
+		for f in (temp_file, error_file):
+			if f.exists():
+				f.unlink()
 
 		# Write to temp file first
 		bundle_dataset(
 			str(temp_file),
 			archive_file_name,
 			dataset=dataset,
+			ortho=ortho,
+			metadata=metadata,
 			include_parquet=include_parquet,
 			include_labels=include_labels,
 			use_original_filename=use_original_filename,
@@ -402,6 +434,7 @@ def create_dataset_bundle_background(
 		for f in (temp_file, download_file):
 			if f.exists():
 				f.unlink()
+		error_file.write_text(str(e) or 'Dataset bundle generation failed', encoding='utf-8')
 
 
 def create_labels_geopackage_background(dataset_id: str):

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -1235,6 +1235,101 @@ def test_download_dataset_async(auth_token, test_dataset_for_download):
 		assert 'LICENSE.txt' in files
 
 
+def test_single_dataset_bundle_metadata_includes_v2_metadata(auth_token, test_dataset_for_download):
+	"""Single-dataset bundles should include extracted v2_metadata fields in METADATA.csv."""
+	metadata_data = {
+		'dataset_id': test_dataset_for_download,
+		'version': 1,
+		'metadata': {
+			'gadm': {
+				'source': 'GADM',
+				'version': '4.1.0',
+				'admin_level_1': 'Germany',
+				'admin_level_2': 'Baden-Wuerttemberg',
+				'admin_level_3': 'Freiburg',
+			},
+			'biome': {
+				'source': 'WWF',
+				'version': '2.0',
+				'biome_id': 4,
+				'biome_name': 'Temperate Broadleaf and Mixed Forests',
+			},
+			'phenology': {
+				'source': 'MODIS',
+				'version': '1.0',
+				'phenology_curve': [0, 1, 2],
+			},
+		},
+	}
+
+	with use_client(auth_token) as db_client:
+		db_client.table(settings.metadata_table).insert(metadata_data).execute()
+
+	try:
+		response = client.get(
+			f'/api/v1/download/datasets/{test_dataset_for_download}/dataset.zip',
+			headers={'Authorization': f'Bearer {auth_token}'},
+		)
+		assert response.status_code == 200
+
+		_wait_for_download_completed(test_dataset_for_download, auth_token)
+
+		download_file = settings.downloads_path / str(test_dataset_for_download) / f'{test_dataset_for_download}.zip'
+		assert download_file.exists()
+
+		with zipfile.ZipFile(download_file) as zf, tempfile.TemporaryDirectory() as tmpdir:
+			zf.extract('METADATA.csv', tmpdir)
+			df = pd.read_csv(Path(tmpdir) / 'METADATA.csv')
+			assert len(df) == 1
+			assert df.loc[0, 'admin_level_1'] == 'Germany'
+			assert df.loc[0, 'admin_level_2'] == 'Baden-Wuerttemberg'
+			assert df.loc[0, 'admin_level_3'] == 'Freiburg'
+			assert df.loc[0, 'biome_name'] == 'Temperate Broadleaf and Mixed Forests'
+			assert bool(df.loc[0, 'has_phenology_curve']) is True
+			assert '"gadm"' in df.loc[0, 'metadata_json']
+	finally:
+		with use_client(auth_token) as db_client:
+			db_client.table(settings.metadata_table).delete().eq('dataset_id', test_dataset_for_download).execute()
+
+
+def test_single_dataset_bundle_status_reports_failed_when_generation_errors(
+	auth_token, test_dataset_for_download, data_directory
+):
+	"""Single-dataset status endpoint should surface bundle failures instead of polling forever."""
+	archive_path = data_directory / settings.archive_path / 'test-download.tif'
+	if archive_path.exists():
+		archive_path.unlink()
+
+	response = client.get(
+		f'/api/v1/download/datasets/{test_dataset_for_download}/dataset.zip',
+		headers={'Authorization': f'Bearer {auth_token}'},
+	)
+	assert response.status_code == 200
+
+	last_status = None
+	for _ in range(20):
+		status_response = client.get(
+			f'/api/v1/download/datasets/{test_dataset_for_download}/status',
+			headers={'Authorization': f'Bearer {auth_token}'},
+		)
+		assert status_response.status_code == 200
+		last_status = status_response.json()
+		if last_status['status'] == 'failed':
+			break
+		time.sleep(0.1)
+	else:
+		pytest.fail(f'Expected failed status, got: {last_status}')
+
+	assert 'No such file or directory' in last_status['message']
+
+	download_response = client.get(
+		f'/api/v1/download/datasets/{test_dataset_for_download}/download',
+		headers={'Authorization': f'Bearer {auth_token}'},
+	)
+	assert download_response.status_code == 500
+	assert 'No such file or directory' in download_response.json()['detail']
+
+
 def test_download_dataset_already_exists(auth_token, test_dataset_for_download):
 	"""Test requesting a download when the file already exists"""
 	# First ensure the download exists

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -1281,9 +1281,9 @@ def test_single_dataset_bundle_metadata_includes_v2_metadata(auth_token, test_da
 			zf.extract('METADATA.csv', tmpdir)
 			df = pd.read_csv(Path(tmpdir) / 'METADATA.csv')
 			assert len(df) == 1
-			assert df.loc[0, 'admin_level_1'] == 'Germany'
-			assert df.loc[0, 'admin_level_2'] == 'Baden-Wuerttemberg'
-			assert df.loc[0, 'admin_level_3'] == 'Freiburg'
+			assert df.loc[0, 'admin_level_0'] == 'Germany'
+			assert df.loc[0, 'admin_level_1'] == 'Baden-Wuerttemberg'
+			assert df.loc[0, 'admin_level_2'] == 'Freiburg'
 			assert df.loc[0, 'biome_name'] == 'Temperate Broadleaf and Mixed Forests'
 			assert bool(df.loc[0, 'has_phenology_curve']) is True
 			assert '"gadm"' in df.loc[0, 'metadata_json']
@@ -2239,9 +2239,9 @@ class TestMultiBundleHelpers:
 		assert result['gsd_cm'] == 5.0
 		assert result['sensor_platform'] == 'drone'
 		assert result['authors'] == 'Author A, Author B'
-		assert result['admin_level_1'] == 'Germany'
-		assert result['admin_level_2'] == 'Baden-Württemberg'
-		assert result['admin_level_3'] == 'Freiburg'
+		assert result['admin_level_0'] == 'Germany'
+		assert result['admin_level_1'] == 'Baden-Württemberg'
+		assert result['admin_level_2'] == 'Freiburg'
 		assert result['centroid_lat'] == 48.5
 		assert result['centroid_lon'] == 8.5
 		assert result['additional_information'] == 'Test info'

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -1,7 +1,9 @@
+import json
 import subprocess
 import os
 import signal
 import shutil
+import time
 from pathlib import Path
 from typing import Optional, List
 from datetime import datetime
@@ -25,6 +27,22 @@ class DevCommands:
 	def __init__(self):
 		self.test_compose_file = 'docker-compose.test.yaml'
 
+	def _compose_cmd(self, *args: str) -> List[str]:
+		"""Build a docker compose command for the test environment."""
+		return ['docker', 'compose', '-f', self.test_compose_file, *args]
+
+	def _compose_lifecycle_cmd(
+		self, action: str, *, flags: Optional[List[str]] = None, services: Optional[List[str]] = None
+	) -> List[str]:
+		"""Build compose up/down commands with consistent lifecycle flags."""
+		cmd = self._compose_cmd(action)
+		if flags:
+			cmd.extend(flags)
+		cmd.append('--remove-orphans')
+		if services:
+			cmd.extend(services)
+		return cmd
+
 	def _run_command(self, command: List[str], check: bool = True) -> subprocess.CompletedProcess:
 		"""Run a shell command and handle errors"""
 		try:
@@ -34,56 +52,96 @@ class DevCommands:
 			print(f'Error: {str(e)}')
 			raise
 
-	def _is_service_running(self, service: str) -> bool:
-		"""Check whether a compose service is currently running."""
+	def _get_compose_services(self) -> List[str]:
+		"""Get the list of services defined in the test compose file."""
 		result = subprocess.run(
-			['docker', 'compose', '-f', self.test_compose_file, 'ps', '--status', 'running', '--services'],
+			self._compose_cmd('config', '--services'),
+			capture_output=True,
+			text=True,
+			check=True,
+		)
+		return [service for service in result.stdout.strip().split('\n') if service]
+
+	def _get_service_statuses(self) -> dict[str, dict]:
+		"""Return compose service status records keyed by service name."""
+		result = subprocess.run(
+			self._compose_cmd('ps', '--format', 'json'),
 			capture_output=True,
 			text=True,
 			check=False,
 		)
 		if result.returncode != 0:
-			return False
+			return {}
 
-		running_services = {line.strip() for line in result.stdout.splitlines() if line.strip()}
-		return service in running_services
+		statuses = {}
+		for line in result.stdout.splitlines():
+			line = line.strip()
+			if not line:
+				continue
+			record = json.loads(line)
+			statuses[record['Service']] = record
+		return statuses
+
+	def _is_service_running(self, service: str) -> bool:
+		"""Check whether a compose service is currently running."""
+		record = self._get_service_statuses().get(service)
+		return bool(record and record.get('State') == 'running')
+
+	def _wait_for_services_ready(self, services: List[str], timeout_seconds: int = 90):
+		"""Wait until all requested services are running and healthy when health checks exist."""
+		deadline = time.monotonic() + timeout_seconds
+		pending: List[str] = []
+
+		while time.monotonic() < deadline:
+			statuses = self._get_service_statuses()
+			pending = []
+
+			for service in services:
+				record = statuses.get(service)
+				if not record:
+					pending.append(f'{service} (missing)')
+					continue
+
+				if record.get('State') != 'running':
+					pending.append(f'{service} ({record.get("State", "unknown")})')
+					continue
+
+				health = record.get('Health')
+				if health and health != 'healthy':
+					pending.append(f'{service} ({health})')
+
+			if not pending:
+				return
+
+			time.sleep(1)
+
+		raise RuntimeError(f'Timed out waiting for test services to become ready: {", ".join(pending)}')
 
 	def _ensure_test_service_running(self, service: str):
 		"""Start the test stack if the requested service is not already running."""
-		if self._is_service_running(service):
-			return
+		if not self._is_service_running(service):
+			print(f'Service "{service}" is not running. Starting test environment...')
+			try:
+				self.start()
+			except subprocess.CalledProcessError:
+				# Compose can report a startup conflict while still leaving the requested
+				# service running. Re-check before surfacing the failure.
+				if not self._is_service_running(service):
+					raise
+				print(f'Service "{service}" is now running despite compose startup warnings. Continuing...')
 
-		print(f'Service "{service}" is not running. Starting test environment...')
-		try:
-			self.start()
-		except subprocess.CalledProcessError:
-			# Compose can report a startup conflict while still leaving the requested
-			# service running. Re-check before surfacing the failure.
-			if not self._is_service_running(service):
-				raise
-			print(f'Service "{service}" is now running despite compose startup warnings. Continuing...')
+		self._wait_for_services_ready(self._get_compose_services())
 
 	def _check_rebuild_needed(self) -> List[str]:
 		"""Check which services need rebuilding by comparing image and dockerfile timestamps"""
 		services_to_rebuild = []
 
 		# Get list of all services
-		result = subprocess.run(
-			['docker', 'compose', '-f', self.test_compose_file, 'config', '--services'],
-			capture_output=True,
-			text=True,
-			check=True,
-		)
-		services = result.stdout.strip().split('\n')
+		services = self._get_compose_services()
 
 		for service in services:
 			# Check if image exists
-			result = subprocess.run(
-				['docker', 'compose', '-f', self.test_compose_file, 'images', '-q', service],
-				capture_output=True,
-				text=True,
-				check=False,
-			)
+			result = subprocess.run(self._compose_cmd('images', '-q', service), capture_output=True, text=True, check=False)
 
 			if not result.stdout.strip():
 				services_to_rebuild.append(service)
@@ -402,15 +460,15 @@ class DevCommands:
 	def start(self, force_rebuild: bool = False):
 		"""Start the test environment and rebuild containers if needed"""
 		if force_rebuild:
-			services_to_rebuild = ['--build']
+			self._run_command(self._compose_lifecycle_cmd('up', flags=['-d', '--build']))
+			return
 		else:
 			services_to_rebuild = self._check_rebuild_needed()
 			if services_to_rebuild:
 				print(f'Rebuilding services: {", ".join(services_to_rebuild)}')
-				services_to_rebuild = ['--build'] + services_to_rebuild
+				self._run_command(self._compose_cmd('build', *services_to_rebuild))
 
-		cmd = ['docker', 'compose', '-f', self.test_compose_file, 'up', '-d', '--remove-orphans'] + services_to_rebuild
-		self._run_command(cmd)
+		self._run_command(self._compose_lifecycle_cmd('up', flags=['-d']))
 
 	def up(self, force_rebuild: bool = False):
 		"""Alias for start() to match the documented CLI examples."""
@@ -418,7 +476,7 @@ class DevCommands:
 
 	def stop(self):
 		"""Stop the test environment"""
-		self._run_command(['docker', 'compose', '-f', self.test_compose_file, 'down', '--remove-orphans'])
+		self._run_command(self._compose_lifecycle_cmd('down'))
 
 	def down(self):
 		"""Alias for stop() to match the documented CLI examples."""
@@ -528,19 +586,16 @@ class DevCommands:
 			# Build and start all services using smart rebuild detection
 			print('Starting development environment...')
 			if force_rebuild:
-				services_to_rebuild = ['--build']
 				print('Force rebuild requested - rebuilding all services')
+				self._run_command(self._compose_lifecycle_cmd('up', flags=['-d', '--build']))
 			else:
 				services_to_rebuild = self._check_rebuild_needed()
 				if services_to_rebuild:
 					print(f'Rebuilding services: {", ".join(services_to_rebuild)}')
-					services_to_rebuild = ['--build'] + services_to_rebuild
+					self._run_command(self._compose_cmd('build', *services_to_rebuild))
 				else:
 					print('No rebuilds needed - using existing containers')
-					services_to_rebuild = []
-
-			cmd = ['docker', 'compose', '-f', self.test_compose_file, 'up', '-d'] + services_to_rebuild
-			self._run_command(cmd)
+				self._run_command(self._compose_lifecycle_cmd('up', flags=['-d']))
 
 			print('🚀 Development environment started!')
 			print('📧 Available test users:')

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -34,6 +34,35 @@ class DevCommands:
 			print(f'Error: {str(e)}')
 			raise
 
+	def _is_service_running(self, service: str) -> bool:
+		"""Check whether a compose service is currently running."""
+		result = subprocess.run(
+			['docker', 'compose', '-f', self.test_compose_file, 'ps', '--status', 'running', '--services'],
+			capture_output=True,
+			text=True,
+			check=False,
+		)
+		if result.returncode != 0:
+			return False
+
+		running_services = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+		return service in running_services
+
+	def _ensure_test_service_running(self, service: str):
+		"""Start the test stack if the requested service is not already running."""
+		if self._is_service_running(service):
+			return
+
+		print(f'Service "{service}" is not running. Starting test environment...')
+		try:
+			self.start()
+		except subprocess.CalledProcessError:
+			# Compose can report a startup conflict while still leaving the requested
+			# service running. Re-check before surfacing the failure.
+			if not self._is_service_running(service):
+				raise
+			print(f'Service "{service}" is now running despite compose startup warnings. Continuing...')
+
 	def _check_rebuild_needed(self) -> List[str]:
 		"""Check which services need rebuilding by comparing image and dockerfile timestamps"""
 		services_to_rebuild = []
@@ -380,12 +409,20 @@ class DevCommands:
 				print(f'Rebuilding services: {", ".join(services_to_rebuild)}')
 				services_to_rebuild = ['--build'] + services_to_rebuild
 
-		cmd = ['docker', 'compose', '-f', self.test_compose_file, 'up', '-d'] + services_to_rebuild
+		cmd = ['docker', 'compose', '-f', self.test_compose_file, 'up', '-d', '--remove-orphans'] + services_to_rebuild
 		self._run_command(cmd)
+
+	def up(self, force_rebuild: bool = False):
+		"""Alias for start() to match the documented CLI examples."""
+		self.start(force_rebuild=force_rebuild)
 
 	def stop(self):
 		"""Stop the test environment"""
-		self._run_command(['docker', 'compose', '-f', self.test_compose_file, 'down'])
+		self._run_command(['docker', 'compose', '-f', self.test_compose_file, 'down', '--remove-orphans'])
+
+	def down(self):
+		"""Alias for stop() to match the documented CLI examples."""
+		self.stop()
 
 	def debug(self, service: str = 'api', test_path: Optional[str] = None, port: Optional[int] = None):
 		"""
@@ -405,6 +442,8 @@ class DevCommands:
 			service = 'processor-test'
 		else:
 			raise ValueError(f'Invalid service: {service}')
+
+		self._ensure_test_service_running(service)
 
 		# Build the pytest command with test_path at the end
 		cmd = [
@@ -432,7 +471,7 @@ class DevCommands:
 		print('Waiting for debugger to attach...')
 		self._run_command(cmd)
 
-	def test(self, service: str = 'api-test', test_path: Optional[str] = None):
+	def test(self, service: str = 'api', test_path: Optional[str] = None):
 		"""
 		Run tests without debugging
 
@@ -446,6 +485,8 @@ class DevCommands:
 			service = 'processor-test'
 		else:
 			raise ValueError(f'Invalid service: {service}')
+
+		self._ensure_test_service_running(service)
 
 		cmd = [
 			'docker',

--- a/processor/tests/test_process_metadata.py
+++ b/processor/tests/test_process_metadata.py
@@ -1,19 +1,79 @@
 import pytest
+from datetime import datetime
 
 from shared.db import use_client
 from shared.settings import settings
-from shared.models import TaskTypeEnum, QueueTask, MetadataType
-from processor.src.process_metadata import process_metadata
-
-pytestmark = pytest.mark.integration
+from shared.models import TaskTypeEnum, QueueTask, MetadataType, StatusEnum, Ortho
+import processor.src.process_metadata as process_metadata_module
 
 
 @pytest.fixture
-def metadata_task(test_dataset_for_processing, test_processor_user):
+def metadata_dataset_for_processing(auth_token, test_processor_user):
+	"""Create only the DB rows metadata processing needs.
+
+	Unlike GeoTIFF/COG/thumbnail stages, metadata processing uses the ortho bbox
+	from the database and never pulls the raster from SSH storage.
+	"""
+	dataset_id = None
+	try:
+		with use_client(auth_token) as client:
+			dataset_data = {
+				'file_name': 'test-process.tif',
+				'license': 'CC BY',
+				'platform': 'drone',
+				'authors': ['Test Author'],
+				'user_id': test_processor_user,
+				'data_access': 'public',
+				'aquisition_year': 2024,
+				'aquisition_month': 1,
+				'aquisition_day': 1,
+			}
+			response = client.table(settings.datasets_table).insert(dataset_data).execute()
+			dataset_id = response.data[0]['id']
+
+			ortho = Ortho(
+				dataset_id=dataset_id,
+				ortho_file_name=f'{dataset_id}_ortho.tif',
+				version=1,
+				ortho_file_size=1,
+				bbox='BOX(13.4050 52.5200,13.4150 52.5300)',
+				ortho_upload_runtime=0.1,
+				ortho_info={'Driver': 'GTiff', 'Size': [1024, 1024]},
+				created_at=datetime.now(),
+			)
+			client.table(settings.orthos_table).insert(ortho.model_dump()).execute()
+
+			status_data = {
+				'dataset_id': dataset_id,
+				'current_status': StatusEnum.idle,
+				'is_upload_done': True,
+				'is_ortho_done': True,
+				'is_cog_done': False,
+				'is_thumbnail_done': False,
+				'is_deadwood_done': False,
+				'is_forest_cover_done': False,
+				'is_metadata_done': False,
+				'is_audited': False,
+				'has_error': False,
+			}
+			client.table(settings.statuses_table).insert(status_data).execute()
+
+		yield dataset_id
+	finally:
+		if dataset_id is not None:
+			with use_client(auth_token) as client:
+				client.table(settings.metadata_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.orthos_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+@pytest.fixture
+def metadata_task(metadata_dataset_for_processing, test_processor_user):
 	"""Create a test task for metadata processing"""
 	return QueueTask(
 		id=1,
-		dataset_id=test_dataset_for_processing,
+		dataset_id=metadata_dataset_for_processing,
 		user_id=test_processor_user,
 		task_types=[TaskTypeEnum.metadata],
 		priority=1,
@@ -24,9 +84,15 @@ def metadata_task(test_dataset_for_processing, test_processor_user):
 	)
 
 
-def test_process_metadata_success(metadata_task, auth_token):
+@pytest.fixture
+def suppress_status_updates(monkeypatch):
+	"""Keep metadata test focused on metadata extraction, not status/RLS behavior."""
+	monkeypatch.setattr(process_metadata_module, 'update_status', lambda *args, **kwargs: None)
+
+
+def test_process_metadata_success(metadata_task, auth_token, suppress_status_updates):
 	"""Test successful metadata processing"""
-	process_metadata(metadata_task, settings.processing_path)
+	process_metadata_module.process_metadata(metadata_task, settings.processing_path)
 
 	with use_client(auth_token) as client:
 		response = (

--- a/processor/tests/test_process_metadata.py
+++ b/processor/tests/test_process_metadata.py
@@ -1,5 +1,6 @@
 import pytest
 from datetime import datetime
+from unittest.mock import ANY
 
 from shared.db import use_client
 from shared.settings import settings
@@ -86,8 +87,14 @@ def metadata_task(metadata_dataset_for_processing, test_processor_user):
 
 @pytest.fixture
 def suppress_status_updates(monkeypatch):
-	"""Keep metadata test focused on metadata extraction, not status/RLS behavior."""
-	monkeypatch.setattr(process_metadata_module, 'update_status', lambda *args, **kwargs: None)
+	"""Record status updates without exercising the DB/RLS path."""
+	calls = []
+
+	def record_update_status(*args, **kwargs):
+		calls.append({'args': args, 'kwargs': kwargs})
+
+	monkeypatch.setattr(process_metadata_module, 'update_status', record_update_status)
+	return calls
 
 
 def test_process_metadata_success(metadata_task, auth_token, suppress_status_updates):
@@ -137,5 +144,13 @@ def test_process_metadata_success(metadata_task, auth_token, suppress_status_upd
 		assert 'version' in metadata
 		assert metadata['processing_runtime'] > 0
 
-		# Clean up
-		client.table(settings.metadata_table).delete().eq('dataset_id', metadata_task.dataset_id).execute()
+	assert suppress_status_updates == [
+		{
+			'args': (ANY, metadata_task.dataset_id),
+			'kwargs': {'current_status': StatusEnum.metadata_processing},
+		},
+		{
+			'args': (ANY, metadata_task.dataset_id),
+			'kwargs': {'current_status': StatusEnum.idle, 'is_metadata_done': True},
+		},
+	]

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -45,11 +45,11 @@ class Settings(BaseSettings):
 
 	# Base paths and directories
 	BASE_DIR: str = str(BASE)
-	# Default GADM path in assets, can be overridden by env var
-	GADM_DATA_PATH: str = str(Path('/app/assets/gadm/gadm_410.gpkg'))
+	# Default to repo-local assets in dev/test; container deployments can still override via env.
+	GADM_DATA_PATH: str = str(ASSETS_DIR / 'gadm' / 'gadm_410.gpkg')
 	CONCURRENT_TASKS: int = 2
 
-	BIOME_DATA_PATH: str = str(Path('/app/assets/biom/terres_ecosystems.gpkg'))
+	BIOME_DATA_PATH: str = str(ASSETS_DIR / 'biom' / 'terres_ecosystems.gpkg')
 
 	BIOME_DICT: dict[int, str] = {
 		1: 'Tropical and Subtropical Moist Broadleaf Forests',
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
 		14: 'Mangroves',
 	}
 
-	PHENOLOGY_DATA_PATH: str = str(Path('/app/assets/pheno/modispheno_aggregated_normalized_filled.zarr'))
+	PHENOLOGY_DATA_PATH: str = str(ASSETS_DIR / 'pheno' / 'modispheno_aggregated_normalized_filled.zarr')
 
 	# DTE maps (deadwood/forest cover COGs)
 	DTE_MAPS_PATH: str = '/data/assets/dte_maps'


### PR DESCRIPTION
## What changed
- include `v2_metadata` fields in single-dataset download bundle metadata output
- surface failed single-dataset bundle generation via `.error` markers instead of leaving status stuck in `processing`
- add API coverage for enriched metadata rows and failed bundle status reporting
- make `deadtrees dev test` and `deadtrees dev debug` bring up the local test stack automatically when needed
- add documented `up`/`down` CLI aliases and make compose startup/shutdown use `--remove-orphans`
- make the processor metadata test independent from SSH/storage fixture setup and use repo-local asset defaults

## Why
Single-dataset downloads could omit metadata from the generated bundle, and a background bundling failure could leave the UI polling forever. Separately, the documented local test flow through `deadtrees-cli` failed on a cold start because it tried to `docker compose exec` into services that were not running yet.

## Impact
- single-dataset download bundles now include the expected metadata fields and `metadata_json`
- failed bundle generation is visible to the API instead of appearing to hang indefinitely
- `deadtrees dev test api` and `deadtrees dev test processor ...` work from a cold local test environment
- the processor metadata test no longer depends on SSH/storage setup that it does not actually need

## Validation
- `./venv/bin/deadtrees dev test api`
- `./venv/bin/deadtrees dev test processor processor/tests/test_process_metadata.py`

## Root cause
- the single-dataset bundle path was not fetching/passing `v2_metadata` into bundle generation
- background bundle errors were logged and cleanup happened, but no failed status artifact was left behind for the status endpoint
- the CLI test command assumed the compose services already existed and were running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset downloads now include enriched metadata with GADM source/version, biome details, and phenology information.
  * Improved error handling for failed downloads with clear error messages displayed to users.

* **Chores**
  * Enhanced development tooling for improved service management and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->