### PR TITLE
[codex] Fix frontend hosting cache headers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,6 +70,10 @@ Workflow files:
 
 These workflows intentionally let Firebase's framework-aware Hosting deploy perform the Vite build. That matches local `firebase deploy --only hosting` behavior and avoids blocking deploys on the repo's current standalone TypeScript check failures from `tsc && vite build`.
 
+Deployment cache policy:
+- HTML / SPA entry responses should revalidate on each request (`Cache-Control: no-cache`) so browsers do not hold on to an old app shell after a deploy.
+- Fingerprinted build assets under `/assets/**` should stay long-lived and immutable (`public, max-age=31536000, immutable`) because their filenames change on every content update.
+
 Required GitHub repository secrets:
 - `FIREBASE_SERVICE_ACCOUNT_DEADWOOD_D4A4B`
 - `VITE_SUPABASE_URL`

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -6,6 +6,26 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ],
     "frameworksBackend": {
       "region": "europe-west1"
     }


### PR DESCRIPTION
## What changed
- set Firebase Hosting to serve HTML and SPA route responses with `Cache-Control: no-cache`
- keep fingerprinted build assets under `/assets/**` long-lived with `public, max-age=31536000, immutable`
- document the intended cache policy in the frontend README

## Why
The live app is currently serving both `https://deadtrees.earth` and hashed JS assets with `Cache-Control: max-age=3600`.
That allows browsers to keep an older SPA shell after a deploy and mix it with newer assets, which matches the production symptom pattern: parts of the app stop loading until users clear site data.

## Root cause
The frontend Hosting config imported on April 14, 2026 did not define explicit cache headers. After the frontend changed again on April 15, 2026, users could receive a stale app shell for up to one hour after deploy.

## Validation
- `npm test` in `frontend/`
- verified live headers before the fix:
  - `/` -> `Cache-Control: max-age=3600`
  - `/assets/index-*.js` -> `Cache-Control: max-age=3600`
- reproduced the live issue pattern in browser testing and confirmed it is consistent with stale frontend state after deploys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment cache policy guidance for HTML and static asset caching strategies.

* **Configuration**
  * Configured hosting headers with no-cache for HTML/SPA responses and immutable long-lived caching for fingerprinted static assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->