### PR TITLE
[codex] Implement analytics v1 instrumentation

### DIFF
--- a/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
+++ b/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "../../hooks/useAuthProvider";
 import { useDatasetEditing } from "../../hooks/useDatasetEditing";
 import { mapColors } from "../../theme/mapColors";
 import { MAP_FLOATING_TOP_CLASS } from "../../theme/mapLayout";
+import { trackAppEvent } from "../../utils/analytics";
 
 interface AuditMapWithControlsProps {
 	dataset: IDataset;
@@ -109,10 +110,14 @@ const AuditMapWithControls = forwardRef<AuditMapWithControlsHandle, AuditMapWith
 		}), []);
 
 		// Handlers for correction review
-		const handleApproveCorrection = async (correctionId: number, _geometryId: number) => {
+		const handleApproveCorrection = async (correctionId: number, geometryId: number) => {
 			try {
+				void geometryId;
 				const result = await approveCorrection(correctionId);
 				if (result) {
+					trackAppEvent("correction_approved", {
+						dataset_id: dataset.id,
+					});
 					message.success("Correction approved");
 					queryClient.invalidateQueries({ queryKey: ["pendingCorrections"] });
 					queryClient.invalidateQueries({ queryKey: ["correctionStats", dataset?.id] });
@@ -128,10 +133,14 @@ const AuditMapWithControls = forwardRef<AuditMapWithControlsHandle, AuditMapWith
 			}
 		};
 
-		const handleRevertCorrection = async (correctionId: number, _geometryId: number) => {
+		const handleRevertCorrection = async (correctionId: number, geometryId: number) => {
 			try {
+				void geometryId;
 				const result = await revertCorrection(correctionId);
 				if (result) {
+					trackAppEvent("correction_reverted", {
+						dataset_id: dataset.id,
+					});
 					message.success("Correction reverted");
 					queryClient.invalidateQueries({ queryKey: ["pendingCorrections"] });
 					queryClient.invalidateQueries({ queryKey: ["correctionStats", dataset?.id] });

--- a/frontend/src/components/DatasetAudit/DatasetAuditDetail.tsx
+++ b/frontend/src/components/DatasetAudit/DatasetAuditDetail.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Form, message, Button, Drawer } from "antd";
 import { IDataset } from "../../types/dataset";
 import { DatasetDetailsMapProvider } from "../../hooks/useDatasetDetailsMapProvider";
@@ -27,6 +27,7 @@ import AuditMapWithControls, { AuditMapWithControlsHandle } from "./AuditMapWith
 import { MAP_AUDIT_SIDEBAR_WIDTH_CLASS, MAP_FLOATING_TOP_CLASS } from "../../theme/mapLayout";
 import { resolveDownloadUrl } from "../../utils/downloadUrl";
 import { useIsMobile } from "../../hooks/useIsMobile";
+import { useAnalytics } from "../../hooks/useAnalytics";
 
 interface DatasetAuditDetailProps {
 	dataset: IDataset;
@@ -51,6 +52,7 @@ interface DownloadApiResponse {
 export default function DatasetAuditDetail({ dataset }: DatasetAuditDetailProps) {
 	const { session } = useAuth();
 	const isMobile = useIsMobile();
+	const { track } = useAnalytics("audit");
 	// Map ref for map controls (zoom, flash, refresh)
 	const mapRef = useRef<AuditMapWithControlsHandle>(null);
 
@@ -145,6 +147,10 @@ export default function DatasetAuditDetail({ dataset }: DatasetAuditDetailProps)
 
 		const downloadStarted = startDownload(`${ds.id}-ortho`);
 		if (!downloadStarted) return;
+		track("dataset_download_started", {
+			dataset_id: ds.id,
+			download_type: "orthophoto",
+		});
 
 		const baseUrl = `${Settings.API_URL}/download/datasets/${ds.id}/dataset.zip`;
 
@@ -203,11 +209,20 @@ export default function DatasetAuditDetail({ dataset }: DatasetAuditDetailProps)
 								}
 
 								downloadMsg();
+								track("dataset_download_completed", {
+									dataset_id: ds.id,
+									download_type: "orthophoto",
+								});
 								window.location.href = downloadUrl;
 								message.success("Download started!");
 								finishDownload();
 							} else if (statusData.status === "failed") {
 								downloadMsg();
+								track("dataset_download_failed", {
+									dataset_id: ds.id,
+									download_type: "orthophoto",
+									failure_reason: statusData.message || "preparation_failed",
+								});
 								message.error(`Download failed: ${statusData.message || "Unknown error"}`);
 								finishDownload();
 							} else {
@@ -216,6 +231,11 @@ export default function DatasetAuditDetail({ dataset }: DatasetAuditDetailProps)
 						})
 						.catch(() => {
 							downloadMsg();
+							track("dataset_download_failed", {
+								dataset_id: ds.id,
+								download_type: "orthophoto",
+								failure_reason: "status_check_failed",
+							});
 							message.error("Failed to check download status");
 							finishDownload();
 						});
@@ -225,10 +245,22 @@ export default function DatasetAuditDetail({ dataset }: DatasetAuditDetailProps)
 			})
 			.catch((error: Error) => {
 				downloadMsg();
+				track("dataset_download_failed", {
+					dataset_id: ds.id,
+					download_type: "orthophoto",
+					failure_reason: error?.message || "start_failed",
+				});
 				message.error(error?.message || "Failed to initiate download");
 				finishDownload();
 			});
 	};
+
+	useEffect(() => {
+		track("correction_review_started", {
+			dataset_id: dataset.id,
+			review_scope: "dataset",
+		});
+	}, [dataset.id, track]);
 
 	// Show loading state
 	if (isLoading) {

--- a/frontend/src/components/DatasetAudit/useAuditDetailState.ts
+++ b/frontend/src/components/DatasetAudit/useAuditDetailState.ts
@@ -21,6 +21,7 @@ import { useDatasetFlags, useUpdateFlagStatus } from "../../hooks/useDatasetFlag
 import { usePhenologyData } from "../../hooks/usePhenologyData";
 import { useSeasonPrompt } from "../../hooks/useSeasonPrompt";
 import { supabase } from "../../hooks/useSupabase";
+import { trackAppEvent } from "../../utils/analytics";
 import { AOIToolbarState } from "../DatasetDetailsMap/DatasetDetailsMap";
 
 export interface UseAuditDetailStateProps {
@@ -281,6 +282,10 @@ export function useAuditDetailState({ dataset }: UseAuditDetailStateProps) {
 
 			const isCompletion = !auditData;
 			await saveAudit(auditPayload);
+			trackAppEvent("audit_completed", {
+				dataset_id: dataset.id,
+				final_assessment: values.final_assessment || "unknown",
+			});
 			if (!isCompletion) {
 				message.success("Audit data updated successfully");
 			}

--- a/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
+++ b/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
@@ -22,6 +22,7 @@ interface BaseMapProps {
 	onMapReady?: (map: import("ol").Map) => void;
 	onOrthoLayerReady?: (layer: import("ol/layer/WebGLTile.js").default) => void;
 	onVectorLayersReady?: (deadwood: VectorTileLayer | null, forestCover: VectorTileLayer | null) => void;
+	onFirstMapInteraction?: () => void;
 
 	// Layer visibility
 	showDeadwood?: boolean;
@@ -59,6 +60,7 @@ export default function BaseMap({
 	onMapReady,
 	onOrthoLayerReady,
 	onVectorLayersReady,
+	onFirstMapInteraction,
 	showDeadwood = true,
 	showForestCover = true,
 	showDroneImagery = true,
@@ -109,6 +111,7 @@ export default function BaseMap({
 			onMapReady?.(map);
 		},
 		onOrthoLayerReady,
+		onFirstInteraction: onFirstMapInteraction,
 		isReady: !isLoadingLabels && !isAOILoading && !!data?.file_name,
 		disableRotation: isMobile,
 	});

--- a/frontend/src/components/DatasetDetailsMap/DatasetDetailsMap.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetDetailsMap.tsx
@@ -34,6 +34,7 @@ interface DatasetDetailsMapProps {
   onMapReady?: (map: OLMap) => void;
   onOrthoLayerReady?: (layer: TileLayerWebGL) => void;
   onVectorLayersReady?: (deadwood: VectorTileLayer | null, forestCover: VectorTileLayer | null) => void;
+  onFirstMapInteraction?: () => void;
   hideDeadwoodLayer?: boolean;
   hideForestCoverLayer?: boolean;
   hideDroneImagery?: boolean;
@@ -73,6 +74,7 @@ const DatasetDetailsMapInner = forwardRef<DatasetDetailsMapHandle, DatasetDetail
   onMapReady,
   onOrthoLayerReady,
   onVectorLayersReady,
+  onFirstMapInteraction,
   hideDeadwoodLayer = false,
   hideForestCoverLayer = false,
   hideDroneImagery = false,
@@ -152,6 +154,7 @@ const DatasetDetailsMapInner = forwardRef<DatasetDetailsMapHandle, DatasetDetail
         onMapReady={onMapReady}
         onOrthoLayerReady={onOrthoLayerReady}
         onVectorLayersReady={onVectorLayersReady}
+        onFirstMapInteraction={onFirstMapInteraction}
         showDeadwood={effectiveDeadwoodVisible}
         showForestCover={effectiveForestCoverVisible}
         showDroneImagery={effectiveDroneImageryVisible}

--- a/frontend/src/components/DatasetDetailsMap/DownloadSection.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DownloadSection.tsx
@@ -8,6 +8,7 @@ import { resolveDownloadUrl } from "../../utils/downloadUrl";
 import { useEffect } from "react";
 import DesktopOnlyFeatureNotice from "../DesktopOnlyFeatureNotice";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
+import { useAnalytics } from "../../hooks/useAnalytics";
 
 interface DownloadSectionProps {
   dataset: IDataset;
@@ -40,6 +41,7 @@ export default function DownloadSection({
 }: DownloadSectionProps) {
   const { session } = useAuth();
   const { isMobile } = useDesktopOnlyFeature();
+  const { track } = useAnalytics("dataset_detail");
   const isViewOnlyDataset = dataset.data_access === "viewonly";
 
   useEffect(() => {
@@ -107,6 +109,12 @@ export default function DownloadSection({
     const downloadStarted = startDownload(dataset.id.toString());
     if (!downloadStarted) return;
 
+    const downloadType = labelsOnly || isViewOnlyDataset ? "labels" : "dataset";
+    track("dataset_download_started", {
+      dataset_id: dataset.id,
+      download_type: downloadType,
+    });
+
     const baseUrl = labelsOnly
       ? `${Settings.API_URL}/download/datasets/${dataset.id}/labels.gpkg`
       : `${Settings.API_URL}/download/datasets/${dataset.id}/dataset.zip`;
@@ -146,6 +154,10 @@ export default function DownloadSection({
 
                 downloadMsg();
                 finishDownload();
+                track("dataset_download_completed", {
+                  dataset_id: dataset.id,
+                  download_type: downloadType,
+                });
                 window.location.href = downloadUrl;
                 message.success({
                   content: `${labelsOnly ? "Predictions" : "Dataset"} download started!`,
@@ -154,6 +166,11 @@ export default function DownloadSection({
               } else if (statusData.status === "failed") {
                 downloadMsg();
                 finishDownload();
+                track("dataset_download_failed", {
+                  dataset_id: dataset.id,
+                  download_type: downloadType,
+                  failure_reason: statusData.message || "preparation_failed",
+                });
                 message.error({
                   content: statusData.message || "Download preparation failed. Please try again.",
                   duration: 5,
@@ -165,6 +182,11 @@ export default function DownloadSection({
             .catch((error) => {
               downloadMsg();
               finishDownload();
+              track("dataset_download_failed", {
+                dataset_id: dataset.id,
+                download_type: downloadType,
+                failure_reason: error.message,
+              });
               message.error({ content: `Error checking download status: ${error.message}`, duration: 5 });
             });
         };
@@ -174,6 +196,11 @@ export default function DownloadSection({
       .catch((error) => {
         downloadMsg();
         finishDownload();
+        track("dataset_download_failed", {
+          dataset_id: dataset.id,
+          download_type: downloadType,
+          failure_reason: error.message,
+        });
         message.error({ content: `Error initiating download: ${error.message}`, duration: 5 });
       });
   };

--- a/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
+++ b/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
@@ -28,6 +28,8 @@ export interface UseMapCoreOptions {
 	onMapReady?: (map: Map) => void;
 	/** Callback when ortho layer is ready */
 	onOrthoLayerReady?: (layer: TileLayerWebGL) => void;
+	/** Callback for the first meaningful interaction after initial map positioning */
+	onFirstInteraction?: () => void;
 	/** Minimum zoom level */
 	minZoom?: number;
 	/** Maximum zoom level */
@@ -85,6 +87,7 @@ export function useMapCore({
 	onViewportChange,
 	onMapReady,
 	onOrthoLayerReady,
+	onFirstInteraction,
 	minZoom = 2,
 	maxZoom = 23,
 	isReady = true,
@@ -99,12 +102,16 @@ export function useMapCore({
 	const onViewportChangeRef = useRef(onViewportChange);
 	const onMapReadyRef = useRef(onMapReady);
 	const onOrthoLayerReadyRef = useRef(onOrthoLayerReady);
+	const onFirstInteractionRef = useRef(onFirstInteraction);
+	const hasSeenInitialMoveEndRef = useRef(false);
+	const hasTrackedInteractionRef = useRef(false);
 	
 	// Keep refs up to date
 	useEffect(() => {
 		onViewportChangeRef.current = onViewportChange;
 		onMapReadyRef.current = onMapReady;
 		onOrthoLayerReadyRef.current = onOrthoLayerReady;
+		onFirstInteractionRef.current = onFirstInteraction;
 	});
 
 	// Layer management
@@ -199,6 +206,14 @@ export function useMapCore({
 					zoom: view.getZoom() || 2,
 					extent: view.calculateExtent(newMap.getSize() || [0, 0]) as number[],
 				});
+				if (!hasSeenInitialMoveEndRef.current) {
+					hasSeenInitialMoveEndRef.current = true;
+					return;
+				}
+				if (!hasTrackedInteractionRef.current) {
+					hasTrackedInteractionRef.current = true;
+					onFirstInteractionRef.current?.();
+				}
 			});
 
 			// Fit to extent if no saved viewport
@@ -222,8 +237,8 @@ export function useMapCore({
 						const disposableLayer = layer as DisposableLayer;
 						const source = disposableLayer.getSource?.();
 						if (source) {
-							if ("clear" in source) source.clear();
-							if ("dispose" in source) source.dispose();
+							if ("clear" in source && typeof source.clear === "function") source.clear();
+							if ("dispose" in source && typeof source.dispose === "function") source.dispose();
 						}
 						disposableLayer.dispose?.();
 					});
@@ -232,6 +247,8 @@ export function useMapCore({
 				mapRef.current.dispose();
 				mapRef.current = null;
 				orthoLayerRef.current = null;
+				hasSeenInitialMoveEndRef.current = false;
+				hasTrackedInteractionRef.current = false;
 				setIsMapReady(false);
 				setExtent(null);
 			}

--- a/frontend/src/components/DatasetMap/DatasetMap.tsx
+++ b/frontend/src/components/DatasetMap/DatasetMap.tsx
@@ -216,6 +216,7 @@ const DatasetMapOL = ({
   setVisibleFeatures,
   filterZoomTrigger = 0,
   colorMode = "quality",
+  onMapInteracted,
 }: {
   data: IDataset[];
   hoveredItem: number | null;
@@ -223,6 +224,7 @@ const DatasetMapOL = ({
   setVisibleFeatures: (ids: string[]) => void;
   filterZoomTrigger?: number;
   colorMode?: DatasetMapColorMode;
+  onMapInteracted?: () => void;
 }) => {
   const navigate = useNavigate();
   const mapRef = useRef<MapRef | null>(null);
@@ -238,6 +240,8 @@ const DatasetMapOL = ({
   const setVisibleFeaturesRef = useRef(setVisibleFeatures);
   const setNavigationSourceRef = useRef(setNavigationSource);
   const navigateRef = useRef(navigate);
+  const hasSeenInitialMoveEndRef = useRef(false);
+  const hasTrackedInteractionRef = useRef(false);
 
   useEffect(() => {
     setHoveredItemRef.current = setHoveredItem;
@@ -327,6 +331,14 @@ const DatasetMapOL = ({
             };
             setDatasetViewport(newViewport);
             updateVisibleFeatures();
+            if (!hasSeenInitialMoveEndRef.current) {
+              hasSeenInitialMoveEndRef.current = true;
+              return;
+            }
+            if (!hasTrackedInteractionRef.current) {
+              hasTrackedInteractionRef.current = true;
+              onMapInteracted?.();
+            }
           };
           map.on("moveend", moveEndListener);
 

--- a/frontend/src/components/Home/GetInContact.tsx
+++ b/frontend/src/components/Home/GetInContact.tsx
@@ -6,6 +6,7 @@ import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
 import { usePresentations } from "../../hooks/usePresentations";
 import { supabase } from "../../hooks/useSupabase";
 import { Settings } from "../../config";
+import { useAnalytics } from "../../hooks/useAnalytics";
 
 interface Contribution {
 	title: string;
@@ -100,13 +101,15 @@ const UpcomingConferences = () => {
 
 const GetInContact = () => {
 	const navigate = useNavigate();
-	const { runDesktopOnlyAction } = useDesktopOnlyFeature();
+	const { isMobile, runDesktopOnlyAction } = useDesktopOnlyFeature();
 	const [email, setEmail] = useState<string>("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const { track } = useAnalytics("newsletter");
 
 	const addSubscriber = useCallback(async () => {
 		const emailCheck = /\S+@\S+\.\S+/;
 		if (!emailCheck.test(email)) {
+			track("newsletter_signup_submitted", { status: "invalid_email" });
 			notification.error({
 				message: "Invalid email",
 				description: "Please enter a valid email address.",
@@ -124,12 +127,14 @@ const GetInContact = () => {
 
 		if (insertError) {
 			if (insertError.code === "23505") {
+				track("newsletter_signup_submitted", { status: "duplicate" });
 				notification.info({
 					message: "Already subscribed",
 					description: "This email is already subscribed to our newsletter.",
 					placement: "topRight",
 				});
 			} else {
+				track("newsletter_signup_submitted", { status: "error" });
 				notification.error({
 					message: "Error",
 					description: "An error occurred while adding the subscriber.",
@@ -138,6 +143,7 @@ const GetInContact = () => {
 				console.error("Error adding subscriber:", insertError);
 			}
 		} else {
+			track("newsletter_signup_submitted", { status: "success" });
 			notification.success({
 				message: "Thank you!",
 				description: "Thank you for subscribing! You will receive updates on new features and developments.",
@@ -146,7 +152,7 @@ const GetInContact = () => {
 			setEmail("");
 		}
 		setIsSubmitting(false);
-	}, [email]);
+	}, [email, track]);
 
 	return (
 		<section className="w-full bg-[#F8FAF9] border-y border-slate-200/50 py-24 md:py-32">
@@ -174,12 +180,25 @@ const GetInContact = () => {
 								<Button
 									type="primary"
 									size="large"
-									onClick={() => runDesktopOnlyAction("upload", () => navigate("/profile"))}
+									onClick={() => {
+										track("landing_cta_clicked", {
+											cta_name: "community_start_contributing",
+											action_target: "/profile",
+											...(isMobile ? { blocked_reason: "mobile" } : {}),
+										});
+										runDesktopOnlyAction("upload", () => navigate("/profile"));
+									}}
 									className="min-h-11 px-6"
 								>
 								Start contributing
 							</Button>
 							<Button
+								onClick={() =>
+									track("landing_cta_clicked", {
+										cta_name: "community_get_in_touch",
+										action_target: "mailto:info@deadtrees.earth",
+									})
+								}
 								size="large"
 								href="mailto:info@deadtrees.earth?subject=deadtrees.earth collaboration"
 								className="min-h-11 px-6"

--- a/frontend/src/components/Home/Hero.tsx
+++ b/frontend/src/components/Home/Hero.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "../../hooks/useAuthProvider";
 import { useData } from "../../hooks/useDataProvider";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
 import { isDatasetViewable } from "../../utils/datasetVisibility";
+import { useAnalytics } from "../../hooks/useAnalytics";
 import LogoBannerBand from "./LogoBanner";
 
 const logos = [
@@ -89,6 +90,7 @@ const Hero = () => {
 	const { user } = useAuth();
 	const { data, authors } = useData();
 	const { isMobile, runDesktopOnlyAction } = useDesktopOnlyFeature();
+	const { track } = useAnalytics("home");
 
 	const stats = useMemo(() => {
 		if (!data) return null;
@@ -102,6 +104,11 @@ const Hero = () => {
 	}, [data, authors]);
 
 	const handleContribute = useCallback(() => {
+		track("landing_cta_clicked", {
+			cta_name: "hero_contribute_drone_data",
+			action_target: user ? "/profile" : "/sign-in",
+			...(isMobile ? { blocked_reason: "mobile" } : {}),
+		});
 		runDesktopOnlyAction("upload", () => {
 			if (user) {
 				navigate("/profile");
@@ -109,15 +116,23 @@ const Hero = () => {
 				navigate("/sign-in");
 			}
 		});
-	}, [navigate, runDesktopOnlyAction, user]);
+	}, [isMobile, navigate, runDesktopOnlyAction, track, user]);
 
 	const handleExploreMap = useCallback(() => {
+		track("landing_cta_clicked", {
+			cta_name: "hero_explore_map",
+			action_target: "/deadtrees",
+		});
 		navigate("/deadtrees");
-	}, [navigate]);
+	}, [navigate, track]);
 
 	const handleExploreDatasets = useCallback(() => {
+		track("landing_cta_clicked", {
+			cta_name: "hero_explore_datasets",
+			action_target: "/dataset",
+		});
 		navigate("/dataset");
-	}, [navigate]);
+	}, [navigate, track]);
 
 	return (
 		<section className="relative flex w-full flex-col overflow-hidden min-h-screen pt-24 md:pt-28">

--- a/frontend/src/components/Home/HowItWorks.tsx
+++ b/frontend/src/components/Home/HowItWorks.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { Button } from "antd";
 import { CloudUploadOutlined, GlobalOutlined, DatabaseOutlined } from "@ant-design/icons";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
+import { useAnalytics } from "../../hooks/useAnalytics";
 import DataGallery from "./DataGallery";
 
 const UPLOAD_VIDEO_URL = "https://data2.deadtrees.earth/assets/v1/videos/upload.mp4";
@@ -45,7 +46,8 @@ const DeferredMiniSatelliteMap = () => {
 
 const HowItWorks = () => {
   const navigate = useNavigate();
-  const { runDesktopOnlyAction } = useDesktopOnlyFeature();
+  const { isMobile, runDesktopOnlyAction } = useDesktopOnlyFeature();
+  const { track } = useAnalytics("home");
 
   return (
     <section className="w-full bg-[#F8FAF9] border-t border-slate-200/50 py-24 md:py-32">
@@ -80,7 +82,14 @@ const HowItWorks = () => {
               size="large"
               icon={<CloudUploadOutlined />}
               className="min-h-11 px-6"
-              onClick={() => runDesktopOnlyAction("upload", () => navigate("/profile"))}
+              onClick={() => {
+                track("landing_cta_clicked", {
+                  cta_name: "pipeline_upload_via_profile",
+                  action_target: "/profile",
+                  ...(isMobile ? { blocked_reason: "mobile" } : {}),
+                });
+                runDesktopOnlyAction("upload", () => navigate("/profile"));
+              }}
             >
                 Upload via Profile
             </Button>
@@ -118,7 +127,17 @@ const HowItWorks = () => {
           </div>
           <div className="flex justify-center">
             <Link to="/dataset">
-              <Button size="large" icon={<DatabaseOutlined />} className="min-h-11 px-6">
+              <Button
+                size="large"
+                icon={<DatabaseOutlined />}
+                className="min-h-11 px-6"
+                onClick={() =>
+                  track("landing_cta_clicked", {
+                    cta_name: "pipeline_browse_dataset_archive",
+                    action_target: "/dataset",
+                  })
+                }
+              >
                 Browse Dataset Archive
               </Button>
             </Link>
@@ -143,7 +162,18 @@ const HowItWorks = () => {
               The high-resolution ground truth trains our satellite models to generate large-scale spatiotemporal maps of forest mortality at the European scale. We provide embedded visualization and download of these extensive tree mortality products.
             </p>
             <Link to="/deadtrees">
-              <Button type="primary" size="large" icon={<GlobalOutlined />} className="min-h-11 px-6">
+              <Button
+                type="primary"
+                size="large"
+                icon={<GlobalOutlined />}
+                className="min-h-11 px-6"
+                onClick={() =>
+                  track("landing_cta_clicked", {
+                    cta_name: "pipeline_explore_satellite_maps",
+                    action_target: "/deadtrees",
+                  })
+                }
+              >
                 Explore Satellite Maps
               </Button>
             </Link>

--- a/frontend/src/components/PublicationModal.tsx
+++ b/frontend/src/components/PublicationModal.tsx
@@ -3,6 +3,7 @@ import { Modal, Form, Input, Button, Typography, Table, Spin, message, Tag, Row,
 import { PlusOutlined, DeleteOutlined, SearchOutlined, ClockCircleOutlined } from "@ant-design/icons";
 import { supabase } from "../hooks/useSupabase";
 import { useAuth } from "../hooks/useAuthProvider";
+import { useAnalytics } from "../hooks/useAnalytics";
 import { processOrcidInput } from "../utils/orcidUtils";
 import { palette } from "../theme/palette";
 
@@ -41,6 +42,7 @@ const PublicationModal: React.FC<PublicationModalProps> = ({ visible, onCancel, 
   const [authors, setAuthors] = useState<Author[]>([]);
   const [orcidLoading, setOrcidLoading] = useState(false);
   const [currentOrcid, setCurrentOrcid] = useState("");
+  const { track } = useAnalytics("profile");
 
   // Generate title based on datasets
   useEffect(() => {
@@ -251,6 +253,10 @@ const PublicationModal: React.FC<PublicationModalProps> = ({ visible, onCancel, 
   };
 
   const handleSubmit = async () => {
+    track("publish_submitted", {
+      dataset_count: datasets.length,
+      publish_target: "freidata",
+    });
     try {
       const values = await form.validateFields();
 
@@ -328,6 +334,10 @@ const PublicationModal: React.FC<PublicationModalProps> = ({ visible, onCancel, 
       }
 
       message.success("Publication submitted successfully");
+      track("publish_completed", {
+        dataset_count: datasets.length,
+        publish_target: "freidata",
+      });
 
       // Call the onSuccess callback if provided
       if (onSuccess) {
@@ -337,6 +347,11 @@ const PublicationModal: React.FC<PublicationModalProps> = ({ visible, onCancel, 
       }
     } catch (error) {
       console.error("Error submitting publication:", error);
+      track("publish_failed", {
+        dataset_count: datasets.length,
+        publish_target: "freidata",
+        failure_reason: error instanceof Error ? error.message : "submit_failed",
+      });
       message.error("Failed to submit publication");
     } finally {
       setLoading(false);

--- a/frontend/src/components/Upload/UploadButton.tsx
+++ b/frontend/src/components/Upload/UploadButton.tsx
@@ -3,10 +3,12 @@ import { Button } from "antd";
 import UploadModal from "./UploadModal";
 import { UploadOutlined } from "@ant-design/icons";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
+import { useAnalytics } from "../../hooks/useAnalytics";
 
 const UploadButton = () => {
   const [modals, setModals] = useState<{ key: string; isVisible: boolean }[]>([]);
-  const { runDesktopOnlyAction } = useDesktopOnlyFeature();
+  const { isMobile, runDesktopOnlyAction } = useDesktopOnlyFeature();
+  const { track } = useAnalytics("profile");
 
   const showModal = () => {
     const newKey = `upload_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
@@ -23,7 +25,14 @@ const UploadButton = () => {
         size="large"
         icon={<UploadOutlined />}
         type="primary"
-        onClick={() => runDesktopOnlyAction("upload", showModal)}
+        onClick={() => {
+          track("landing_cta_clicked", {
+            cta_name: "profile_upload_data",
+            action_target: "upload_modal",
+            ...(isMobile ? { blocked_reason: "mobile" } : {}),
+          });
+          runDesktopOnlyAction("upload", showModal);
+        }}
       >
         Upload Data
       </Button>

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -38,6 +38,7 @@ import { isTokenExpiringSoon } from "../../utils/isTokenExpiringSoon";
 import { supabase } from "../../hooks/useSupabase";
 import { RcFile } from "antd/es/upload";
 import type { Dayjs } from "dayjs";
+import { useAnalytics } from "../../hooks/useAnalytics";
 // New interfaces
 interface IFormValues {
   license: ILicense;
@@ -60,6 +61,20 @@ interface UploadModalProps {
 // Add these types near the top of the file
 interface UploadResponse {
   id: string;
+}
+
+interface UploadMetadata {
+  license: string;
+  platform: string;
+  authors: string[];
+  upload_type: string;
+  project_id?: string;
+  aquisition_year?: number;
+  aquisition_month?: number;
+  aquisition_day?: number;
+  additional_information?: string;
+  data_access?: string;
+  citation_doi?: string;
 }
 
 function createLabelObjectFormData(
@@ -114,6 +129,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
   } = useUploadNotification(uploadKey, fileName);
 
   const [uploadValidationError, setUploadValidationError] = useState<string | null>(null);
+  const { track } = useAnalytics("profile");
 
   const { canUpload: canUploadPrivate } = useCanUploadPrivate();
 
@@ -138,7 +154,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
     }
   };
 
-  const uploadOrthophoto = async (file: RcFile, metadata: Record<string, unknown>): Promise<UploadResponse> => {
+  const uploadOrthophoto = async (file: RcFile, metadata: UploadMetadata): Promise<UploadResponse> => {
     return new Promise((resolve, reject) => {
       // Create a new AbortController for this upload
       abortControllerRef.current = new AbortController();
@@ -197,6 +213,11 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
 
       // Detect file type and validate file size
       const uploadType = detectUploadType(uploadFile.name);
+      const hasLabelsFile = labelsFileList.length > 0;
+      track("upload_started", {
+        upload_type: uploadType,
+        has_labels_file: hasLabelsFile,
+      });
       validateFileSize(uploadFile.originFileObj, uploadType);
       if (uploadType === UploadType.GEOTIFF) {
         await validateGeoTiffAiEligibility(uploadFile.originFileObj);
@@ -204,14 +225,14 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
 
       // console.log("values.author", values.author);
       // Create metadata object
-      const metadata = {
+      const metadata: UploadMetadata = {
         license: values.license,
-        platform: values.platform,
+        platform: String(values.platform),
         authors: values.author,
         upload_type: uploadType,
         project_id: undefined,
         aquisition_year: values.aquisition_date?.year(),
-        aquisition_month: values.aquisition_date?.month() + 1,
+        aquisition_month: values.aquisition_date ? values.aquisition_date.month() + 1 : undefined,
         aquisition_day: values.aquisition_date?.date(),
         additional_information: values.additional_information,
         data_access: values.is_private ? "private" : "public",
@@ -230,7 +251,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
 
       // Upload labels if present
       if (labelsFileList.length > 0) {
-        const labelFile = labelsFileList[0].originFileObj;
+          const labelFile = labelsFileList[0]?.originFileObj;
         if (labelFile) {
           const labelFormData = createLabelObjectFormData(
             uploadResponse.id.toString(),
@@ -249,6 +270,11 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
           : ["cog", "thumbnail", "metadata", "geotiff", "deadwood", "treecover"]; // GeoTIFF workflow (no ODM needed)
 
       await processDataset(Number(uploadResponse.id), validAccessToken, processingSteps);
+      track("upload_completed", {
+        dataset_id: Number(uploadResponse.id),
+        upload_type: uploadType,
+        has_labels_file: hasLabelsFile,
+      });
 
       showSuccessNotification();
     } catch (error) {
@@ -257,6 +283,11 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
         // console.log("Upload was cancelled by the user");
       } else {
         console.error("Upload error:", error);
+        track("upload_failed", {
+          upload_type:
+            fileList[0]?.name ? detectUploadType(fileList[0].name) : undefined,
+          failure_reason: error instanceof Error ? error.message : "unknown_error",
+        });
         showErrorNotification();
       }
     } finally {

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+import { useLocation } from "react-router-dom";
+
+import { useAuth } from "./useAuthProvider";
+import { useCanAudit } from "./useUserPrivileges";
+import { useIsMobile } from "./useIsMobile";
+import {
+  AnalyticsEventName,
+  AnalyticsEventPropertiesMap,
+  SourceSurface,
+  deriveUserSegment,
+  trackAppEvent,
+} from "../utils/analytics";
+
+export function useAnalytics(sourceSurface: SourceSurface) {
+  const location = useLocation();
+  const { user } = useAuth();
+  const { canAudit } = useCanAudit();
+  const isMobile = useIsMobile();
+
+  const userSegment = deriveUserSegment(!!user, canAudit);
+
+  const track = useCallback(
+    <T extends AnalyticsEventName>(eventName: T, properties: AnalyticsEventPropertiesMap[T]) => {
+      trackAppEvent(eventName, properties, {
+        page: location.pathname,
+        sourceSurface,
+        isMobile,
+        isLoggedIn: !!user,
+        userSegment,
+      });
+    },
+    [isMobile, location.pathname, sourceSurface, user, userSegment],
+  );
+
+  return { track, userSegment };
+}

--- a/frontend/src/hooks/useAuthProvider.tsx
+++ b/frontend/src/hooks/useAuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { Session, User } from "@supabase/supabase-js";
-import { identifyUser } from "../utils/analytics";
+import { identifyUser, trackAuthCompletion } from "../utils/analytics";
 
 import { supabase } from "./useSupabase";
 
@@ -26,6 +26,21 @@ const AuthProvider = (props: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
 
+  const getIsCoreTeam = useCallback(async (userId: string): Promise<boolean> => {
+    const { data, error } = await supabase
+      .from("privileged_users")
+      .select("can_audit")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Failed to load privileged user state for analytics", error);
+      return false;
+    }
+
+    return data?.can_audit === true;
+  }, []);
+
   const signOut = useCallback(async () => {
     // Clear local auth state immediately so route guards and auth pages
     // cannot briefly see a stale signed-in session during sign-out.
@@ -37,12 +52,27 @@ const AuthProvider = (props: AuthProviderProps) => {
   }, []);
 
   useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: listener } = supabase.auth.onAuthStateChange(async (event, session) => {
       setSession(session);
       setUser(session?.user || null);
 
       // Identify user in PostHog when auth state changes
-      identifyUser(session?.user || null);
+      if (!session?.user) {
+        identifyUser(null);
+        return;
+      }
+
+      const isCoreTeam = await getIsCoreTeam(session.user.id);
+      identifyUser(session.user, { isCoreTeam });
+
+      if (event === "SIGNED_IN") {
+        const currentPath = window.location.pathname;
+        if (currentPath.startsWith("/sign-up")) {
+          trackAuthCompletion("sign_up_completed", { isCoreTeam, authPath: currentPath });
+        } else if (currentPath.startsWith("/sign-in") || currentPath.startsWith("/reset-password")) {
+          trackAuthCompletion("sign_in_completed", { isCoreTeam, authPath: currentPath });
+        }
+      }
     });
 
     const setData = async () => {
@@ -58,7 +88,12 @@ const AuthProvider = (props: AuthProviderProps) => {
       setUser(session?.user || null);
 
       // Identify user in PostHog when component mounts
-      identifyUser(session?.user || null);
+      if (session?.user) {
+        const isCoreTeam = await getIsCoreTeam(session.user.id);
+        identifyUser(session.user, { isCoreTeam });
+      } else {
+        identifyUser(null);
+      }
     };
 
     setData();
@@ -66,7 +101,7 @@ const AuthProvider = (props: AuthProviderProps) => {
     return () => {
       listener.subscription.unsubscribe();
     };
-  }, []);
+  }, [getIsCoreTeam]);
 
   const value = {
     session,

--- a/frontend/src/hooks/useDatasetEditing.ts
+++ b/frontend/src/hooks/useDatasetEditing.ts
@@ -18,6 +18,7 @@ import {
   type LayerType,
 } from "./useSaveCorrections";
 import { useDatasetLabelTypes } from "./useDatasetLabelTypes";
+import { trackAppEvent } from "../utils/analytics";
 
 interface UseDatasetEditingOptions {
   datasetId: number | undefined;
@@ -124,6 +125,12 @@ export function useDatasetEditing({ datasetId, user }: UseDatasetEditingOptions)
       }
       setEditingLayerType(layerType);
       setIsEditing(true);
+      if (datasetId) {
+        trackAppEvent("edit_started", {
+          dataset_id: datasetId,
+          layer_type: layerType,
+        });
+      }
       editor.startEditing();
       const overlaySource = editor.getOverlayLayer()?.getSource();
       emitDebugEvent("start-editing:after-editor-start", {
@@ -134,18 +141,24 @@ export function useDatasetEditing({ datasetId, user }: UseDatasetEditingOptions)
         overlayFeatureCount: overlaySource?.getFeatures()?.length ?? null,
       });
     },
-    [user, navigate, editor, emitDebugEvent, hasDeadwood, hasForestCover]
+    [datasetId, user, navigate, editor, emitDebugEvent, hasDeadwood, hasForestCover]
   );
 
   // Cancel editing
   const handleCancelEditing = useCallback(() => {
+    if (datasetId && editingLayerType) {
+      trackAppEvent("edit_cancelled", {
+        dataset_id: datasetId,
+        layer_type: editingLayerType,
+      });
+    }
     editor.stopEditing();
     editor.getOverlayLayer()?.getSource()?.clear();
     setIsEditing(false);
     setEditingLayerType(null);
     setInitialFeatures([]);
     message.info("Editing cancelled");
-  }, [editor]);
+  }, [datasetId, editingLayerType, editor]);
 
   // Save edits
   const handleSaveEdits = useCallback(async () => {
@@ -198,6 +211,10 @@ export function useDatasetEditing({ datasetId, user }: UseDatasetEditingOptions)
       }
 
       message.success("Corrections saved successfully!");
+      trackAppEvent("edit_saved", {
+        dataset_id: datasetId,
+        layer_type: editingLayerType,
+      });
       editor.stopEditing();
       editor.getOverlayLayer()?.getSource()?.clear();
       setIsEditing(false);
@@ -217,7 +234,7 @@ export function useDatasetEditing({ datasetId, user }: UseDatasetEditingOptions)
     } finally {
       setIsSaving(false);
     }
-  }, [predictionLabel?.id, editingLayerType, user?.id, datasetId, editor, initialFeatures, geoJson, saveCorrections]);
+  }, [predictionLabel?.id, editingLayerType, user?.id, datasetId, editor, initialFeatures, geoJson, saveCorrections, emitDebugEvent]);
 
   // Load geometries into editor when editing starts
   useEffect(() => {

--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -23,6 +23,7 @@ import { useDatasetFilter } from "../hooks/useDatasetFilterProvider";
 import { isDatasetViewable } from "../utils/datasetVisibility";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useDesktopOnlyFeature } from "../hooks/useDesktopOnlyFeature";
+import { useAnalytics } from "../hooks/useAnalytics";
 
 type FilterTag = "platform" | "license" | "authors_image" | "admin_level_1" | "admin_level_3" | "biome";
 
@@ -60,6 +61,7 @@ export default function Dataset() {
   const colorMode: DatasetMapColorMode = "timeline";
   const isMobile = useIsMobile();
   const { runDesktopOnlyAction } = useDesktopOnlyFeature();
+  const { track } = useAnalytics("dataset_archive");
   // Incremented on explicit filter actions to trigger map zoom
   const [filterZoomTrigger, setFilterZoomTrigger] = useState(0);
 
@@ -71,6 +73,17 @@ export default function Dataset() {
 
     return () => clearTimeout(timer);
   }, [searchInput]);
+
+  useEffect(() => {
+    track("dataset_archive_viewed", {});
+  }, [track]);
+
+  useEffect(() => {
+    if (!searchValue.trim()) return;
+    track("dataset_search_used", {
+      search_length: searchValue.trim().length,
+    });
+  }, [searchValue, track]);
 
   const handleSearch = (value: string) => {
     setSearchInput(value);
@@ -84,6 +97,10 @@ export default function Dataset() {
     setFilter(filterValue);
     setFilterTag(filterType);
     setFilterZoomTrigger((n) => n + 1);
+    track("dataset_filter_applied", {
+      filter_type: filterType,
+      filter_value: filterValue,
+    });
   };
 
   const handleFilterButtonClick = () => {
@@ -93,6 +110,14 @@ export default function Dataset() {
   const handleApplyFilters = (newFilters: AdvancedFilters) => {
     setAdvancedFilters(newFilters);
     setFilterZoomTrigger((n) => n + 1);
+    const appliedFilters = Object.entries(newFilters).filter(([, value]) => {
+      if (Array.isArray(value)) return value.length > 0;
+      return value !== null && value !== undefined && value !== "";
+    });
+    track("dataset_filter_applied", {
+      filter_type: appliedFilters.map(([key]) => key).join(",") || "advanced",
+      filter_value: String(appliedFilters.length),
+    });
   };
 
   const processedData = useMemo(() => {
@@ -325,6 +350,11 @@ export default function Dataset() {
             setVisibleFeatures={setVisibleFeatures}
             filterZoomTrigger={filterZoomTrigger}
             colorMode={colorMode}
+            onMapInteracted={() =>
+              track("dataset_map_interacted", {
+                interaction_type: "move",
+              })
+            }
           />
         )}
       </div>

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import type { Dayjs } from "dayjs";
 import {
 	Table,
 	Button,
@@ -43,6 +44,7 @@ import { getBiomeEmoji, getBiomeTagColor, truncateBiomeLabel } from "../utils/bi
 import { useDatasetLogs, useProcessingOverview, ProcessingOverviewRow, ProcessingStatus } from "../hooks/useProcessingOverview";
 import { getAcquisitionPeriod } from "../utils/phenologyUtils";
 import { useIsMobile } from "../hooks/useIsMobile";
+import { useAnalytics } from "../hooks/useAnalytics";
 
 const { Title, Text } = Typography;
 
@@ -53,6 +55,7 @@ type AuditTab = "pending" | "completed" | "reference" | "edits-flags" | "process
 type CompletedStatusFilter = "all" | "ready" | "fixable" | "excluded" | "needs-review" | "reviewed";
 
 type ProcessingStateFilterKey = "ortho" | "cog" | "thumbnail" | "deadwood" | "forestCover" | "metadata";
+type AcquisitionMonthRange = [Dayjs | null, Dayjs | null] | null;
 
 const PROCESSING_STATE_OPTIONS: Array<{ label: string; value: ProcessingStateFilterKey }> = [
 	{ label: "Ortho", value: "ortho" },
@@ -210,6 +213,7 @@ function DatasetAuditInner() {
 	const navigate = useNavigate();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const { setFilteredDatasetIds } = useAuditNavigation();
+	const { track } = useAnalytics("audit");
 
 	// ALL HOOKS MUST BE CALLED FIRST
 	const { user } = useAuth();
@@ -239,7 +243,7 @@ function DatasetAuditInner() {
 	const [activeTab, setActiveTab] = useState<AuditTab>(initialTab);
 	const [statusFilter, setStatusFilter] = useState<CompletedStatusFilter>(initialStatus);
 	const [idFilter, setIdFilter] = useState<string>(searchParams.get("id") || "");
-	const [acquisitionMonthRange, setAcquisitionMonthRange] = useState<unknown>(null);
+	const [acquisitionMonthRange, setAcquisitionMonthRange] = useState<AcquisitionMonthRange>(null);
 	const [biomeFilter, setBiomeFilter] = useState<string>(initialBiome);
 	const [countryFilter, setCountryFilter] = useState<string>(initialCountry);
 	const [auditorFilter, setAuditorFilter] = useState<string>(initialAuditor);
@@ -423,8 +427,8 @@ function DatasetAuditInner() {
 			}
 		}
 
-		const acquisitionStart = (acquisitionMonthRange as any)?.[0] ?? null;
-		const acquisitionEnd = (acquisitionMonthRange as any)?.[1] ?? null;
+		const acquisitionStart = acquisitionMonthRange?.[0] ?? null;
+		const acquisitionEnd = acquisitionMonthRange?.[1] ?? null;
 		const acquisitionStartIndex =
 			acquisitionStart && typeof acquisitionStart.year === "function" && typeof acquisitionStart.month === "function"
 				? acquisitionStart.year() * 12 + acquisitionStart.month()
@@ -601,19 +605,6 @@ function DatasetAuditInner() {
 		}
 	}, [user, isAuthLoading, isAuditPrivilegeLoading, canAudit, navigate]);
 
-	// Loading state
-	if (isAuthLoading || isAuditPrivilegeLoading) {
-		return <div className="p-6">Loading...</div>;
-	}
-
-	// Detail view
-	if (id) {
-		const dataset = datasets?.find((d) => d.id.toString() === id);
-		if (isDatasetLoading) return <div>Loading dataset...</div>;
-		if (!dataset) return <div>Dataset not found</div>;
-		return <DatasetAuditDetail dataset={dataset} />;
-	}
-
 	const handleStartAudit = async (datasetId: number) => {
 		try {
 			const { data, error } = await supabase
@@ -633,12 +624,34 @@ function DatasetAuditInner() {
 				return;
 			}
 
+			track("audit_started", { dataset_id: datasetId });
 			navigate(`/dataset-audit/${datasetId}`);
 		} catch (error) {
 			console.error("Error checking audit status:", error);
+			track("audit_started", { dataset_id: datasetId });
 			navigate(`/dataset-audit/${datasetId}`);
 		}
 	};
+
+	useEffect(() => {
+		track("audit_queue_viewed", { audit_tab: activeTab });
+		if (activeTab === "edits-flags") {
+			track("correction_review_started", { review_scope: "queue" });
+		}
+	}, [activeTab, track]);
+
+	// Loading state
+	if (isAuthLoading || isAuditPrivilegeLoading) {
+		return <div className="p-6">Loading...</div>;
+	}
+
+	// Detail view
+	if (id) {
+		const dataset = datasets?.find((d) => d.id.toString() === id);
+		if (isDatasetLoading) return <div>Loading dataset...</div>;
+		if (!dataset) return <div>Dataset not found</div>;
+		return <DatasetAuditDetail dataset={dataset} />;
+	}
 
 	const processingColumns: ColumnsType<ProcessingOverviewRow> = [
 		{
@@ -1104,7 +1117,7 @@ function DatasetAuditInner() {
 
 	const hasActiveFilters =
 		idFilter ||
-		Boolean((acquisitionMonthRange as any)?.[0] || (acquisitionMonthRange as any)?.[1]) ||
+		Boolean(acquisitionMonthRange?.[0] || acquisitionMonthRange?.[1]) ||
 		biomeFilter ||
 		countryFilter ||
 		auditorFilter ||
@@ -1490,8 +1503,8 @@ function DatasetAuditInner() {
 												</Text>
 												<DatePicker.RangePicker
 													picker="month"
-													value={acquisitionMonthRange as any}
-													onChange={(value) => setAcquisitionMonthRange(value as any)}
+													value={acquisitionMonthRange}
+													onChange={(value) => setAcquisitionMonthRange(value)}
 													allowClear
 													placeholder={["From", "To"]}
 													style={{ width: isMobile ? "100%" : 200 }}

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -15,6 +15,7 @@ import { useCreateFlag } from "../hooks/useDatasetFlags";
 import { useDatasetEditing } from "../hooks/useDatasetEditing";
 import { useCanAudit } from "../hooks/useUserPrivileges";
 import { useIsMobile } from "../hooks/useIsMobile";
+import { useAnalytics } from "../hooks/useAnalytics";
 
 import DatasetLayerControlPanel from "../components/DatasetDetailsMap/DatasetLayerControlPanel";
 import EditingSidebar from "../components/DatasetDetailsMap/EditingSidebar";
@@ -32,6 +33,7 @@ export default function DatasetDetails() {
   const hasValidDatasetId = typeof datasetId === "number" && Number.isFinite(datasetId);
   const { user } = useAuth();
   const { canAudit } = useCanAudit();
+  const { track } = useAnalytics("dataset_detail");
   const { data: dataset, isLoading: isDatasetLoading } = usePublicDatasetById(hasValidDatasetId ? datasetId : undefined);
   const {
     setViewport,
@@ -100,10 +102,19 @@ export default function DatasetDetails() {
     async (values: { is_ortho_mosaic_issue: boolean; is_prediction_issue: boolean; description: string }) => {
       if (!dataset) return;
       await createFlag({ dataset_id: dataset.id, ...values });
+      track("flag_submitted", {
+        dataset_id: dataset.id,
+        flag_type:
+          values.is_ortho_mosaic_issue && values.is_prediction_issue
+            ? "mixed"
+            : values.is_ortho_mosaic_issue
+              ? "orthomosaic"
+              : "prediction",
+      });
       message.success("Issue reported successfully");
       setReportModalOpen(false);
     },
-    [dataset, createFlag]
+    [dataset, createFlag, track]
   );
 
   useEffect(() => {
@@ -111,6 +122,21 @@ export default function DatasetDetails() {
       setLabelsOnly(true);
     }
   }, [dataset?.data_access, labelsOnly, setLabelsOnly]);
+
+  useEffect(() => {
+    if (!dataset) return;
+    track("dataset_opened", { dataset_id: dataset.id });
+    if (dataset.is_deadwood_done || dataset.is_forest_cover_done) {
+      track("processing_result_viewed", {
+        dataset_id: dataset.id,
+        processing_type: dataset.is_deadwood_done && dataset.is_forest_cover_done
+          ? "deadwood_and_forest_cover"
+          : dataset.is_deadwood_done
+            ? "deadwood"
+            : "forest_cover",
+      });
+    }
+  }, [dataset, track]);
 
   // Loading state
   if (!hasValidDatasetId || isDatasetLoading) {
@@ -308,6 +334,12 @@ export default function DatasetDetails() {
             data={dataset}
             onMapReady={editing.handleMapReady}
             onOrthoLayerReady={editing.handleOrthoLayerReady}
+            onFirstMapInteraction={() =>
+              track("dataset_map_interacted", {
+                dataset_id: dataset.id,
+                interaction_type: "move",
+              })
+            }
             hideDeadwoodLayer={isEditing}
             hideForestCoverLayer={isEditing}
             refreshKey={refreshKey}

--- a/frontend/src/pages/DatasetReferencePatchEditor.tsx
+++ b/frontend/src/pages/DatasetReferencePatchEditor.tsx
@@ -13,6 +13,7 @@ import {
   useReopenPatchGeneration,
 } from "../hooks/useReferencePatches";
 import { useAuth } from "../hooks/useAuthProvider";
+import { useAnalytics } from "../hooks/useAnalytics";
 import ReferencePatchEditorView from "../components/ReferencePatches/ReferencePatchEditorView";
 import { palette } from "../theme/palette";
 import { MAP_FLOATING_TOP_CLASS } from "../theme/mapLayout";
@@ -21,6 +22,7 @@ export default function DatasetReferencePatchEditor() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { track } = useAnalytics("editor");
   const datasetId = id ? parseInt(id, 10) : undefined;
   const { data: dataset } = useDatasetById(datasetId);
 
@@ -33,6 +35,13 @@ export default function DatasetReferencePatchEditor() {
   const { mutateAsync: reopenPatchGeneration } = useReopenPatchGeneration();
 
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    if (!datasetId) return;
+    track("reference_patch_editor_opened", {
+      dataset_id: datasetId,
+    });
+  }, [datasetId, track]);
 
   // Count 20cm base patches
   const basePatchesCount = useMemo(() => allPatches.filter((p) => p.resolution_cm === 20).length, [allPatches]);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import PlatformFeatures from "../components/Home/PlatformFeatures";
 import GetInContact from "../components/Home/GetInContact";
 
 import { useData } from "../hooks/useDataProvider";
+import { useAnalytics } from "../hooks/useAnalytics";
 
 const FAQ_ITEM_STYLE = {
 	border: "1px solid #e2e8f0",
@@ -20,6 +21,7 @@ const FAQ_ITEM_STYLE = {
 
 const FAQ = () => {
   const { authors } = useData();
+  const { track } = useAnalytics("faq");
   const contributorNames = useMemo(
     () => (authors || []).map((author) => author.label).sort((a, b) => a.localeCompare(b)),
     [authors],
@@ -175,6 +177,12 @@ const FAQ = () => {
           style={{ backgroundColor: "transparent" }}
           className="w-full"
           items={FAQItems}
+          onChange={(activeKeys) => {
+            const openedKey = Array.isArray(activeKeys) ? activeKeys.at(-1) : activeKeys;
+            if (typeof openedKey === "string") {
+              track("faq_opened", { faq_item_key: openedKey });
+            }
+          }}
         />
       </div>
     </section>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -12,6 +12,7 @@ import PublicationModal from "../components/PublicationModal";
 import PublicationsTable from "../components/PublicationsTable";
 import { useIsMobile } from "../hooks/useIsMobile";
 import DesktopOnlyFeatureNotice from "../components/DesktopOnlyFeatureNotice";
+import { useAnalytics } from "../hooks/useAnalytics";
 
 interface ProfileAvatarProps {
   email: string;
@@ -53,6 +54,7 @@ export default function ProfilePage() {
   const { session, user } = useAuth();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+  const { track } = useAnalytics("profile");
 
   // const { data: userData } = useUserDatasets();
   const { data: myFlags = [] } = useMyFlags();
@@ -73,6 +75,9 @@ export default function ProfilePage() {
   };
 
   const showPublicationModal = () => {
+    track("publish_started", {
+      dataset_count: selectedDatasets.length,
+    });
     setIsPublicationModalVisible(true);
   };
 

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -2,11 +2,20 @@ import { SignUp as SignUpAuthUI } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { supabase } from "../../hooks/useSupabase";
 import { Link, useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
 import { palette } from "../../theme/palette";
+import { useAnalytics } from "../../hooks/useAnalytics";
 
 const SignUp = () => {
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo") || "/profile";
+  const { track } = useAnalytics("auth");
+
+  useEffect(() => {
+    track("sign_up_started", {
+      auth_path: window.location.pathname + window.location.search,
+    });
+  }, [track]);
 
   return (
     <div className="m-auto flex h-full max-w-7xl items-center justify-center">

--- a/frontend/src/utils/analytics.test.ts
+++ b/frontend/src/utils/analytics.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAnalyticsPayload,
+  deriveUserSegment,
+  sanitizeEventProperties,
+} from "./analytics";
+
+describe("deriveUserSegment", () => {
+  it("classifies anonymous users as visitors", () => {
+    expect(deriveUserSegment(false, false)).toBe("visitor");
+  });
+
+  it("classifies signed-in contributors", () => {
+    expect(deriveUserSegment(true, false)).toBe("contributor");
+  });
+
+  it("classifies core team members", () => {
+    expect(deriveUserSegment(true, true)).toBe("core_team");
+  });
+});
+
+describe("sanitizeEventProperties", () => {
+  it("keeps only the allowlisted analytics keys", () => {
+    expect(
+      sanitizeEventProperties({
+        dataset_id: 42,
+        page: "/dataset/42",
+        download_type: "dataset",
+        ignored_key: "drop-me",
+      }),
+    ).toEqual({
+      dataset_id: 42,
+      page: "/dataset/42",
+      download_type: "dataset",
+    });
+  });
+
+  it("drops empty values from the essential payload", () => {
+    expect(
+      sanitizeEventProperties({
+        dataset_id: 42,
+        failure_reason: "",
+        status: undefined,
+      }),
+    ).toEqual({
+      dataset_id: 42,
+    });
+  });
+});
+
+describe("createAnalyticsPayload", () => {
+  it("fills shared context fields without overriding explicit properties", () => {
+    const payload = createAnalyticsPayload(
+      "dataset_download_started",
+      {
+        dataset_id: 42,
+        download_type: "dataset",
+      },
+      {
+        page: "/dataset/42",
+        sourceSurface: "dataset_detail",
+        isMobile: false,
+        isLoggedIn: true,
+        userSegment: "contributor",
+      },
+    );
+
+    expect(payload).toEqual({
+      dataset_id: 42,
+      download_type: "dataset",
+      page: "/dataset/42",
+      source_surface: "dataset_detail",
+      is_mobile: false,
+      is_logged_in: true,
+      user_segment: "contributor",
+    });
+  });
+
+  it("preserves explicit event properties over the shared context", () => {
+    const payload = createAnalyticsPayload(
+      "dataset_opened",
+      {
+        dataset_id: 7,
+        page: "/custom",
+        source_surface: "profile",
+      },
+      {
+        page: "/dataset/7",
+        sourceSurface: "dataset_detail",
+        isLoggedIn: true,
+        userSegment: "contributor",
+      },
+    );
+
+    expect(payload.page).toBe("/custom");
+    expect(payload.source_surface).toBe("profile");
+    expect(payload.is_logged_in).toBe(true);
+    expect(payload.user_segment).toBe("contributor");
+  });
+});

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -340,9 +340,9 @@ export const initializePostHog = (consent: string | null = null): void => {
     });
   }
 
-  if (consent === "accepted" && !posthog.has_opted_in_capturing) {
+  if (consent === "accepted" && !posthog.has_opted_in_capturing()) {
     posthog.opt_in_capturing();
-  } else if (consent === "rejected" && !posthog.has_opted_out_capturing) {
+  } else if (consent === "rejected" && !posthog.has_opted_out_capturing()) {
     posthog.opt_out_capturing();
   }
 };

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,105 +1,345 @@
 import { User } from "@supabase/supabase-js";
+import posthog from "posthog-js";
 
-// Access the global posthog instance
-declare const posthog: any;
 const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_PROJECT_KEY as string | undefined;
 
-// The current cookie consent version
-// Increment this whenever you want users to re-consent
 export const COOKIE_CONSENT_VERSION = "1.1";
-
-// Cookie storage keys
 export const COOKIE_CONSENT_KEY = "cookieConsent";
 export const COOKIE_CONSENT_VERSION_KEY = "cookieConsentVersion";
 
-// Check if PostHog is available
-const isPostHogAvailable = (): boolean => {
-  return typeof posthog !== "undefined";
+export type UserSegment = "visitor" | "contributor" | "core_team";
+
+export type SourceSurface =
+  | "home"
+  | "auth"
+  | "dataset_archive"
+  | "dataset_detail"
+  | "profile"
+  | "audit"
+  | "editor"
+  | "newsletter"
+  | "deadtrees_map"
+  | "about"
+  | "faq";
+
+type AnalyticsBaseProperties = {
+  page?: string;
+  source_surface?: SourceSurface;
+  is_mobile?: boolean;
+  is_logged_in?: boolean;
+  user_segment?: UserSegment;
+  dataset_id?: number;
+  status?: string;
 };
 
-// Check if cookies are accepted and version is current
+export interface AnalyticsEventPropertiesMap {
+  landing_cta_clicked: AnalyticsBaseProperties & {
+    cta_name: string;
+    action_target?: string;
+    blocked_reason?: "mobile";
+  };
+  faq_opened: AnalyticsBaseProperties & {
+    faq_item_key: string;
+  };
+  newsletter_signup_submitted: AnalyticsBaseProperties & {
+    status: "success" | "duplicate" | "error" | "invalid_email";
+  };
+  dataset_archive_viewed: AnalyticsBaseProperties;
+  dataset_search_used: AnalyticsBaseProperties & {
+    search_length: number;
+  };
+  dataset_filter_applied: AnalyticsBaseProperties & {
+    filter_type: string;
+    filter_value?: string;
+  };
+  dataset_map_interacted: AnalyticsBaseProperties & {
+    interaction_type: "move";
+  };
+  dataset_opened: AnalyticsBaseProperties & {
+    dataset_id: number;
+  };
+  sign_up_started: AnalyticsBaseProperties & {
+    auth_path: string;
+  };
+  sign_up_completed: AnalyticsBaseProperties & {
+    auth_path: string;
+  };
+  sign_in_completed: AnalyticsBaseProperties & {
+    auth_path: string;
+  };
+  upload_started: AnalyticsBaseProperties & {
+    upload_type: string;
+    has_labels_file: boolean;
+  };
+  upload_completed: AnalyticsBaseProperties & {
+    dataset_id: number;
+    upload_type: string;
+    has_labels_file: boolean;
+  };
+  upload_failed: AnalyticsBaseProperties & {
+    upload_type?: string;
+    failure_reason: string;
+  };
+  processing_result_viewed: AnalyticsBaseProperties & {
+    dataset_id: number;
+    processing_type: "deadwood" | "forest_cover" | "deadwood_and_forest_cover";
+  };
+  dataset_download_started: AnalyticsBaseProperties & {
+    dataset_id: number;
+    download_type: "dataset" | "labels" | "orthophoto";
+  };
+  dataset_download_completed: AnalyticsBaseProperties & {
+    dataset_id: number;
+    download_type: "dataset" | "labels" | "orthophoto";
+  };
+  dataset_download_failed: AnalyticsBaseProperties & {
+    dataset_id: number;
+    download_type: "dataset" | "labels" | "orthophoto";
+    failure_reason: string;
+  };
+  edit_started: AnalyticsBaseProperties & {
+    dataset_id: number;
+    layer_type: "deadwood" | "forest_cover";
+  };
+  edit_saved: AnalyticsBaseProperties & {
+    dataset_id: number;
+    layer_type: "deadwood" | "forest_cover";
+  };
+  edit_cancelled: AnalyticsBaseProperties & {
+    dataset_id: number;
+    layer_type: "deadwood" | "forest_cover";
+  };
+  flag_submitted: AnalyticsBaseProperties & {
+    dataset_id: number;
+    flag_type: "orthomosaic" | "prediction" | "mixed";
+  };
+  publish_started: AnalyticsBaseProperties & {
+    dataset_count: number;
+  };
+  publish_submitted: AnalyticsBaseProperties & {
+    dataset_count: number;
+    publish_target: "freidata";
+  };
+  publish_completed: AnalyticsBaseProperties & {
+    dataset_count: number;
+    publish_target: "freidata";
+  };
+  publish_failed: AnalyticsBaseProperties & {
+    dataset_count: number;
+    publish_target: "freidata";
+    failure_reason: string;
+  };
+  audit_queue_viewed: AnalyticsBaseProperties & {
+    audit_tab?: string;
+  };
+  audit_started: AnalyticsBaseProperties & {
+    dataset_id: number;
+  };
+  audit_completed: AnalyticsBaseProperties & {
+    dataset_id: number;
+    final_assessment: string;
+  };
+  correction_review_started: AnalyticsBaseProperties & {
+    dataset_id?: number;
+    review_scope: "queue" | "dataset";
+  };
+  correction_approved: AnalyticsBaseProperties & {
+    dataset_id: number;
+  };
+  correction_reverted: AnalyticsBaseProperties & {
+    dataset_id: number;
+  };
+  reference_patch_editor_opened: AnalyticsBaseProperties & {
+    dataset_id: number;
+  };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventPropertiesMap;
+
+type EssentialAnalyticsProperty =
+  | "page"
+  | "source_surface"
+  | "is_mobile"
+  | "is_logged_in"
+  | "user_segment"
+  | "dataset_id"
+  | "status"
+  | "cta_name"
+  | "action_target"
+  | "blocked_reason"
+  | "faq_item_key"
+  | "auth_path"
+  | "upload_type"
+  | "has_labels_file"
+  | "processing_type"
+  | "download_type"
+  | "failure_reason"
+  | "layer_type"
+  | "flag_type"
+  | "dataset_count"
+  | "publish_target"
+  | "audit_tab"
+  | "final_assessment"
+  | "review_scope"
+  | "filter_type"
+  | "filter_value"
+  | "interaction_type"
+  | "search_length";
+
+const ESSENTIAL_PROPERTY_KEYS: EssentialAnalyticsProperty[] = [
+  "page",
+  "source_surface",
+  "is_mobile",
+  "is_logged_in",
+  "user_segment",
+  "dataset_id",
+  "status",
+  "cta_name",
+  "action_target",
+  "blocked_reason",
+  "faq_item_key",
+  "auth_path",
+  "upload_type",
+  "has_labels_file",
+  "processing_type",
+  "download_type",
+  "failure_reason",
+  "layer_type",
+  "flag_type",
+  "dataset_count",
+  "publish_target",
+  "audit_tab",
+  "final_assessment",
+  "review_scope",
+  "filter_type",
+  "filter_value",
+  "interaction_type",
+  "search_length",
+];
+
+const ESSENTIAL_EVENTS = new Set<AnalyticsEventName>([
+  "sign_up_completed",
+  "sign_in_completed",
+  "upload_started",
+  "upload_completed",
+  "upload_failed",
+  "processing_result_viewed",
+  "dataset_download_started",
+  "dataset_download_completed",
+  "dataset_download_failed",
+  "edit_started",
+  "edit_saved",
+  "edit_cancelled",
+  "flag_submitted",
+  "publish_started",
+  "publish_submitted",
+  "publish_completed",
+  "publish_failed",
+  "audit_queue_viewed",
+  "audit_started",
+  "audit_completed",
+  "correction_review_started",
+  "correction_approved",
+  "correction_reverted",
+  "reference_patch_editor_opened",
+]);
+
+const isPostHogAvailable = (): boolean => typeof posthog !== "undefined";
+
+const getStorage = (): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const getCurrentPath = (): string => {
+  if (typeof window === "undefined") return "/";
+  return `${window.location.pathname}${window.location.search}`;
+};
+
+const getCurrentPage = (): string => {
+  if (typeof window === "undefined") return "/";
+  return window.location.pathname;
+};
+
+export const deriveUserSegment = (isLoggedIn: boolean, isCoreTeam: boolean): UserSegment => {
+  if (!isLoggedIn) return "visitor";
+  return isCoreTeam ? "core_team" : "contributor";
+};
+
 export const hasAcceptedCookies = (): boolean => {
+  const storage = getStorage();
+  if (!storage) return false;
+
   return (
-    localStorage.getItem(COOKIE_CONSENT_KEY) === "accepted" &&
-    localStorage.getItem(COOKIE_CONSENT_VERSION_KEY) === COOKIE_CONSENT_VERSION
+    storage.getItem(COOKIE_CONSENT_KEY) === "accepted" &&
+    storage.getItem(COOKIE_CONSENT_VERSION_KEY) === COOKIE_CONSENT_VERSION
   );
 };
 
-// Check if consent is needed (missing or outdated)
 export const isConsentNeeded = (): boolean => {
-  const storedVersion = localStorage.getItem(COOKIE_CONSENT_VERSION_KEY);
-  return !localStorage.getItem(COOKIE_CONSENT_KEY) || storedVersion !== COOKIE_CONSENT_VERSION;
+  const storage = getStorage();
+  if (!storage) return true;
+
+  const storedVersion = storage.getItem(COOKIE_CONSENT_VERSION_KEY);
+  return !storage.getItem(COOKIE_CONSENT_KEY) || storedVersion !== COOKIE_CONSENT_VERSION;
 };
 
-// Check if analytics capture is allowed - either user explicitly accepted or we're in essential mode
 export const canCaptureEvents = (): boolean => {
   if (!isPostHogAvailable()) return false;
-
-  // If user has explicitly opted in
-  if (posthog.has_opted_in_capturing) return true;
-
-  // If user has explicitly opted out
-  if (posthog.has_opted_out_capturing) return false;
-
-  // Default to false if we're not sure
+  if (posthog.has_opted_in_capturing()) return true;
+  if (posthog.has_opted_out_capturing()) return false;
   return false;
 };
 
-// Reset user consent (force them to choose again)
 export const resetConsent = (): void => {
-  localStorage.removeItem(COOKIE_CONSENT_KEY);
-  localStorage.removeItem(COOKIE_CONSENT_VERSION_KEY);
+  const storage = getStorage();
+  storage?.removeItem(COOKIE_CONSENT_KEY);
+  storage?.removeItem(COOKIE_CONSENT_VERSION_KEY);
 
   if (isPostHogAvailable()) {
     posthog.opt_out_capturing();
   }
 };
 
-// Save user consent with current version
 export const saveConsent = (consent: "accepted" | "rejected"): void => {
-  localStorage.setItem(COOKIE_CONSENT_KEY, consent);
-  localStorage.setItem(COOKIE_CONSENT_VERSION_KEY, COOKIE_CONSENT_VERSION);
+  const storage = getStorage();
+  storage?.setItem(COOKIE_CONSENT_KEY, consent);
+  storage?.setItem(COOKIE_CONSENT_VERSION_KEY, COOKIE_CONSENT_VERSION);
 };
 
-// Initialize PostHog with appropriate settings
 export const initializePostHog = (consent: string | null = null): void => {
-  if (!isPostHogAvailable()) return;
-  if (!POSTHOG_PROJECT_KEY) return;
+  if (!isPostHogAvailable() || !POSTHOG_PROJECT_KEY) return;
 
-  // If already initialized with correct settings, don't reinitialize
   if (
-    (consent === "accepted" && posthog.has_opted_in_capturing) ||
-    (consent === "rejected" && posthog.has_opted_out_capturing)
+    (consent === "accepted" && posthog.has_opted_in_capturing()) ||
+    (consent === "rejected" && posthog.has_opted_out_capturing())
   ) {
     return;
   }
 
-  // Get consent from localStorage if not provided
   if (consent === null) {
-    consent = localStorage.getItem(COOKIE_CONSENT_KEY);
-
-    // If consent exists but version is outdated, consider it as pending
-    const storedVersion = localStorage.getItem(COOKIE_CONSENT_VERSION_KEY);
+    const storage = getStorage();
+    consent = storage?.getItem(COOKIE_CONSENT_KEY) ?? null;
+    const storedVersion = storage?.getItem(COOKIE_CONSENT_VERSION_KEY);
     if (consent && storedVersion !== COOKIE_CONSENT_VERSION) {
       consent = "pending";
     }
   }
 
-  // Initialize PostHog
-  if (!posthog.has_opted_in_capturing && !posthog.has_opted_out_capturing) {
+  if (!posthog.has_opted_in_capturing() && !posthog.has_opted_out_capturing()) {
     posthog.init(POSTHOG_PROJECT_KEY, {
       api_host: "https://eu.i.posthog.com",
-      // Use cookie persistence only if user explicitly accepted
       persistence: consent === "accepted" ? "cookie" : "memory",
-      // Disable autocapture unless user explicitly accepted
       autocapture: consent === "accepted",
-      // Always capture errors and performance - these are essential
       capture_pageview: true,
       capture_pageleave: consent === "accepted",
     });
   }
 
-  // Update opt-in status based on consent
   if (consent === "accepted" && !posthog.has_opted_in_capturing) {
     posthog.opt_in_capturing();
   } else if (consent === "rejected" && !posthog.has_opted_out_capturing) {
@@ -107,88 +347,131 @@ export const initializePostHog = (consent: string | null = null): void => {
   }
 };
 
-// Track page views - always track but anonymously if no consent
 export const trackPageView = (url: string): void => {
   if (!isPostHogAvailable()) return;
 
   if (canCaptureEvents()) {
     posthog.capture("$pageview", { url });
-  } else {
-    // Track anonymously with minimal data for essential analytics
-    posthog.capture("$pageview", {
-      url_path: new URL(url, window.location.origin).pathname,
-      // Don't include identifiable data
-    });
+    return;
   }
+
+  posthog.capture("$pageview", {
+    url_path: new URL(url, typeof window !== "undefined" ? window.location.origin : "https://deadtrees.earth").pathname,
+  });
 };
 
-// Identify user - only if they have consented OR they're logged in (functional necessity)
-export const identifyUser = (user: User | null): void => {
+export const identifyUser = (user: User | null, options?: { isCoreTeam?: boolean }): void => {
   if (!isPostHogAvailable() || !user) return;
 
-  // For logged-in users, we need some identification for functional purposes
-  // But respect their cookie preferences for how much we track
+  const userSegment = deriveUserSegment(true, options?.isCoreTeam === true);
+
   if (hasAcceptedCookies()) {
-    // Full identification with all properties
     posthog.identify(user.id, {
       email: user.email,
       name: user.user_metadata?.full_name,
       login_method: user.app_metadata?.provider,
       last_login: new Date().toISOString(),
+      user_segment: userSegment,
+      is_core_team: options?.isCoreTeam === true,
     });
-  } else {
-    // Minimal identification - just a stable ID for continuity
-    // This is necessary for functional purposes, but we limit what we store
-    posthog.identify(user.id, {
-      logged_in: true,
-    });
+    return;
   }
+
+  posthog.identify(user.id, {
+    logged_in: true,
+    user_segment: userSegment,
+    is_core_team: options?.isCoreTeam === true,
+  });
 };
 
-// Track events with appropriate level of detail
+export const sanitizeEventProperties = (
+  properties: Record<string, unknown>,
+): Record<string, unknown> => {
+  return ESSENTIAL_PROPERTY_KEYS.reduce<Record<string, unknown>>((safeProps, key) => {
+    const value = properties[key];
+    if (value !== undefined && value !== null && value !== "") {
+      safeProps[key] = value;
+    }
+    return safeProps;
+  }, {});
+};
+
+type EventContext = {
+  sourceSurface?: SourceSurface;
+  isMobile?: boolean;
+  isLoggedIn?: boolean;
+  userSegment?: UserSegment;
+  page?: string;
+};
+
+export const createAnalyticsPayload = <T extends AnalyticsEventName>(
+  _eventName: T,
+  properties: AnalyticsEventPropertiesMap[T],
+  context: EventContext = {},
+): AnalyticsEventPropertiesMap[T] => {
+  return {
+    ...properties,
+    page: properties.page ?? context.page ?? getCurrentPage(),
+    source_surface: properties.source_surface ?? context.sourceSurface,
+    is_mobile: properties.is_mobile ?? context.isMobile,
+    is_logged_in: properties.is_logged_in ?? context.isLoggedIn,
+    user_segment: properties.user_segment ?? context.userSegment,
+  };
+};
+
 export const trackEvent = (
   eventName: string,
-  properties: Record<string, any> = {},
-  isEssential: boolean = false,
+  properties: Record<string, unknown> = {},
+  isEssential = false,
 ): void => {
   if (!isPostHogAvailable()) return;
-
-  // Only track non-essential events if user has consented
   if (!isEssential && !canCaptureEvents()) return;
 
-  // For essential events, track with minimal data
-  if (!hasAcceptedCookies()) {
-    // Filter out potentially identifying properties
-    const safeProperties = {
-      event_type: properties.event_type,
-      status: properties.status,
-      page: properties.page,
-    };
-    posthog.capture(eventName, safeProperties);
-  } else {
-    // Track with full properties if user consented
-    posthog.capture(eventName, properties);
-  }
+  const payload = isEssential && !hasAcceptedCookies() ? sanitizeEventProperties(properties) : properties;
+  posthog.capture(eventName, payload);
 };
 
-// Track email link clicks
-export const trackEmailLinkClick = (campaign: string, linkType: string): void => {
-  // Consider this essential since it's part of your core analytics need
-  const isEssential = true;
+export const trackAppEvent = <T extends AnalyticsEventName>(
+  eventName: T,
+  properties: AnalyticsEventPropertiesMap[T],
+  context: EventContext = {},
+): void => {
+  const payload = createAnalyticsPayload(eventName, properties, context);
+  trackEvent(eventName, payload, ESSENTIAL_EVENTS.has(eventName));
+};
 
+export const trackAuthCompletion = (
+  authEvent: "sign_in_completed" | "sign_up_completed",
+  options: {
+    isCoreTeam?: boolean;
+    authPath?: string;
+  } = {},
+): void => {
+  trackAppEvent(
+    authEvent,
+    {
+      auth_path: options.authPath ?? getCurrentPath(),
+      source_surface: "auth",
+      user_segment: deriveUserSegment(true, options.isCoreTeam === true),
+      is_logged_in: true,
+    } as AnalyticsEventPropertiesMap[typeof authEvent],
+  );
+};
+
+export const trackEmailLinkClick = (campaign: string, linkType: string): void => {
   trackEvent(
     "email_link_clicked",
     {
       campaign,
       linkType,
-      // Only include these if user has consented
-      ...(hasAcceptedCookies() && {
+      page: getCurrentPage(),
+      ...(hasAcceptedCookies() && typeof window !== "undefined" && {
         referrer: document.referrer,
         utm_source: new URLSearchParams(window.location.search).get("utm_source"),
         utm_medium: new URLSearchParams(window.location.search).get("utm_medium"),
         utm_campaign: new URLSearchParams(window.location.search).get("utm_campaign"),
       }),
     },
-    isEssential,
+    true,
   );
 };


### PR DESCRIPTION
## What changed

- adds a typed analytics contract and `useAnalytics` helper for explicit product events
- instruments the main visitor, auth, upload, download, edit, publish, audit, and correction-review flows
- adds focused analytics tests and consent-aware PostHog capture behavior

## Why

- replace fragile selector-based analytics with named product events
- establish a baseline for AARRR funnels, retention, and cohort-based feature impact analysis
- improve visibility into where contributors and core-team workflows struggle

## Impact

- PostHog can use explicit frontend events as the new source of truth for product reporting
- contributor activation and retention events are now available from the app itself
- core-team audit and correction workflows are now observable end-to-end

## Validation

- `npm test -- analytics.test.ts`
- `npm run build` *(fails due pre-existing TypeScript errors elsewhere in the frontend; branch-local analytics regressions fixed before opening this PR)*
