### PR TITLE
fix(download): skip reference patch labels in bundle exports

### DIFF
--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -24,6 +24,12 @@ DEADTREES_BASE_URL = 'https://deadtrees.earth/datasets'
 logger = UnifiedLogger(__name__)
 
 
+EXPORTABLE_LABEL_SOURCES = {
+	LabelSourceEnum.model_prediction,
+	LabelSourceEnum.visual_interpretation,
+}
+
+
 # =============================================================================
 # Multi-Dataset Bundle Helpers
 # =============================================================================
@@ -299,8 +305,8 @@ def bundle_multi_dataset(
 		if include_labels:
 			with tempfile.TemporaryDirectory() as temp_dir:
 				for dataset, ortho, metadata, archive_file_path in datasets_info:
-					# Get all labels for this dataset
-					labels = get_all_dataset_labels(dataset.id)
+					# Get only dataset-level labels that this export path can serialize.
+					labels = get_exportable_dataset_labels(dataset.id)
 					
 					if not labels:
 						continue
@@ -499,9 +505,25 @@ def get_all_dataset_labels(dataset_id: int) -> List[Label]:
 		return [Label(**label_data) for label_data in all_labels]
 
 
+def filter_exportable_dataset_labels(labels: List[Label]) -> List[Label]:
+	"""Keep only dataset-level label sources supported by download bundles."""
+	filtered_labels = [label for label in labels if label.label_source in EXPORTABLE_LABEL_SOURCES]
+
+	skipped_count = len(labels) - len(filtered_labels)
+	if skipped_count:
+		logger.info(f'Skipping {skipped_count} non-exportable labels during bundle generation')
+
+	return filtered_labels
+
+
+def get_exportable_dataset_labels(dataset_id: int) -> List[Label]:
+	"""Fetch labels for a dataset and drop unsupported sources like reference patches."""
+	return filter_exportable_dataset_labels(get_all_dataset_labels(dataset_id))
+
+
 def create_labels_geopackages(dataset_id: int) -> Dict[str, Path]:
 	"""Create GeoPackage files for all labels of a dataset, grouped by label type"""
-	labels = get_all_dataset_labels(dataset_id)
+	labels = get_exportable_dataset_labels(dataset_id)
 	if not labels:
 		return {}
 
@@ -659,8 +681,8 @@ def bundle_dataset(
 		if include_labels:
 			# Get and add all labels
 			with tempfile.TemporaryDirectory() as temp_dir:
-				# Get all labels for this dataset
-				labels = get_all_dataset_labels(dataset.id)
+				# Get only dataset-level labels that this export path can serialize.
+				labels = get_exportable_dataset_labels(dataset.id)
 
 				if labels:
 					# Process each type of label
@@ -769,9 +791,7 @@ def create_consolidated_geopackage(dataset_id: int) -> Path:
 	if not all_labels:
 		raise ValueError(f'No labels found for dataset {dataset_id}')
 
-	# Filter labels to only include model_prediction and visual_interpretation sources
-	target_sources = [LabelSourceEnum.model_prediction, LabelSourceEnum.visual_interpretation]
-	filtered_labels = [label for label in all_labels if label.label_source in target_sources]
+	filtered_labels = filter_exportable_dataset_labels(all_labels)
 
 	if not filtered_labels:
 		raise ValueError(

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -606,6 +606,52 @@ def test_download_dataset_with_labels(auth_token, test_dataset_with_label):
 			assert gdf_aoi.iloc[0]['notes'] == 'Test AOI from real data'
 
 
+def test_download_dataset_ignores_reference_patch_labels_without_dataset_geometries(
+	auth_token, test_dataset_with_label, test_user
+):
+	"""Dataset ZIP export should skip reference-patch labels instead of failing the bundle."""
+	dataset_id = test_dataset_with_label
+	inserted_label_id = None
+
+	with use_client(auth_token) as db_client:
+		response = (
+			db_client.table(settings.labels_table)
+			.insert(
+				{
+					'dataset_id': dataset_id,
+					'user_id': test_user,
+					'aoi_id': None,
+					'label_source': LabelSourceEnum.reference_patch.value,
+					'label_type': LabelTypeEnum.semantic_segmentation.value,
+					'label_data': LabelDataEnum.deadwood.value,
+					'label_quality': 1,
+				}
+			)
+			.execute()
+		)
+		inserted_label_id = response.data[0]['id']
+
+	try:
+		response = client.get(
+			f'/api/v1/download/datasets/{dataset_id}/dataset.zip',
+			headers={'Authorization': f'Bearer {auth_token}'},
+		)
+		assert response.status_code == 200
+
+		_wait_for_download_completed(dataset_id, auth_token)
+
+		download_file = settings.downloads_path / str(dataset_id) / f'{dataset_id}.zip'
+		assert download_file.exists()
+
+		with zipfile.ZipFile(download_file) as zf:
+			files = zf.namelist()
+			assert any(f.startswith('labels_') and f.endswith('.gpkg') for f in files)
+	finally:
+		if inserted_label_id is not None:
+			with use_client(auth_token) as db_client:
+				db_client.table(settings.labels_table).delete().eq('id', inserted_label_id).execute()
+
+
 @pytest.fixture(scope='function')
 def test_dataset_with_label_no_aoi(auth_token, test_dataset_for_download, test_user):
 	"""Create a test dataset with label but without AOI"""


### PR DESCRIPTION
## Summary
- skip non-dataset label sources like `reference_patch` when building dataset ZIP label bundles
- reuse the same exportable-label filtering across single-dataset, multi-dataset, and helper geopackage paths
- add a regression test covering dataset ZIP export when an empty `reference_patch` label row exists

## Validation
- `deadtrees dev test api api/tests/routers/test_download.py::test_download_dataset_ignores_reference_patch_labels_without_dataset_geometries`
- `deadtrees dev test api api/tests/routers/test_download.py::test_download_dataset_with_labels`

## Notes
- broader download-suite reruns still show unrelated shared-state flakiness in existing tests