### PR TITLE
[codex] recover stale processor tasks

### DIFF
--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -78,6 +78,12 @@ def get_completed_stages(status_data: dict) -> list[str]:
 	return completed
 
 
+def are_requested_stages_complete(status_data: dict, task_types: list) -> bool:
+	"""Return True when all requested pipeline stages are already marked complete."""
+	requested = [done_flag for task_type, done_flag, _ in PIPELINE_STAGE_MAP if task_type in task_types]
+	return bool(requested) and all(status_data.get(done_flag, False) for done_flag in requested)
+
+
 
 def get_next_task(token: str) -> QueueTask:
 	"""Get the next task (QueueTask class) in the queue from supabase.
@@ -451,12 +457,29 @@ def background_process():
 				status_resp = client.table(settings.statuses_table) \
 					.select('*').eq('dataset_id', active_task.dataset_id).execute()
 
+			should_mark_error = True
 			if status_resp.data:
 				status = status_resp.data[0]
-				if status['current_status'] != 'idle':
+				completed = get_completed_stages(status)
+				if are_requested_stages_complete(status, active_task.task_types):
+					logger.info(
+						f'Removing stale completed queue task {active_task.id} for dataset {active_task.dataset_id}',
+						LogContext(
+							category=LogCategory.PROCESS,
+							dataset_id=active_task.dataset_id,
+							user_id=active_task.user_id,
+							token=token,
+						),
+					)
+					should_mark_error = False
+					crashed_stage = 'completed'
+					error_msg = ''
+				elif status['current_status'] != 'idle':
 					crashed_stage = detect_crashed_stage(status, active_task.task_types)
-					completed = get_completed_stages(status)
 					error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
+				elif completed:
+					crashed_stage = detect_crashed_stage(status, active_task.task_types)
+					error_msg = f'Processing container crashed after completing {completed} and before starting {crashed_stage}.'
 				else:
 					crashed_stage = 'startup'
 					error_msg = 'Processing container crashed before the first stage status update.'
@@ -464,23 +487,24 @@ def background_process():
 				crashed_stage = 'unknown'
 				error_msg = 'Processing container crashed and no status row was available for recovery.'
 
-			update_status(
-				token,
-				dataset_id=active_task.dataset_id,
-				current_status=StatusEnum.idle,
-				has_error=True,
-				error_message=error_msg,
-			)
-
-			try:
-				create_processing_failure_issue(
-					token=token,
+			if should_mark_error:
+				update_status(
+					token,
 					dataset_id=active_task.dataset_id,
-					stage=crashed_stage,
+					current_status=StatusEnum.idle,
+					has_error=True,
 					error_message=error_msg,
 				)
-			except Exception as linear_error:
-				logger.warning(f'Failed to create Linear issue for stale active task: {linear_error}')
+
+				try:
+					create_processing_failure_issue(
+						token=token,
+						dataset_id=active_task.dataset_id,
+						stage=crashed_stage,
+						error_message=error_msg,
+					)
+				except Exception as linear_error:
+					logger.warning(f'Failed to create Linear issue for stale active task: {linear_error}')
 
 			with use_client(token) as client:
 				client.table(settings.queue_table).delete().eq('id', active_task.id).execute()

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -95,6 +95,38 @@ def get_next_task(token: str) -> QueueTask:
 	return QueueTask(**response.data[0])
 
 
+def get_active_task(token: str) -> QueueTask | None:
+	"""Get a task still marked as actively processing in the raw queue table.
+
+	Active tasks are excluded from `v2_queue_positions`, so crash recovery must
+	inspect `v2_queue` directly before looking for waiting work.
+	"""
+	with use_client(token) as client:
+		response = (
+			client.table(settings.queue_table)
+			.select('id,dataset_id,user_id,priority,is_processing,task_types')
+			.eq('is_processing', True)
+			.order('priority', desc=True)
+			.order('created_at')
+			.limit(1)
+			.execute()
+		)
+	if not response.data or len(response.data) == 0:
+		return None
+
+	task_data = response.data[0]
+	return QueueTask(
+		id=task_data['id'],
+		dataset_id=task_data['dataset_id'],
+		user_id=task_data['user_id'],
+		priority=task_data['priority'],
+		is_processing=task_data['is_processing'],
+		current_position=-1,
+		estimated_time=None,
+		task_types=task_data['task_types'],
+	)
+
+
 def is_dataset_uploaded_or_processed(task: QueueTask, token: str) -> tuple:
 	"""Check if a dataset is ready for processing by verifying its upload status and error status.
 
@@ -158,6 +190,13 @@ def process_task(task: QueueTask, token: str):
 			extra={'task_types': [t.value for t in task.task_types]},
 		),
 	)
+
+	# Keep queue bookkeeping aligned with the live worker state.
+	# `v2_statuses.current_status` remains the crash/source-of-truth signal,
+	# but `v2_queue.is_processing` is still consumed by ops snapshots and queue views.
+	with use_client(token) as client:
+		client.table(settings.queue_table).update({'is_processing': True}).eq('id', task.id).execute()
+
 	# remove processing path if it exists
 	if Path(settings.processing_path).exists():
 		shutil.rmtree(settings.processing_path, ignore_errors=True)
@@ -379,15 +418,16 @@ def background_process():
 
 	On each run this function:
 	1. Logs in as the processor service account.
-	2. Loops through the queue, clearing any crashed tasks it finds:
+	2. Clears any stale `is_processing=true` queue rows left behind by crashes.
+	3. Loops through the waiting queue, clearing any crashed tasks it finds:
 	   - A "crash" is detected when current_status != 'idle' for a queued task,
 	     meaning a previous container run died (OOM, kill) mid-processing.
 	   - Crashed tasks are marked as errored, a Linear issue is created, and
 	     the task is removed from the queue.
-	3. Once a healthy, ready task is found, processes it and exits.
+	4. Once a healthy, ready task is found, processes it and exits.
 
 	docker compose up guarantees only one processor container runs at a time,
-	so no is_processing flag or concurrency guard is needed.
+	so `is_processing` is bookkeeping only, not the concurrency guard.
 	"""
 	# use the processor to log in
 	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
@@ -395,6 +435,57 @@ def background_process():
 		raise Exception(status_code=401, detail='Invalid token after fresh login')
 
 	while True:
+		active_task = get_active_task(token)
+		if active_task is not None:
+			logger.warning(
+				f'Found stale active queue task {active_task.id} for dataset {active_task.dataset_id}; recovering it before new work',
+				LogContext(
+					category=LogCategory.PROCESS,
+					dataset_id=active_task.dataset_id,
+					user_id=active_task.user_id,
+					token=token,
+				),
+			)
+
+			with use_client(token) as client:
+				status_resp = client.table(settings.statuses_table) \
+					.select('*').eq('dataset_id', active_task.dataset_id).execute()
+
+			if status_resp.data:
+				status = status_resp.data[0]
+				if status['current_status'] != 'idle':
+					crashed_stage = detect_crashed_stage(status, active_task.task_types)
+					completed = get_completed_stages(status)
+					error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
+				else:
+					crashed_stage = 'startup'
+					error_msg = 'Processing container crashed before the first stage status update.'
+			else:
+				crashed_stage = 'unknown'
+				error_msg = 'Processing container crashed and no status row was available for recovery.'
+
+			update_status(
+				token,
+				dataset_id=active_task.dataset_id,
+				current_status=StatusEnum.idle,
+				has_error=True,
+				error_message=error_msg,
+			)
+
+			try:
+				create_processing_failure_issue(
+					token=token,
+					dataset_id=active_task.dataset_id,
+					stage=crashed_stage,
+					error_message=error_msg,
+				)
+			except Exception as linear_error:
+				logger.warning(f'Failed to create Linear issue for stale active task: {linear_error}')
+
+			with use_client(token) as client:
+				client.table(settings.queue_table).delete().eq('id', active_task.id).execute()
+			continue
+
 		task = get_next_task(token)
 		if task is None:
 			print('No tasks in the queue.')

--- a/processor/src/utils/startup_cleanup.py
+++ b/processor/src/utils/startup_cleanup.py
@@ -22,8 +22,9 @@ def cleanup_orphaned_resources(token: str):
 	1. Removes old extract containers (Alpine containers stuck with tail -f)
 	2. Removes orphaned Docker volumes (optional)
 
-	Note: Stuck queue items (previously is_processing=True) are now handled by
-	crash detection in background_process() which checks current_status in v2_statuses.
+	Note: Stuck queue items are handled by crash detection in background_process(),
+	which checks current_status in v2_statuses. The queue's is_processing flag is
+	kept only for live bookkeeping and operational visibility.
 
 	Args:
 		token: Authentication token for database operations

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -7,7 +7,7 @@ from shared.settings import settings
 from shared.models import TaskTypeEnum, QueueTask, StatusEnum
 from processor.src.processor import (
 	background_process, process_task, get_next_task,
-	detect_crashed_stage, get_completed_stages, PIPELINE_STAGE_MAP,
+	detect_crashed_stage, get_completed_stages, are_requested_stages_complete, PIPELINE_STAGE_MAP,
 )
 
 
@@ -464,6 +464,17 @@ def test_get_completed_stages_none_completed():
 	assert completed == []
 
 
+def test_are_requested_stages_complete_only_returns_true_when_all_requested_flags_are_done():
+	status_data = {
+		'is_ortho_done': True,
+		'is_metadata_done': True,
+		'is_cog_done': False,
+	}
+	assert are_requested_stages_complete(status_data, [TaskTypeEnum.geotiff, TaskTypeEnum.metadata]) is True
+	assert are_requested_stages_complete(status_data, [TaskTypeEnum.geotiff, TaskTypeEnum.cog]) is False
+	assert are_requested_stages_complete(status_data, []) is False
+
+
 @pytest.fixture
 def crashed_dataset_task(test_processor_user, auth_token):
 	"""Create a task that simulates a previous crash (current_status stuck, some stages done)."""
@@ -630,3 +641,84 @@ def test_background_process_detects_stale_active_task_without_stage_update(
 		assert status['has_error'] is True, 'Status should have has_error=True'
 		assert status['current_status'] == 'idle', 'Status should remain/reset to idle'
 		assert 'before the first stage status update' in status['error_message']
+
+
+@pytest.fixture
+def stale_completed_active_task(test_processor_user, auth_token):
+	"""Create a completed task that still has a stale active queue row."""
+	task_id = None
+	dataset_id = None
+	try:
+		with use_client(auth_token) as client:
+			dataset_data = {
+				'file_name': 'completed_stale_active_test.tif',
+				'user_id': test_processor_user,
+				'license': 'CC BY',
+				'platform': 'drone',
+				'authors': ['Test Author'],
+				'data_access': 'public',
+				'aquisition_year': 2024,
+				'aquisition_month': 1,
+				'aquisition_day': 1,
+			}
+			dataset_response = client.table(settings.datasets_table).insert(dataset_data).execute()
+			dataset_id = dataset_response.data[0]['id']
+
+			status_data = {
+				'dataset_id': dataset_id,
+				'is_upload_done': True,
+				'current_status': 'idle',
+				'is_metadata_done': True,
+				'has_error': False,
+			}
+			client.table(settings.statuses_table).insert(status_data).execute()
+
+			task_data = {
+				'dataset_id': dataset_id,
+				'user_id': test_processor_user,
+				'task_types': [TaskTypeEnum.metadata],
+				'priority': 1,
+				'is_processing': True,
+			}
+			response = client.table(settings.queue_table).insert(task_data).execute()
+			task_id = response.data[0]['id']
+
+			yield {'task_id': task_id, 'dataset_id': dataset_id}
+
+	finally:
+		if auth_token:
+			with use_client(auth_token) as client:
+				if task_id:
+					client.table(settings.queue_table).delete().eq('id', task_id).execute()
+				if dataset_id:
+					client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+					client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+def test_background_process_removes_stale_completed_active_task_without_marking_error(
+	stale_completed_active_task, auth_token, monkeypatch
+):
+	"""Completed tasks should not be reclassified as crashes during stale queue recovery."""
+	issue_calls = []
+	monkeypatch.setattr(processor_module, 'create_processing_failure_issue', lambda **kwargs: issue_calls.append(kwargs))
+
+	dataset_id = stale_completed_active_task['dataset_id']
+
+	background_process()
+
+	with use_client(auth_token) as client:
+		queue_response = (
+			client.table(settings.queue_table).select('*')
+			.eq('id', stale_completed_active_task['task_id']).execute()
+		)
+		assert len(queue_response.data) == 0, 'Completed stale task should be removed from queue'
+
+		status_response = (
+			client.table(settings.statuses_table).select('*')
+			.eq('dataset_id', dataset_id).execute()
+		)
+		assert len(status_response.data) == 1
+		status = status_response.data[0]
+		assert status['has_error'] is False, 'Completed stale task should not be marked as errored'
+		assert status['current_status'] == 'idle', 'Completed status should remain idle'
+		assert issue_calls == [], 'Completed stale tasks should not create failure issues'

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -85,6 +85,7 @@ def test_process_task_success_path_with_refresh(monkeypatch):
 	)
 	stage_calls = []
 	deleted_task_ids = []
+	processing_updates = []
 
 	class _DeleteQuery:
 		def eq(self, field, value):
@@ -95,7 +96,23 @@ def test_process_task_success_path_with_refresh(monkeypatch):
 		def execute(self):
 			return None
 
+	class _UpdateQuery:
+		def __init__(self, payload):
+			self.payload = payload
+
+		def eq(self, field, value):
+			assert field == 'id'
+			assert self.payload == {'is_processing': True}
+			processing_updates.append(value)
+			return self
+
+		def execute(self):
+			return None
+
 	class _TableQuery:
+		def update(self, payload):
+			return _UpdateQuery(payload)
+
 		def delete(self):
 			return _DeleteQuery()
 
@@ -126,6 +143,7 @@ def test_process_task_success_path_with_refresh(monkeypatch):
 	process_task(task, 'initial-token')
 
 	assert stage_calls == [(task.id, str(settings.processing_path))]
+	assert processing_updates == [task.id]
 	assert deleted_task_ids == [task.id]
 
 
@@ -492,6 +510,7 @@ def crashed_dataset_task(test_processor_user, auth_token):
 					TaskTypeEnum.thumbnail, TaskTypeEnum.deadwood, TaskTypeEnum.treecover,
 				],
 				'priority': 1,
+				'is_processing': True,
 			}
 			response = client.table(settings.queue_table).insert(task_data).execute()
 			task_id = response.data[0]['id']
@@ -534,3 +553,80 @@ def test_background_process_detects_crashed_dataset(crashed_dataset_task, auth_t
 		assert status['has_error'] is True, 'Status should have has_error=True'
 		assert status['current_status'] == 'idle', 'Status should be reset to idle'
 		assert 'deadwood_segmentation' in status['error_message'], 'Error should mention crashed stage'
+
+
+@pytest.fixture
+def stale_active_task_without_stage_update(test_processor_user, auth_token):
+	"""Create a task stuck with is_processing=True before any stage status was written."""
+	task_id = None
+	dataset_id = None
+	try:
+		with use_client(auth_token) as client:
+			dataset_data = {
+				'file_name': 'pre_stage_crash_test.tif',
+				'user_id': test_processor_user,
+				'license': 'CC BY',
+				'platform': 'drone',
+				'authors': ['Test Author'],
+				'data_access': 'public',
+				'aquisition_year': 2024,
+				'aquisition_month': 1,
+				'aquisition_day': 1,
+			}
+			dataset_response = client.table(settings.datasets_table).insert(dataset_data).execute()
+			dataset_id = dataset_response.data[0]['id']
+
+			status_data = {
+				'dataset_id': dataset_id,
+				'is_upload_done': True,
+				'current_status': 'idle',
+				'has_error': False,
+			}
+			client.table(settings.statuses_table).insert(status_data).execute()
+
+			task_data = {
+				'dataset_id': dataset_id,
+				'user_id': test_processor_user,
+				'task_types': [TaskTypeEnum.metadata],
+				'priority': 1,
+				'is_processing': True,
+			}
+			response = client.table(settings.queue_table).insert(task_data).execute()
+			task_id = response.data[0]['id']
+
+			yield {'task_id': task_id, 'dataset_id': dataset_id}
+
+	finally:
+		if auth_token:
+			with use_client(auth_token) as client:
+				if task_id:
+					client.table(settings.queue_table).delete().eq('id', task_id).execute()
+				if dataset_id:
+					client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+					client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+def test_background_process_detects_stale_active_task_without_stage_update(
+	stale_active_task_without_stage_update, auth_token
+):
+	"""Test that background_process clears a stale active queue row even if status stayed idle."""
+	dataset_id = stale_active_task_without_stage_update['dataset_id']
+
+	background_process()
+
+	with use_client(auth_token) as client:
+		queue_response = (
+			client.table(settings.queue_table).select('*')
+			.eq('id', stale_active_task_without_stage_update['task_id']).execute()
+		)
+		assert len(queue_response.data) == 0, 'Stale active task should be removed from queue'
+
+		status_response = (
+			client.table(settings.statuses_table).select('*')
+			.eq('dataset_id', dataset_id).execute()
+		)
+		assert len(status_response.data) == 1
+		status = status_response.data[0]
+		assert status['has_error'] is True, 'Status should have has_error=True'
+		assert status['current_status'] == 'idle', 'Status should remain/reset to idle'
+		assert 'before the first stage status update' in status['error_message']


### PR DESCRIPTION
## What changed
- restore live `v2_queue.is_processing` bookkeeping when the processor actually starts a task
- recover stale `is_processing=true` queue rows before reading waiting work from `v2_queue_positions`
- add processor tests covering the queue bookkeeping update and both crash-recovery paths

## Why
The processor had moved to `v2_statuses.current_status` as the real runtime signal, but several queue views and ops checks still depended on `v2_queue.is_processing`. That left active work invisible in queue snapshots and could also hide stale active tasks from `v2_queue_positions` after a crash.

## Impact
- queue snapshots and dashboards can reflect active processing again
- rerun protection based on active queue rows remains meaningful
- crashes after setting `is_processing=true` are cleaned up on the next processor run instead of leaving hidden active rows behind

## Root cause
`is_processing` had effectively become inert in the processor code, while queue consumers still treated it as operational state.

## Validation
- `./venv/bin/deadtrees dev test api`
- `./venv/bin/deadtrees dev test processor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery for tasks interrupted during processing
  * Enhanced task state tracking to prevent duplicate execution
  * Better error detection and messaging for failed tasks

* **Tests**
  * Added test coverage for crash recovery and stale task detection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->