### PR TITLE
Fix stale frontend auth session recovery

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,6 +51,18 @@ npm run dev
 
 By default, Vite serves at `http://localhost:5173`.
 
+Preferred profile-based commands:
+
+```bash
+cd frontend
+npm run dev:local
+npm run dev:prod
+```
+
+- `npm run dev:local` loads `frontend/.env.dev.local` and is meant for local backend / local Supabase development.
+- `npm run dev:prod` loads `frontend/.env.prod.local` and is meant for testing the local frontend against the live production services.
+- Both files are local-only and ignored by git because they end in `.local`.
+
 ### Build and Lint
 
 ```bash
@@ -96,10 +108,34 @@ Firebase's official Hosting docs say this command creates the deploy service acc
 
 ## Environment Variables
 
-Create a `.env.local` file (or equivalent environment setup) and provide the values your deployment mode needs:
+For ad hoc development you can still use a single `.env.local`, but the recommended setup is to keep two local-only profiles:
+
+```bash
+frontend/.env.dev.local
+frontend/.env.prod.local
+```
+
+Suggested contents:
+
+`frontend/.env.dev.local`
 
 ```bash
 VITE_MODE=development
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_ANON_KEY=...
+
+# optional integrations
+VITE_SAM_API_URL=...
+VITE_POSTHOG_PROJECT_KEY=...
+VITE_GEOPIFY_KEY=...
+VITE_SUPABASE_SENTINEL_PROCESSING_URL=...
+VITE_SUPABASE_SENTINEL_PROCESSING_ANON_KEY=...
+```
+
+`frontend/.env.prod.local`
+
+```bash
+VITE_MODE=production
 VITE_SUPABASE_URL=...
 VITE_SUPABASE_ANON_KEY=...
 
@@ -110,6 +146,12 @@ VITE_GEOPIFY_KEY=...
 VITE_SUPABASE_SENTINEL_PROCESSING_URL=...
 VITE_SUPABASE_SENTINEL_PROCESSING_ANON_KEY=...
 ```
+
+Notes:
+
+- `VITE_MODE=development` makes `src/config.ts` use the local development URLs.
+- `VITE_MODE=production` makes `src/config.ts` use the explicit `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` values from the env file.
+- If you already have an older `frontend/.env.local`, split it into the two profile files above and prefer the `dev:local` / `dev:prod` scripts.
 
 ## Important Feature Areas
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "bash ./scripts/run-vite-profile.sh local",
+    "dev:prod": "bash ./scripts/run-vite-profile.sh prod",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/frontend/scripts/run-vite-profile.sh
+++ b/frontend/scripts/run-vite-profile.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PROFILE="${1:-}"
+shift || true
+
+case "$PROFILE" in
+  local)
+    ENV_FILE="$FRONTEND_DIR/.env.dev.local"
+    DEFAULT_MODE="development"
+    ;;
+  prod)
+    ENV_FILE="$FRONTEND_DIR/.env.prod.local"
+    DEFAULT_MODE="production"
+    ;;
+  *)
+    echo "Usage: bash ./scripts/run-vite-profile.sh <local|prod> [vite args...]" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing env profile: $ENV_FILE" >&2
+  echo "Create it first. See frontend/README.md for the expected setup." >&2
+  exit 1
+fi
+
+cd "$FRONTEND_DIR"
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+export VITE_MODE="${VITE_MODE:-$DEFAULT_MODE}"
+
+echo "Starting Vite with profile '$PROFILE' using $(basename "$ENV_FILE") (VITE_MODE=$VITE_MODE)"
+
+exec ./node_modules/.bin/vite "$@"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import ResetPassword from "./pages/auth/ResetPassword";
 import About from "./pages/About";
 import Impressum from "./pages/Impressum";
 import Footer from "./components/Footer";
+import { PublicOnly, RequireAuth } from "./components/AuthGate";
 import Datenschutzerklaerung from "./pages/Datenschutzerklaerung";
 import TermsOfService from "./pages/TermsOfService";
 import { antdTheme } from "./theme/antdTheme";
@@ -94,7 +95,14 @@ function AppWithTracking() {
     <Routes>
       <Route path="/" element={<LayoutWrapper />}>
         <Route path="/" element={<HomePage />} />
-        <Route path="profile" element={<ProfilePage />} />
+        <Route
+          path="profile"
+          element={(
+            <RequireAuth>
+              <ProfilePage />
+            </RequireAuth>
+          )}
+        />
         <Route path="dataset" element={<Dataset />} />
         <Route path="dataset/:id" element={<DatasetDetails />} />
         <Route path="dataset-audit" element={<DatasetAudit />} />
@@ -111,8 +119,22 @@ function AppWithTracking() {
         <Route path="impressum" element={<Impressum />} />
         <Route path="datenschutzerklaerung" element={<Datenschutzerklaerung />} />
         <Route path="terms-of-service" element={<TermsOfService />} />
-        <Route path="sign-up" element={<SignUp />} />
-        <Route path="sign-in" element={<SignIn />} />
+        <Route
+          path="sign-up"
+          element={(
+            <PublicOnly>
+              <SignUp />
+            </PublicOnly>
+          )}
+        />
+        <Route
+          path="sign-in"
+          element={(
+            <PublicOnly>
+              <SignIn />
+            </PublicOnly>
+          )}
+        />
         <Route path="forgot-password" element={<Forgotpassword />} />
         <Route path="reset-password" element={<ResetPassword />} />
       </Route>

--- a/frontend/src/api/uploadOrtho.ts
+++ b/frontend/src/api/uploadOrtho.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { Settings } from "../config";
-import { supabase } from "../hooks/useSupabase";
+import { clearLocalSupabaseSession, supabase } from "../hooks/useSupabase";
+import { isInvalidSessionError } from "../utils/authSession";
 import { isTokenExpiringSoon } from "../utils/isTokenExpiringSoon";
 
 interface UploadOptions {
@@ -73,6 +74,11 @@ async function uploadChunks(file: File, totalChunks: number, uploadStartTime: nu
     if (isTokenExpiringSoon(currentSession)) {
       const { data, error } = await supabase.auth.refreshSession();
       if (error) {
+        if (isInvalidSessionError(error)) {
+          await clearLocalSupabaseSession();
+          throw new Error("Session expired. Please sign in again.");
+        }
+
         console.error("Error refreshing token:", error);
         throw error;
       }

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,54 @@
+import { Spin } from "antd";
+import { ReactNode } from "react";
+import { Navigate, useLocation, useSearchParams } from "react-router-dom";
+
+import { useAuth } from "../hooks/useAuthProvider";
+
+function AuthLoadingScreen({ tip }: { tip: string }) {
+  return (
+    <div className="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center gap-3 text-slate-600">
+      <Spin size="large" />
+      <span>{tip}</span>
+    </div>
+  );
+}
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { recoveryReason, status } = useAuth();
+  const location = useLocation();
+
+  if (status === "checking") {
+    return <AuthLoadingScreen tip="Checking session..." />;
+  }
+
+  if (status !== "authenticated") {
+    const returnTo = `${location.pathname}${location.search}`;
+    const params = new URLSearchParams();
+    if (returnTo !== "/profile") {
+      params.set("returnTo", returnTo);
+    }
+    if (recoveryReason === "session_expired") {
+      params.set("reason", recoveryReason);
+    }
+    const signInUrl = params.size ? `/sign-in?${params.toString()}` : "/sign-in";
+    return <Navigate replace to={signInUrl} />;
+  }
+
+  return <>{children}</>;
+}
+
+export function PublicOnly({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo") || "/profile";
+
+  if (status === "checking") {
+    return <AuthLoadingScreen tip="Checking session..." />;
+  }
+
+  if (status === "authenticated") {
+    return <Navigate replace to={returnTo} />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -33,9 +33,10 @@ import {
   validateGeoTiffAiEligibility,
   validateZipCompressionMethods,
 } from "../../utils/fileValidation";
+import { isInvalidSessionError } from "../../utils/authSession";
 
 import { isTokenExpiringSoon } from "../../utils/isTokenExpiringSoon";
-import { supabase } from "../../hooks/useSupabase";
+import { clearLocalSupabaseSession, supabase } from "../../hooks/useSupabase";
 import { RcFile } from "antd/es/upload";
 import type { Dayjs } from "dayjs";
 import { useAnalytics } from "../../hooks/useAnalytics";
@@ -182,7 +183,14 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
   const getValidAccessToken = async (): Promise<string> => {
     if (isTokenExpiringSoon(session)) {
       const { data, error } = await supabase.auth.refreshSession();
-      if (error) throw error;
+      if (error) {
+        if (isInvalidSessionError(error)) {
+          await clearLocalSupabaseSession();
+          throw new Error("Session expired. Please sign in again.");
+        }
+
+        throw error;
+      }
       return data.session!.access_token;
     }
     return session!.access_token;

--- a/frontend/src/hooks/useAuthProvider.tsx
+++ b/frontend/src/hooks/useAuthProvider.tsx
@@ -1,30 +1,65 @@
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Session, User } from "@supabase/supabase-js";
-import { identifyUser, trackAuthCompletion } from "../utils/analytics";
 
-import { supabase } from "./useSupabase";
+import { identifyUser, trackAuthCompletion } from "../utils/analytics";
+import { getAuthErrorText, hasWellFormedJwt, isInvalidSessionError } from "../utils/authSession";
+
+import { clearLocalSupabaseSession, clearSupabaseAuthStorage, supabase } from "./useSupabase";
 
 interface AuthProviderProps {
   children: React.ReactNode;
 }
 
+export type AuthStatus = "checking" | "authenticated" | "anonymous";
+export type AuthRecoveryReason = "session_expired" | null;
+
 type AuthContextType = {
+  loading: boolean;
+  recoveryReason: AuthRecoveryReason;
   session: Session | null;
+  status: AuthStatus;
   user: User | null;
   signOut: () => Promise<void>;
 };
 
-const AuthContext = createContext<AuthContextType>({
+type AuthState = {
+  recoveryReason: AuthRecoveryReason;
+  session: Session | null;
+  status: AuthStatus;
+  user: User | null;
+};
+
+const anonymousState: AuthState = {
+  recoveryReason: null,
+  status: "anonymous",
   session: null,
+  user: null,
+};
+
+const checkingState: AuthState = {
+  recoveryReason: null,
+  status: "checking",
+  session: null,
+  user: null,
+};
+
+const AuthContext = createContext<AuthContextType>({
+  loading: true,
+  recoveryReason: null,
+  session: null,
+  status: "checking",
   user: null,
   signOut: async () => {
     await supabase.auth.signOut();
   },
 });
 
-const AuthProvider = (props: AuthProviderProps) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [session, setSession] = useState<Session | null>(null);
+const AUTH_VALIDATION_TIMEOUT_MS = 2000;
+
+const AuthProvider = ({ children }: AuthProviderProps) => {
+  const authRequestRef = useRef(0);
+  const authStateRef = useRef<AuthState>(checkingState);
+  const [authState, setAuthState] = useState<AuthState>(checkingState);
 
   const getIsCoreTeam = useCallback(async (userId: string): Promise<boolean> => {
     const { data, error } = await supabase
@@ -41,75 +76,227 @@ const AuthProvider = (props: AuthProviderProps) => {
     return data?.can_audit === true;
   }, []);
 
-  const signOut = useCallback(async () => {
-    // Clear local auth state immediately so route guards and auth pages
-    // cannot briefly see a stale signed-in session during sign-out.
-    setSession(null);
-    setUser(null);
+  const applyAnonymousState = useCallback((recoveryReason: AuthRecoveryReason = null) => {
+    clearSupabaseAuthStorage();
+    setAuthState({
+      ...anonymousState,
+      recoveryReason,
+    });
     identifyUser(null);
-
-    await supabase.auth.signOut();
   }, []);
 
-  useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange(async (event, session) => {
-      setSession(session);
-      setUser(session?.user || null);
+  const applyAuthenticatedState = useCallback((session: Session, user: User) => {
+    setAuthState({
+      recoveryReason: null,
+      status: "authenticated",
+      session,
+      user,
+    });
 
-      // Identify user in PostHog when auth state changes
-      if (!session?.user) {
-        identifyUser(null);
+    // Identify immediately so analytics stop treating the browser as anonymous.
+    identifyUser(user);
+  }, []);
+
+  const enrichUserAnalytics = useCallback(
+    async (user: User, requestId: number) => {
+      const isCoreTeam = await getIsCoreTeam(user.id);
+
+      if (authRequestRef.current !== requestId) {
         return;
       }
 
-      const isCoreTeam = await getIsCoreTeam(session.user.id);
-      identifyUser(session.user, { isCoreTeam });
+      identifyUser(user, { isCoreTeam });
+    },
+    [getIsCoreTeam],
+  );
+
+  const recoverInvalidSession = useCallback(
+    (error: unknown, requestId?: number) => {
+      if (requestId !== undefined && authRequestRef.current !== requestId) {
+        return;
+      }
+
+      console.warn("Clearing invalid local Supabase session", getAuthErrorText(error));
+      applyAnonymousState("session_expired");
+
+      void clearLocalSupabaseSession().catch((signOutError) => {
+        console.error("Failed to clear local Supabase session", signOutError);
+      });
+    },
+    [applyAnonymousState],
+  );
+
+  const validateSession = useCallback(
+    async (nextSession: Session, requestId: number) => {
+      if (!hasWellFormedJwt(nextSession.access_token)) {
+        recoverInvalidSession(new Error("Stored access token is malformed."), requestId);
+        return null;
+      }
+
+      const authValidationTimeout = Symbol("authValidationTimeout");
+      const validationResult = await Promise.race([
+        supabase.auth.getUser(),
+        new Promise<typeof authValidationTimeout>((resolve) => {
+          window.setTimeout(() => resolve(authValidationTimeout), AUTH_VALIDATION_TIMEOUT_MS);
+        }),
+      ]);
+
+      if (authRequestRef.current !== requestId) {
+        return null;
+      }
+
+      if (validationResult === authValidationTimeout) {
+        recoverInvalidSession(new Error("Auth session validation timed out."), requestId);
+        return null;
+      }
+
+      const {
+        data: { user: validatedUser },
+        error,
+      } = validationResult;
+
+      if (error) {
+        if (isInvalidSessionError(error)) {
+          recoverInvalidSession(error, requestId);
+          return null;
+        }
+
+        throw error;
+      }
+
+      if (!validatedUser) {
+        recoverInvalidSession(new Error("Supabase returned no authenticated user for the restored session."), requestId);
+        return null;
+      }
+
+      applyAuthenticatedState(nextSession, validatedUser);
+      void enrichUserAnalytics(validatedUser, requestId);
+
+      return validatedUser;
+    },
+    [applyAuthenticatedState, enrichUserAnalytics, recoverInvalidSession],
+  );
+
+  const restoreSession = useCallback(
+    async (nextSession: Session, event?: string) => {
+      const requestId = ++authRequestRef.current;
+      const shouldShowCheckingState =
+        event !== "TOKEN_REFRESHED" && authStateRef.current.status !== "authenticated";
+
+      if (shouldShowCheckingState) {
+        setAuthState(checkingState);
+      }
+
+      const validatedUser = await validateSession(nextSession, requestId);
+      if (!validatedUser) {
+        return null;
+      }
 
       if (event === "SIGNED_IN") {
         const currentPath = window.location.pathname;
         if (currentPath.startsWith("/sign-up")) {
-          trackAuthCompletion("sign_up_completed", { isCoreTeam, authPath: currentPath });
+          trackAuthCompletion("sign_up_completed", { authPath: currentPath, isCoreTeam: false });
         } else if (currentPath.startsWith("/sign-in") || currentPath.startsWith("/reset-password")) {
-          trackAuthCompletion("sign_in_completed", { isCoreTeam, authPath: currentPath });
+          trackAuthCompletion("sign_in_completed", { authPath: currentPath, isCoreTeam: false });
         }
       }
-    });
 
-    const setData = async () => {
-      const {
-        data: { session },
-        error,
-      } = await supabase.auth.getSession();
-      if (error) {
+      return validatedUser;
+    },
+    [validateSession],
+  );
+
+  const signOut = useCallback(async () => {
+    authRequestRef.current += 1;
+    applyAnonymousState();
+
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      if (!isInvalidSessionError(error)) {
         throw error;
       }
+    } finally {
+      clearSupabaseAuthStorage();
+    }
+  }, [applyAnonymousState]);
 
-      setSession(session);
-      setUser(session?.user || null);
+  useEffect(() => {
+    authStateRef.current = authState;
+  }, [authState]);
 
-      // Identify user in PostHog when component mounts
-      if (session?.user) {
-        const isCoreTeam = await getIsCoreTeam(session.user.id);
-        identifyUser(session.user, { isCoreTeam });
-      } else {
-        identifyUser(null);
+  useEffect(() => {
+    let isMounted = true;
+
+    const { data: listener } = supabase.auth.onAuthStateChange((event, nextSession) => {
+      if (event === "INITIAL_SESSION" || !isMounted) {
+        return;
+      }
+
+      if (!nextSession) {
+        authRequestRef.current += 1;
+        applyAnonymousState();
+        return;
+      }
+
+      void restoreSession(nextSession, event);
+    });
+
+    const initializeAuth = async () => {
+      const requestId = ++authRequestRef.current;
+      setAuthState(checkingState);
+
+      try {
+        const {
+          data: { session: restoredSession },
+          error,
+        } = await supabase.auth.getSession();
+
+        if (authRequestRef.current !== requestId || !isMounted) {
+          return;
+        }
+
+        if (error) {
+          if (isInvalidSessionError(error)) {
+            recoverInvalidSession(error, requestId);
+            return;
+          }
+
+          throw error;
+        }
+
+        if (!restoredSession) {
+          applyAnonymousState();
+          return;
+        }
+
+        await validateSession(restoredSession, requestId);
+      } catch (error) {
+        console.error("Failed to restore Supabase auth session", error);
+        if (authRequestRef.current === requestId) {
+          applyAnonymousState();
+        }
       }
     };
 
-    setData();
+    void initializeAuth();
 
     return () => {
+      isMounted = false;
       listener.subscription.unsubscribe();
     };
-  }, [getIsCoreTeam]);
+  }, [applyAnonymousState, recoverInvalidSession, restoreSession, validateSession]);
 
   const value = {
-    session,
-    user,
+    loading: authState.status === "checking",
+    recoveryReason: authState.recoveryReason,
+    session: authState.session,
+    status: authState.status,
+    user: authState.user,
     signOut,
   };
 
-  return <AuthContext.Provider value={value}> {props.children} </AuthContext.Provider>;
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {

--- a/frontend/src/hooks/useAuthProvider.tsx
+++ b/frontend/src/hooks/useAuthProvider.tsx
@@ -29,6 +29,15 @@ type AuthState = {
   user: User | null;
 };
 
+type SessionValidationResult =
+  | {
+      status: "valid";
+      user: User;
+    }
+  | {
+      status: "invalid";
+    };
+
 const anonymousState: AuthState = {
   recoveryReason: null,
   status: "anonymous",
@@ -110,6 +119,23 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
     [getIsCoreTeam],
   );
 
+  const trackAuthCompletionForUser = useCallback(
+    async (user: User, currentPath: string, requestId: number) => {
+      const isCoreTeam = await getIsCoreTeam(user.id);
+
+      if (authRequestRef.current !== requestId) {
+        return;
+      }
+
+      if (currentPath.startsWith("/sign-up")) {
+        trackAuthCompletion("sign_up_completed", { authPath: currentPath, isCoreTeam });
+      } else if (currentPath.startsWith("/sign-in") || currentPath.startsWith("/reset-password")) {
+        trackAuthCompletion("sign_in_completed", { authPath: currentPath, isCoreTeam });
+      }
+    },
+    [getIsCoreTeam],
+  );
+
   const recoverInvalidSession = useCallback(
     (error: unknown, requestId?: number) => {
       if (requestId !== undefined && authRequestRef.current !== requestId) {
@@ -130,7 +156,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
     async (nextSession: Session, requestId: number) => {
       if (!hasWellFormedJwt(nextSession.access_token)) {
         recoverInvalidSession(new Error("Stored access token is malformed."), requestId);
-        return null;
+        return { status: "invalid" } satisfies SessionValidationResult;
       }
 
       const authValidationTimeout = Symbol("authValidationTimeout");
@@ -146,8 +172,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       }
 
       if (validationResult === authValidationTimeout) {
-        recoverInvalidSession(new Error("Auth session validation timed out."), requestId);
-        return null;
+        throw new Error("Auth session validation timed out.");
       }
 
       const {
@@ -158,7 +183,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       if (error) {
         if (isInvalidSessionError(error)) {
           recoverInvalidSession(error, requestId);
-          return null;
+          return { status: "invalid" } satisfies SessionValidationResult;
         }
 
         throw error;
@@ -166,15 +191,31 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
       if (!validatedUser) {
         recoverInvalidSession(new Error("Supabase returned no authenticated user for the restored session."), requestId);
-        return null;
+        return { status: "invalid" } satisfies SessionValidationResult;
       }
 
       applyAuthenticatedState(nextSession, validatedUser);
       void enrichUserAnalytics(validatedUser, requestId);
 
-      return validatedUser;
+      return {
+        status: "valid",
+        user: validatedUser,
+      } satisfies SessionValidationResult;
     },
     [applyAuthenticatedState, enrichUserAnalytics, recoverInvalidSession],
+  );
+
+  const recoverTransientValidationFailure = useCallback(
+    (nextSession: Session, error: unknown, requestId: number) => {
+      if (authRequestRef.current !== requestId) {
+        return;
+      }
+
+      console.warn("Auth session validation failed temporarily; keeping current session.", getAuthErrorText(error));
+      applyAuthenticatedState(nextSession, nextSession.user);
+      void enrichUserAnalytics(nextSession.user, requestId);
+    },
+    [applyAuthenticatedState, enrichUserAnalytics],
   );
 
   const restoreSession = useCallback(
@@ -187,23 +228,26 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
         setAuthState(checkingState);
       }
 
-      const validatedUser = await validateSession(nextSession, requestId);
-      if (!validatedUser) {
+      let validationResult: SessionValidationResult;
+      try {
+        validationResult = await validateSession(nextSession, requestId);
+      } catch (error) {
+        recoverTransientValidationFailure(nextSession, error, requestId);
+        return null;
+      }
+
+      if (validationResult.status !== "valid") {
         return null;
       }
 
       if (event === "SIGNED_IN") {
         const currentPath = window.location.pathname;
-        if (currentPath.startsWith("/sign-up")) {
-          trackAuthCompletion("sign_up_completed", { authPath: currentPath, isCoreTeam: false });
-        } else if (currentPath.startsWith("/sign-in") || currentPath.startsWith("/reset-password")) {
-          trackAuthCompletion("sign_in_completed", { authPath: currentPath, isCoreTeam: false });
-        }
+        void trackAuthCompletionForUser(validationResult.user, currentPath, requestId);
       }
 
-      return validatedUser;
+      return validationResult.user;
     },
-    [validateSession],
+    [recoverTransientValidationFailure, trackAuthCompletionForUser, validateSession],
   );
 
   const signOut = useCallback(async () => {
@@ -270,7 +314,11 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
           return;
         }
 
-        await validateSession(restoredSession, requestId);
+        try {
+          await validateSession(restoredSession, requestId);
+        } catch (validationError) {
+          recoverTransientValidationFailure(restoredSession, validationError, requestId);
+        }
       } catch (error) {
         console.error("Failed to restore Supabase auth session", error);
         if (authRequestRef.current === requestId) {
@@ -285,7 +333,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       isMounted = false;
       listener.subscription.unsubscribe();
     };
-  }, [applyAnonymousState, recoverInvalidSession, restoreSession, validateSession]);
+  }, [applyAnonymousState, recoverInvalidSession, recoverTransientValidationFailure, restoreSession, validateSession]);
 
   const value = {
     loading: authState.status === "checking",

--- a/frontend/src/hooks/useAuthProvider.tsx
+++ b/frontend/src/hooks/useAuthProvider.tsx
@@ -2,7 +2,12 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState } f
 import { Session, User } from "@supabase/supabase-js";
 
 import { identifyUser, trackAuthCompletion } from "../utils/analytics";
-import { getAuthErrorText, hasWellFormedJwt, isInvalidSessionError } from "../utils/authSession";
+import {
+  classifySessionValidationResult,
+  getAuthErrorText,
+  hasWellFormedJwt,
+  isInvalidSessionError,
+} from "../utils/authSession";
 
 import { clearLocalSupabaseSession, clearSupabaseAuthStorage, supabase } from "./useSupabase";
 
@@ -172,7 +177,8 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       }
 
       if (validationResult === authValidationTimeout) {
-        throw new Error("Auth session validation timed out.");
+        const outcome = classifySessionValidationResult({ timedOut: true });
+        throw new Error(outcome.reason);
       }
 
       const {
@@ -180,17 +186,17 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
         error,
       } = validationResult;
 
-      if (error) {
-        if (isInvalidSessionError(error)) {
-          recoverInvalidSession(error, requestId);
-          return { status: "invalid" } satisfies SessionValidationResult;
-        }
+      const outcome = classifySessionValidationResult({
+        error,
+        user: validatedUser,
+      });
 
-        throw error;
+      if (outcome.status === "transient_failure") {
+        throw new Error(outcome.reason);
       }
 
-      if (!validatedUser) {
-        recoverInvalidSession(new Error("Supabase returned no authenticated user for the restored session."), requestId);
+      if (outcome.status === "invalid_session") {
+        recoverInvalidSession(error ?? new Error(outcome.reason), requestId);
         return { status: "invalid" } satisfies SessionValidationResult;
       }
 

--- a/frontend/src/hooks/useDatasets.ts
+++ b/frontend/src/hooks/useDatasets.ts
@@ -11,6 +11,8 @@ interface DatasetQueryOptions {
 
 // Base datasets hook - includes ALL datasets (for admin/audit use)
 export function useDatasets(options: DatasetQueryOptions = {}) {
+  const { status } = useAuth();
+
   return useQuery({
     queryKey: ["datasets"],
     queryFn: async () => {
@@ -18,7 +20,7 @@ export function useDatasets(options: DatasetQueryOptions = {}) {
       if (error) throw error;
       return data;
     },
-    enabled: options.enabled ?? true,
+    enabled: (options.enabled ?? true) && status !== "checking",
     staleTime: 5 * 60 * 1000, // 5 minutes - data is fresh for 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache for 10 minutes
   });
@@ -26,6 +28,8 @@ export function useDatasets(options: DatasetQueryOptions = {}) {
 
 // Public datasets hook - excludes datasets marked as "exclude_completely"
 export function usePublicDatasets(options: DatasetQueryOptions = {}) {
+  const { status } = useAuth();
+
   return useQuery({
     queryKey: ["public-datasets"],
     queryFn: async () => {
@@ -33,7 +37,7 @@ export function usePublicDatasets(options: DatasetQueryOptions = {}) {
       if (error) throw error;
       return data;
     },
-    enabled: options.enabled ?? true,
+    enabled: (options.enabled ?? true) && status !== "checking",
     staleTime: 5 * 60 * 1000, // 5 minutes - data is fresh for 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache for 10 minutes
   });
@@ -41,9 +45,11 @@ export function usePublicDatasets(options: DatasetQueryOptions = {}) {
 
 // Public single dataset hook - optimized for dataset details page
 export function usePublicDatasetById(datasetId: number | undefined) {
+  const { status } = useAuth();
+
 	return useQuery({
 		queryKey: ["public-dataset-by-id", datasetId],
-		enabled: !!datasetId,
+		enabled: !!datasetId && status !== "checking",
 		queryFn: async () => {
 			if (!datasetId) return null;
 			const { data, error } = await supabase
@@ -61,9 +67,11 @@ export function usePublicDatasetById(datasetId: number | undefined) {
 
 // Fetch a single dataset by id; minimal fields are enough for Tiles page
 export function useDatasetById(datasetId: number | undefined) {
+  const { status } = useAuth();
+
   return useQuery({
     queryKey: ["dataset-by-id", datasetId],
-    enabled: !!datasetId,
+    enabled: !!datasetId && status !== "checking",
     queryFn: async () => {
       if (!datasetId) return null;
       const { data, error } = await supabase.from(Settings.DATA_TABLE_FULL).select("*").eq("id", datasetId).single();
@@ -75,7 +83,7 @@ export function useDatasetById(datasetId: number | undefined) {
 
 // User-specific datasets - uses public view to exclude excluded and archived datasets
 export function useUserDatasets(options: DatasetQueryOptions = {}) {
-  const { session } = useAuth();
+  const { session, status } = useAuth();
 
   return useQuery({
     queryKey: ["userDatasets", session?.user?.id],
@@ -88,7 +96,7 @@ export function useUserDatasets(options: DatasetQueryOptions = {}) {
       if (error) throw error;
       return data;
     },
-    enabled: (options.enabled ?? true) && !!session?.user?.id,
+    enabled: (options.enabled ?? true) && status === "authenticated" && !!session?.user?.id,
     staleTime: 5 * 60 * 1000, // 5 minutes - data is fresh for 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache for 10 minutes
   });

--- a/frontend/src/hooks/useSaveCorrections.ts
+++ b/frontend/src/hooks/useSaveCorrections.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "./useSupabase";
+import { clearLocalSupabaseSession, supabase } from "./useSupabase";
 import { useAuth } from "./useAuthProvider";
+import { isInvalidSessionError } from "../utils/authSession";
 import { isTokenExpiringSoon } from "../utils/isTokenExpiringSoon";
 import type Feature from "ol/Feature";
 import type { Geometry } from "ol/geom";
@@ -213,6 +214,9 @@ export function useSaveCorrections() {
       if (isTokenExpiringSoon(session)) {
         const { error: refreshError } = await supabase.auth.refreshSession();
         if (refreshError) {
+          if (isInvalidSessionError(refreshError)) {
+            await clearLocalSupabaseSession();
+          }
           throw new Error("Session expired. Please sign in again.");
         }
       }

--- a/frontend/src/hooks/useSupabase.ts
+++ b/frontend/src/hooks/useSupabase.ts
@@ -1,5 +1,25 @@
 import { createClient } from "@supabase/supabase-js";
 
 import { Settings } from "../config";
+import { isInvalidSessionError } from "../utils/authSession";
 
 export const supabase = createClient(Settings.SUPABASE_URL, Settings.SUPABASE_ANON_KEY);
+
+export function clearSupabaseAuthStorage() {
+  const storageKey = supabase.auth.storageKey;
+
+  if (typeof window !== "undefined" && storageKey) {
+    window.localStorage.removeItem(storageKey);
+    window.localStorage.removeItem(`${storageKey}-code-verifier`);
+  }
+}
+
+export async function clearLocalSupabaseSession() {
+  const { error } = await supabase.auth.signOut({ scope: "local" });
+
+  if (error && !isInvalidSessionError(error)) {
+    throw error;
+  }
+
+  clearSupabaseAuthStorage();
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Avatar, Badge, Button, Segmented, Typography, Table, Tag, Tooltip } from "antd";
 import { useAuth } from "../hooks/useAuthProvider";
 import DataTable from "../components/DataTable";
@@ -63,12 +63,6 @@ export default function ProfilePage() {
   const [selectedDatasets, setSelectedDatasets] = useState<DatasetType[]>([]);
   const [isPublicationModalVisible, setIsPublicationModalVisible] = useState(false);
   const [resetSelectionFlag, setResetSelectionFlag] = useState(false);
-
-  useEffect(() => {
-    if (!session) {
-      navigate("/sign-in");
-    }
-  }, [session, navigate]);
 
   const handleSelectedRowsChange = (rows: DatasetType[]) => {
     setSelectedDatasets(rows);

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -1,27 +1,27 @@
+import { Alert } from "antd";
 import { SignIn as SignInAuthUI } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
+import { Link, useSearchParams } from "react-router-dom";
 import { supabase } from "../../hooks/useSupabase";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { useEffect } from "react";
-import { useAuth } from "../../hooks/useAuthProvider";
 import { palette } from "../../theme/palette";
 
 const SignIn = () => {
-  const { session } = useAuth();
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo") || "/profile";
-
-  useEffect(() => {
-    if (session) {
-      navigate(returnTo);
-    }
-  }, [session, navigate, returnTo]);
+  const sessionExpired = searchParams.get("reason") === "session_expired";
 
   return (
     <div className="m-auto flex h-full  max-w-7xl items-center justify-center">
       <div className="w-96 rounded-md p-8">
         <h1 className="mb-8 text-3xl font-semibold text-gray-600">Sign In</h1>
+        {sessionExpired ? (
+          <Alert
+            type="warning"
+            showIcon
+            className="mb-4"
+            message="Your session expired. Please sign in again."
+          />
+        ) : null}
         <SignInAuthUI
           supabaseClient={supabase}
           providers={[]}

--- a/frontend/src/utils/authSession.test.ts
+++ b/frontend/src/utils/authSession.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { getAuthErrorText, hasWellFormedJwt, isInvalidSessionError } from "./authSession";
+
+describe("getAuthErrorText", () => {
+  it("combines useful error fields into a searchable string", () => {
+    expect(
+      getAuthErrorText({
+        name: "AuthApiError",
+        message: "InvalidJWTToken: JWT expired",
+        status: 401,
+      }),
+    ).toContain("InvalidJWTToken: JWT expired");
+  });
+});
+
+describe("isInvalidSessionError", () => {
+  it("detects invalid JWT errors from structured auth responses", () => {
+    expect(
+      isInvalidSessionError({
+        name: "AuthApiError",
+        message: "InvalidJWTToken: JWT expired",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects stale refresh token failures", () => {
+    expect(
+      isInvalidSessionError({
+        message: "Refresh Token Not Found",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats auth 401 responses as invalid local sessions", () => {
+    expect(
+      isInvalidSessionError({
+        status: 401,
+        message: "Unauthorized",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated errors as auth-session failures", () => {
+    expect(
+      isInvalidSessionError({
+        message: "Network request failed",
+        status: 500,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("hasWellFormedJwt", () => {
+  it("detects malformed JWT values", () => {
+    expect(hasWellFormedJwt("invalid-jwt-token")).toBe(false);
+    expect(hasWellFormedJwt("header.payload.signature")).toBe(true);
+  });
+});

--- a/frontend/src/utils/authSession.test.ts
+++ b/frontend/src/utils/authSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getAuthErrorText, hasWellFormedJwt, isInvalidSessionError } from "./authSession";
+import { classifySessionValidationResult, getAuthErrorText, hasWellFormedJwt, isInvalidSessionError } from "./authSession";
 
 describe("getAuthErrorText", () => {
   it("combines useful error fields into a searchable string", () => {
@@ -55,5 +55,46 @@ describe("hasWellFormedJwt", () => {
   it("detects malformed JWT values", () => {
     expect(hasWellFormedJwt("invalid-jwt-token")).toBe(false);
     expect(hasWellFormedJwt("header.payload.signature")).toBe(true);
+  });
+});
+
+describe("classifySessionValidationResult", () => {
+  it("treats timeouts as transient validation failures", () => {
+    expect(classifySessionValidationResult({ timedOut: true })).toEqual({
+      status: "transient_failure",
+      reason: "Auth session validation timed out.",
+    });
+  });
+
+  it("treats non-auth failures as transient validation failures", () => {
+    expect(
+      classifySessionValidationResult({
+        error: new Error("Service unavailable"),
+      }),
+    ).toEqual({
+      status: "transient_failure",
+      reason: "Error Service unavailable",
+    });
+  });
+
+  it("treats invalid auth responses as invalid sessions", () => {
+    expect(
+      classifySessionValidationResult({
+        error: {
+          message: "InvalidJWTToken: JWT expired",
+          status: 401,
+        },
+      }),
+    ).toEqual({
+      status: "invalid_session",
+      reason: "InvalidJWTToken: JWT expired 401",
+    });
+  });
+
+  it("treats missing users as invalid sessions", () => {
+    expect(classifySessionValidationResult({ user: null })).toEqual({
+      status: "invalid_session",
+      reason: "Supabase returned no authenticated user for the restored session.",
+    });
   });
 });

--- a/frontend/src/utils/authSession.ts
+++ b/frontend/src/utils/authSession.ts
@@ -1,0 +1,80 @@
+type ErrorLike = {
+  code?: number | string;
+  details?: string;
+  error_description?: string;
+  hint?: string;
+  message?: string;
+  name?: string;
+  status?: number;
+};
+
+const INVALID_SESSION_MARKERS = [
+  "invalidjwttoken",
+  "invalid jwt",
+  "jwt expired",
+  "jwt has expired",
+  "session expired",
+  "auth session missing",
+  "refresh token",
+  "user from sub claim in jwt does not exist",
+  "jwserror",
+];
+
+const INVALID_SESSION_STATUS_CODES = new Set([401, 403]);
+
+function toErrorLike(error: unknown): ErrorLike | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  return error as ErrorLike;
+}
+
+export function hasWellFormedJwt(token: string | null | undefined): boolean {
+  if (!token) {
+    return false;
+  }
+
+  return token.split(".").length === 3;
+}
+
+export function getAuthErrorText(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return [error.name, error.message].filter(Boolean).join(" ");
+  }
+
+  const errorLike = toErrorLike(error);
+  if (!errorLike) {
+    return "";
+  }
+
+  return [
+    errorLike.name,
+    errorLike.message,
+    errorLike.error_description,
+    errorLike.details,
+    errorLike.hint,
+    errorLike.code,
+    errorLike.status,
+  ]
+    .filter((value) => value !== undefined && value !== null && value !== "")
+    .join(" ");
+}
+
+export function isInvalidSessionError(error: unknown): boolean {
+  const errorLike = toErrorLike(error);
+  if (errorLike?.status && INVALID_SESSION_STATUS_CODES.has(errorLike.status)) {
+    return true;
+  }
+
+  const normalizedText = getAuthErrorText(error).toLowerCase();
+  if (!normalizedText) {
+    return false;
+  }
+
+  return INVALID_SESSION_MARKERS.some((marker) => normalizedText.includes(marker));
+}

--- a/frontend/src/utils/authSession.ts
+++ b/frontend/src/utils/authSession.ts
@@ -8,6 +8,19 @@ type ErrorLike = {
   status?: number;
 };
 
+export type SessionValidationOutcome =
+  | {
+      status: "valid";
+    }
+  | {
+      status: "invalid_session";
+      reason: string;
+    }
+  | {
+      status: "transient_failure";
+      reason: string;
+    };
+
 const INVALID_SESSION_MARKERS = [
   "invalidjwttoken",
   "invalid jwt",
@@ -77,4 +90,44 @@ export function isInvalidSessionError(error: unknown): boolean {
   }
 
   return INVALID_SESSION_MARKERS.some((marker) => normalizedText.includes(marker));
+}
+
+export function classifySessionValidationResult({
+  error,
+  timedOut = false,
+  user,
+}: {
+  error?: unknown;
+  timedOut?: boolean;
+  user?: unknown;
+}): SessionValidationOutcome {
+  if (timedOut) {
+    return {
+      status: "transient_failure",
+      reason: "Auth session validation timed out.",
+    };
+  }
+
+  if (error) {
+    return isInvalidSessionError(error)
+      ? {
+          status: "invalid_session",
+          reason: getAuthErrorText(error) || "Invalid auth session.",
+        }
+      : {
+          status: "transient_failure",
+          reason: getAuthErrorText(error) || "Auth session validation failed.",
+        };
+  }
+
+  if (!user) {
+    return {
+      status: "invalid_session",
+      reason: "Supabase returned no authenticated user for the restored session.",
+    };
+  }
+
+  return {
+    status: "valid",
+  };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
-    hmr: {
-      clientPort: 5173,
-    },
     proxy: {
       "/api/sam": {
         target: "https://geosense--sam-api-fastapi-app.modal.run",


### PR DESCRIPTION
## Summary
- refactor frontend auth into an explicit session state machine with shared route guards
- clear invalid restored Supabase sessions immediately and redirect to sign-in with a session-expired message
- delay dataset queries until auth bootstrap has settled to avoid extra 401 noise from stale JWTs

## Testing
- npm test
- headed Playwright against local frontend on prod profile with live Supabase auth
- verified normal sign-in, poisoned JWT recovery, and sign-in after recovery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auth/session handling and routing/redirect behavior; mistakes could log users out unexpectedly or block access, though changes are contained to frontend session management and query gating.
> 
> **Overview**
> Hardens frontend auth recovery by refactoring `useAuthProvider` into an explicit `checking/authenticated/anonymous` state machine that validates restored sessions (JWT shape + `getUser` with timeout), clears invalid local Supabase auth storage, and surfaces a `session_expired` recovery reason.
> 
> Adds shared route guards via `AuthGate` (`RequireAuth` for `/profile`, `PublicOnly` for `/sign-in`/`/sign-up`) and updates `SignIn` to show a session-expired warning and preserve `returnTo` redirects. Dataset queries are delayed until auth bootstrap completes to reduce 401 noise, and long-running token refresh flows (uploads/corrections) now detect invalid sessions, clear local state, and prompt re-auth.
> 
> Separately adds profile-based Vite dev scripts (`dev:local`/`dev:prod`) with a new `run-vite-profile.sh` env loader and updates README env guidance; removes custom Vite HMR `clientPort` config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c0b054881668c63ccdc39cf0155120dbf376d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->