### PR TITLE
Cap ODM container memory to stop processor OOM collateral (DT-263)

### DIFF
--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -7,6 +7,12 @@ services:
     network_mode: host
     # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m processor.src.processor
     command: python -m processor.src.processor
+    # Self-heal if the processor container crashes (e.g. OOM collateral kill
+    # during a heavy ODM / treecover stage). Clean exits (exit 0 after finishing
+    # a task) are not restarted, so the existing cron-based polling model is
+    # preserved. Cap retries so a persistently broken container does not
+    # thrash forever.
+    restart: on-failure:5
     deploy:
       resources:
         limits:

--- a/processor/src/process_odm.py
+++ b/processor/src/process_odm.py
@@ -670,6 +670,16 @@ def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_i
 			stdout_logs = ''
 			exit_status = 1
 			try:
+				# Hard cap ODM container RAM via cgroups so a runaway ODM stage
+				# (texrecon / gdal ortho writeout) cannot exhaust host memory and
+				# take the processor container down with it as OOM collateral.
+				# Host has ~125 GB; processor is capped at 96 GB; leaving ODM
+				# uncapped was causing global OOM events that killed the
+				# processor mid-pipeline (see DT-263 / forensics for 8469, 8473,
+				# 8503). 100 GB is generous for ODM while guaranteeing the
+				# processor can always keep running. oom_score_adj biases the
+				# kernel OOM killer toward the ODM container if memory pressure
+				# still occurs, protecting the processor from collateral kills.
 				odm_container = client.containers.run(
 					image='opendronemap/odm',
 					command=odm_command,
@@ -677,6 +687,9 @@ def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_i
 					environment={
 						'GDAL_CACHEMAX': '16384',
 					},
+					mem_limit='100g',
+					memswap_limit='100g',
+					oom_score_adj=500,
 					remove=False,
 					detach=True,
 					name=f'dt-odm-pipeline-d{dataset_id}-{int(time.time())}',


### PR DESCRIPTION
## Summary

- Cap the ODM Docker container at **100 GB** (`mem_limit` + `memswap_limit`) and set `oom_score_adj=500` so the kernel OOM killer targets ODM rather than the processor.
- Add `restart: on-failure:5` to the processor service so it self-heals if it does crash (clean exits are not restarted, so cron polling still works).

## Why

Over the last 90 days we've had:

- **14** `Processing container crashed during odm_processing` errors (processor OOM-killed mid-pipeline)
- **5** direct `odm exit 137` ODM OOM kills
- e.g. DT-263, DT-194, DT-162, and the forensics bundles for datasets 8469 / 8473 / 8503

Root cause: the processor container has `mem_limit: 96G`, but the ODM container we launch from inside it had **no memory limit at all** on a 125 GB host. During texrecon / orthophoto writeout ODM would happily consume 60+ GB (its internal GDAL_CACHEMAX logic reads `psutil.virtual_memory().total`, which ignores cgroups and sees the full host RAM), the two containers together exceeded host memory, and the kernel OOM killer frequently picked the processor as the victim — which is why we see more "processor crashed" errors than "ODM crashed" errors even though ODM is the heavy process.

The previous attempt to bound memory via `GDAL_CACHEMAX=16384` in the container's env (DT-162) was silently overridden by ODM's own `opendm/utils.py`, which recomputes `GDAL_CACHEMAX` from its view of available RAM on every stage. Container-level cgroup limits cannot be overridden from inside the container and are therefore the correct enforcement point.

## Changes

`processor/src/process_odm.py` (inside `_run_odm_container`):

```python
odm_container = client.containers.run(
    image='opendronemap/odm',
    command=odm_command,
    volumes={volume_name: {'bind': '/odm_data', 'mode': 'rw'}},
    environment={'GDAL_CACHEMAX': '16384'},
    mem_limit='100g',        # new
    memswap_limit='100g',    # new: same value = swap disabled
    oom_score_adj=500,       # new: prefer killing ODM on global OOM
    ...
)
```

`docker-compose.processor.yaml`:

```yaml
restart: on-failure:5
```

## Why these numbers

- Host RAM: ~125 GB. Processor cgroup: 96 GB. ODM during a pipeline actually competes with a mostly-idle processor (which is blocked on `container.wait()`), so 100 GB for ODM + ~5 GB steady processor load + system = fits comfortably in 125 GB with headroom.
- `oom_score_adj=500` is a moderate positive bias (range is -1000..1000). If we ever still hit global OOM, the kernel now prefers to kill the ODM container over the processor.
- `restart: on-failure:5` does not restart on clean exit 0, so the existing cron-based "pick one task, exit, cron re-launches next minute" model is preserved. It only kicks in for crashes.

## Verification

- Full processor test suite: **93 passed, 0 failed**, 35 skipped (missing optional assets), 15 deselected (slow end-to-end ODM integration test):

  ```
  deadtrees dev test processor -- -m 'not slow'
  ```

- `docker-compose -f docker-compose.processor.yaml config` passes.
- Runtime sanity check confirming docker-py applies the args at the cgroup level:

  ```
  cat /sys/fs/cgroup/memory.max  -> 107374182400   (= exactly 100 GiB)
  cat /proc/self/oom_score_adj   -> 500
  ```

## Not in scope (follow-ups)

- Apply the same `mem_limit` + `oom_score_adj` pattern to the treecover (TCD) container — same failure mode, smaller blast radius.
- Cap `GDAL_CACHEMAX` inside `processor/src/cog.py` (gdal_translate OOMs inside the processor cgroup during COG stage).
- Increase stderr capture in `_run_odm_container` from 500 → 5000 chars and stamp `OOMKilled` into the DB error message so we don't have to dig through debug bundles.
- Explore LXCFS or a small patch to `opendm/utils.py` so ODM's internal `GDAL_CACHEMAX` auto-detection respects cgroups (would let us lower the hard cap further).
- Once `restart: on-failure:5` is verified on prod, the `* * * * * docker compose ... up` cron entry can be removed (per `.cursor/rules/AGENT.mdc`).

## Test plan

- [ ] Merge, let auto-deploy rebuild the processor on prod.
- [ ] Re-queue one of the previously failing large datasets (e.g. 8473) with `['odm', 'geotiff', 'cog', 'thumbnail', 'metadata', 'deadwood', 'treecover']`.
- [ ] Watch `docker stats` during texrecon — ODM should now plateau around 100 GB instead of climbing until the kernel intervenes.
- [ ] Confirm `deadtrees-processor-1` stays up for the duration of the ODM run (no exit 137 on the processor).
- [ ] Spot-check `journalctl -k | grep -i oom` for the period — either no kills, or only the ODM container cgroup.

Related: DT-263, DT-194, DT-162.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes container runtime resource limits and restart behavior; mis-sizing the ODM cap could surface new ODM failures (exit 137) or mask underlying crashes via retries.
> 
> **Overview**
> Reduces processor OOM collateral by **hard-capping the nested ODM container** to `100g` RAM (with swap effectively disabled via matching `memswap_limit`) and setting `oom_score_adj=500` so the kernel prefers killing ODM over the processor under global memory pressure.
> 
> Adds `restart: on-failure:5` to `docker-compose.processor.yaml` so the processor container will self-heal after crashes while preserving the existing “exit 0 after finishing a task” polling model (no restart on clean exit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4009921420f491c523771c8f4849780dcc72b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->