### PR TITLE
[codex] Add shared worktree bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # testdata
+/assets
 assets/*
 api/tests/test_data/*
 processor/src/deadwood_segmentation/models/*
@@ -158,6 +159,7 @@ celerybeat.pid
 .env
 .env.export
 .playwright-cli/
+/.local
 .local/ssh/
 .venv
 env/
@@ -197,6 +199,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 development.ipynb
+/data
 data/*
 *.geojson
 .DS_Store

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # already provided by the distro geospatial stack to avoid slow source builds.
 COPY api/requirements.txt .
 RUN pip install --upgrade pip && \
-    grep -Ev '^(rasterio==.*|geopandas|fiona|pyproj|shapely)$' requirements.txt > docker-requirements.txt && \
+    grep -Ev '^(rasterio|geopandas|fiona|pyproj|shapely)(==.*)?$' requirements.txt > docker-requirements.txt && \
     pip install -r docker-requirements.txt && \
     rm docker-requirements.txt && \
     rm requirements.txt

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,17 +1,29 @@
-# pull a Python 3.12 version
-FROM python:3.12.1
+# Start from the same GDAL image we use for processor so arm64 geospatial builds
+# can reuse distro-provided Python bindings instead of compiling from source.
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.10.3@sha256:b50822a4059629f6a579908584e25e6adccfc70a57914290dd01217f19871d08
 
-# install GDAL and the matching pathon bindings
-# TODO: THIS IS QUICK AND DIRTY. This is only necessary, because utils subpackage uses the type annotations
-# of rasterio, which in turn needs GDAL to be present.
-RUN apt-get update && apt-get install -y gdal-bin libgdal-dev && \
-    pip install --upgrade pip && \
-    pip install GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}')
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    curl \
+    python3-fiona \
+    python3-rasterio \
+    python3-shapely \
+    python3-geopandas \
+    python3-pyproj \
+    && rm -rf /var/lib/apt/lists/*
 
-# install everything
+RUN python3 -m venv /opt/venv --system-site-packages
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Keep api/requirements.txt as the source of truth, but skip packages that are
+# already provided by the distro geospatial stack to avoid slow source builds.
 COPY api/requirements.txt .
 RUN pip install --upgrade pip && \
-    pip install -r requirements.txt && \
+    grep -Ev '^(rasterio==.*|geopandas|fiona|pyproj|shapely)$' requirements.txt > docker-requirements.txt && \
+    pip install -r docker-requirements.txt && \
+    rm docker-requirements.txt && \
     rm requirements.txt
 
 # create a folder for the application

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -27,3 +27,4 @@ fiona
 pillow
 pyproj
 shapely
+pyogrio

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -20,12 +20,29 @@ from shared.models import (
 	PlatformEnum,
 )
 
+DEFAULT_COMPOSE_PROJECT_NAME = 'deadtrees-test'
+SERVICE_DEPENDENCIES = {
+	'api-test': ['api-test', 'nginx', 'mailpit'],
+	'processor-test': ['processor-test', 'nginx'],
+}
+SERVICE_BUILD_FILES = {
+	'api-test': ['api/Dockerfile', 'api/requirements.txt'],
+	'processor-test': [
+		'processor/Dockerfile',
+		'processor/requirements.txt',
+		'processor/src/deadwood_segmentation/deadtreesmodels/requirements.txt',
+	],
+	'nginx': ['nginx/test-conf/Dockerfile', 'nginx/test-conf/storage-server.conf', 'nginx/test-conf/entrypoint.sh'],
+}
+
 
 class DevCommands:
 	"""Development environment management commands"""
 
 	def __init__(self):
 		self.test_compose_file = 'docker-compose.test.yaml'
+		self.compose_env = os.environ.copy()
+		self.compose_env.setdefault('COMPOSE_PROJECT_NAME', DEFAULT_COMPOSE_PROJECT_NAME)
 
 	def _compose_cmd(self, *args: str) -> List[str]:
 		"""Build a docker compose command for the test environment."""
@@ -46,7 +63,7 @@ class DevCommands:
 	def _run_command(self, command: List[str], check: bool = True) -> subprocess.CompletedProcess:
 		"""Run a shell command and handle errors"""
 		try:
-			return subprocess.run(command, check=check)
+			return subprocess.run(command, check=check, env=self.compose_env)
 		except subprocess.CalledProcessError as e:
 			print(f'Error executing command: {" ".join(command)}')
 			print(f'Error: {str(e)}')
@@ -59,6 +76,7 @@ class DevCommands:
 			capture_output=True,
 			text=True,
 			check=True,
+			env=self.compose_env,
 		)
 		return [service for service in result.stdout.strip().split('\n') if service]
 
@@ -69,6 +87,7 @@ class DevCommands:
 			capture_output=True,
 			text=True,
 			check=False,
+			env=self.compose_env,
 		)
 		if result.returncode != 0:
 			return {}
@@ -86,6 +105,10 @@ class DevCommands:
 		"""Check whether a compose service is currently running."""
 		record = self._get_service_statuses().get(service)
 		return bool(record and record.get('State') == 'running')
+
+	def _services_for_target(self, service: str) -> List[str]:
+		"""Return the compose services required for a given test target."""
+		return SERVICE_DEPENDENCIES.get(service, [service])
 
 	def _wait_for_services_ready(self, services: List[str], timeout_seconds: int = 90):
 		"""Wait until all requested services are running and healthy when health checks exist."""
@@ -118,52 +141,62 @@ class DevCommands:
 		raise RuntimeError(f'Timed out waiting for test services to become ready: {", ".join(pending)}')
 
 	def _ensure_test_service_running(self, service: str):
-		"""Start the test stack if the requested service is not already running."""
-		if not self._is_service_running(service):
-			print(f'Service "{service}" is not running. Starting test environment...')
+		"""Start only the services needed for the requested test target."""
+		required_services = self._services_for_target(service)
+		missing_services = [required for required in required_services if not self._is_service_running(required)]
+		if missing_services:
+			print(f'Services not running for "{service}": {", ".join(missing_services)}. Starting shared test services...')
 			try:
-				self.start()
+				self.start(services=required_services)
 			except subprocess.CalledProcessError:
 				# Compose can report a startup conflict while still leaving the requested
 				# service running. Re-check before surfacing the failure.
-				if not self._is_service_running(service):
+				still_missing = [required for required in required_services if not self._is_service_running(required)]
+				if still_missing:
 					raise
-				print(f'Service "{service}" is now running despite compose startup warnings. Continuing...')
+				print(f'Shared test services for "{service}" are now running despite compose startup warnings. Continuing...')
 
-		self._wait_for_services_ready(self._get_compose_services())
+		self._wait_for_services_ready(required_services)
 
-	def _check_rebuild_needed(self) -> List[str]:
+	def _check_rebuild_needed(self, services: Optional[List[str]] = None) -> List[str]:
 		"""Check which services need rebuilding by comparing image and dockerfile timestamps"""
 		services_to_rebuild = []
 
-		# Get list of all services
-		services = self._get_compose_services()
+		service_names = services or self._get_compose_services()
 
-		for service in services:
+		for service in service_names:
+			build_files = [Path(path) for path in SERVICE_BUILD_FILES.get(service, [f'{service}/Dockerfile'])]
+			existing_build_files = [path for path in build_files if path.exists()]
+			if not existing_build_files:
+				continue
+
 			# Check if image exists
-			result = subprocess.run(self._compose_cmd('images', '-q', service), capture_output=True, text=True, check=False)
+			result = subprocess.run(
+				self._compose_cmd('images', '-q', service),
+				capture_output=True,
+				text=True,
+				check=False,
+				env=self.compose_env,
+			)
 
 			if not result.stdout.strip():
 				services_to_rebuild.append(service)
 				continue
 
-			# Get Dockerfile timestamp if it exists
-			dockerfile_path = f'./{service}/Dockerfile'
-			if os.path.exists(dockerfile_path):
-				dockerfile_mtime = os.path.getmtime(dockerfile_path)
+			image_id = result.stdout.strip().splitlines()[-1]
+			image_created = subprocess.run(
+				['docker', 'image', 'inspect', '-f', '{{.Created}}', image_id],
+				capture_output=True,
+				text=True,
+				check=False,
+			)
+			if image_created.returncode != 0:
+				services_to_rebuild.append(service)
+				continue
 
-				# Get image creation timestamp
-				result = subprocess.run(
-					['docker', 'inspect', '-f', '{{.Created}}', f'deadwood_network-{service}'],
-					capture_output=True,
-					text=True,
-					check=False,
-				)
-
-				if result.returncode == 0:
-					image_timestamp = datetime.fromisoformat(result.stdout.strip().replace('Z', '+00:00'))
-					if dockerfile_mtime > image_timestamp.timestamp():
-						services_to_rebuild.append(service)
+			image_timestamp = datetime.fromisoformat(image_created.stdout.strip().replace('Z', '+00:00')).timestamp()
+			if any(path.stat().st_mtime > image_timestamp for path in existing_build_files):
+				services_to_rebuild.append(service)
 
 		return services_to_rebuild
 
@@ -457,18 +490,19 @@ class DevCommands:
 		except Exception as e:
 			print(f'⚠ Cleanup error: {str(e)}')
 
-	def start(self, force_rebuild: bool = False):
-		"""Start the test environment and rebuild containers if needed"""
+	def start(self, force_rebuild: bool = False, services: Optional[List[str]] = None):
+		"""Start the shared test environment, optionally scoped to a subset of services."""
+		selected_services = services or self._get_compose_services()
 		if force_rebuild:
-			self._run_command(self._compose_lifecycle_cmd('up', flags=['-d', '--build']))
+			self._run_command(self._compose_lifecycle_cmd('up', flags=['-d', '--build'], services=selected_services))
 			return
 		else:
-			services_to_rebuild = self._check_rebuild_needed()
+			services_to_rebuild = self._check_rebuild_needed(selected_services)
 			if services_to_rebuild:
 				print(f'Rebuilding services: {", ".join(services_to_rebuild)}')
 				self._run_command(self._compose_cmd('build', *services_to_rebuild))
 
-		self._run_command(self._compose_lifecycle_cmd('up', flags=['-d']))
+		self._run_command(self._compose_lifecycle_cmd('up', flags=['-d'], services=selected_services))
 
 	def up(self, force_rebuild: bool = False):
 		"""Alias for start() to match the documented CLI examples."""

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -141,20 +141,23 @@ class DevCommands:
 		raise RuntimeError(f'Timed out waiting for test services to become ready: {", ".join(pending)}')
 
 	def _ensure_test_service_running(self, service: str):
-		"""Start only the services needed for the requested test target."""
+		"""Refresh only the services needed for the requested test target."""
 		required_services = self._services_for_target(service)
 		missing_services = [required for required in required_services if not self._is_service_running(required)]
 		if missing_services:
 			print(f'Services not running for "{service}": {", ".join(missing_services)}. Starting shared test services...')
-			try:
-				self.start(services=required_services)
-			except subprocess.CalledProcessError:
-				# Compose can report a startup conflict while still leaving the requested
-				# service running. Re-check before surfacing the failure.
-				still_missing = [required for required in required_services if not self._is_service_running(required)]
-				if still_missing:
-					raise
-				print(f'Shared test services for "{service}" are now running despite compose startup warnings. Continuing...')
+		else:
+			print(f'Refreshing shared test services for "{service}" so this worktree owns the active bind mounts...')
+
+		try:
+			self.start(services=required_services)
+		except subprocess.CalledProcessError:
+			# Compose can report a startup conflict while still leaving the requested
+			# services running. Re-check before surfacing the failure.
+			still_missing = [required for required in required_services if not self._is_service_running(required)]
+			if still_missing:
+				raise
+			print(f'Shared test services for "{service}" are now running despite compose startup warnings. Continuing...')
 
 		self._wait_for_services_ready(required_services)
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -205,6 +205,21 @@ This writes an ignored keypair to `.local/ssh/processing-to-storage` and `.local
 If you prefer a different key location, set absolute paths in `LOCAL_TEST_SSH_PRIVATE_KEY_PATH` and
 `LOCAL_TEST_SSH_PUBLIC_KEY_PATH` before running `docker compose -f docker-compose.test.yaml ...`.
 
+## Codex app worktrees
+
+If you use the Codex desktop app, configure a project Local Environment so new
+Dead Trees worktrees bootstrap themselves automatically.
+
+- Setup script: `bash scripts/setup-worktree.sh`
+- Suggested actions:
+  - `source venv/bin/activate && deadtrees dev test api`
+  - `source venv/bin/activate && deadtrees dev test processor`
+  - `npm --prefix frontend test`
+
+The setup script auto-detects the primary checkout from `git worktree list`,
+so a Codex-created worktree will reuse the main checkout for shared `assets`,
+`data`, and `.local/ssh` without hardcoding a machine-specific path.
+
 ## Project structure
 
 ```bash

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -7,6 +7,7 @@ server {
     server_name localhost;
     listen 80 default_server;
     listen [::]:80 default_server;
+    resolver 127.0.0.11 ipv6=off;
 
     client_max_body_size 10G;
 
@@ -16,7 +17,8 @@ server {
 
     location /api/v1 {
         rewrite  ^/api/v1/?(.*)$ /$1 break;
-        proxy_pass http://api-test:8017;
+        set $api_test_upstream http://api-test:8017;
+        proxy_pass $api_test_upstream;
         
         # Standard proxy headers
         proxy_set_header Host $host;

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -210,8 +210,14 @@ ensure_assets_and_keys() {
 
 require_command git
 require_command python3
-require_command npm
-require_command make
+
+if [[ "$INSTALL_FRONTEND" == true ]]; then
+  require_command npm
+fi
+
+if [[ "$ENSURE_ASSETS" == true ]]; then
+  require_command make
+fi
 
 if [[ -z "$SHARED_ROOT" ]]; then
   SHARED_ROOT="$(detect_default_shared_root)"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+DEFAULT_COMPOSE_PROJECT_NAME="deadtrees-test"
+SHARED_ROOT=""
+LINK_SHARED=true
+INSTALL_FRONTEND=true
+INSTALL_PYTHON=true
+ENSURE_ASSETS=true
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/setup-worktree.sh [options]
+
+Prepare a Dead Trees git worktree so it can run frontend, API, and processor tests
+without duplicating the local Supabase database or heavy asset directories.
+
+Options:
+  --shared-root PATH       Use PATH as the canonical checkout for shared assets/data
+  --no-link-shared         Keep local assets/data/.local instead of symlinking
+  --skip-frontend-install  Do not run npm --prefix frontend ci
+  --skip-python-install    Do not create/update venv or install deadtrees-cli
+  --skip-assets            Do not download missing test assets
+  -h, --help               Show this help
+EOF
+}
+
+log() {
+  printf '[setup-worktree] %s\n' "$*"
+}
+
+die() {
+  printf '[setup-worktree] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+relative_to_repo_root() {
+  python3 - "$REPO_ROOT" "$1" <<'PY'
+from pathlib import Path
+import sys
+
+repo_root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+
+try:
+    print(target.relative_to(repo_root))
+except ValueError:
+    print(target)
+PY
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --shared-root)
+      [[ $# -ge 2 ]] || die "--shared-root requires a path"
+      SHARED_ROOT="$2"
+      shift 2
+      ;;
+    --no-link-shared)
+      LINK_SHARED=false
+      shift
+      ;;
+    --skip-frontend-install)
+      INSTALL_FRONTEND=false
+      shift
+      ;;
+    --skip-python-install)
+      INSTALL_PYTHON=false
+      shift
+      ;;
+    --skip-assets)
+      ENSURE_ASSETS=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+detect_default_shared_root() {
+  local first_worktree
+  first_worktree="$(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')"
+  if [[ -n "$first_worktree" ]]; then
+    printf '%s\n' "$first_worktree"
+  fi
+}
+
+ensure_file_from_example() {
+  local target="$1"
+  local example="$2"
+
+  if [[ -e "$target" ]]; then
+    return
+  fi
+
+  cp "$example" "$target"
+  log "Created $(relative_to_repo_root "$target") from example"
+}
+
+ensure_env_line() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+
+  if [[ ! -f "$file" ]]; then
+    touch "$file"
+  fi
+
+  if grep -Eq "^${key}=" "$file"; then
+    return
+  fi
+
+  printf '\n%s=%s\n' "$key" "$value" >>"$file"
+  log "Added ${key} to $(relative_to_repo_root "$file")"
+}
+
+dir_is_empty() {
+  local path="$1"
+  [[ -d "$path" ]] && [[ -z "$(find "$path" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]
+}
+
+link_shared_path() {
+  local relative_path="$1"
+  local source_path="$SHARED_ROOT/$relative_path"
+  local target_path="$REPO_ROOT/$relative_path"
+
+  if [[ "$SHARED_ROOT" == "$REPO_ROOT" ]]; then
+    return
+  fi
+
+  if [[ ! -e "$source_path" ]]; then
+    log "Shared path missing, skipping link: $relative_path"
+    return
+  fi
+
+  mkdir -p "$(dirname "$target_path")"
+
+  if [[ -L "$target_path" ]]; then
+    if [[ "$(readlink "$target_path")" == "$source_path" ]]; then
+      return
+    fi
+    rm "$target_path"
+  elif [[ -d "$target_path" ]] && dir_is_empty "$target_path"; then
+    rmdir "$target_path"
+  elif [[ -e "$target_path" ]]; then
+    log "Keeping existing local path: $relative_path"
+    return
+  fi
+
+  ln -s "$source_path" "$target_path"
+  log "Linked $relative_path -> $source_path"
+}
+
+ensure_python_env() {
+  if [[ ! -d "$REPO_ROOT/venv" ]]; then
+    python3 -m venv "$REPO_ROOT/venv"
+    log "Created venv"
+  fi
+
+  "$REPO_ROOT/venv/bin/python" -m pip install --upgrade pip
+  "$REPO_ROOT/venv/bin/pip" install -e "$REPO_ROOT/deadtrees-cli[test]"
+}
+
+ensure_frontend_deps() {
+  npm --prefix "$REPO_ROOT/frontend" ci
+}
+
+ensure_assets_and_keys() {
+  local need_assets=false
+  local need_processor_assets=false
+  local need_ssh=false
+
+  [[ -f "$REPO_ROOT/assets/test_data/test-data.tif" ]] || need_assets=true
+  [[ -f "$REPO_ROOT/assets/test_data/test-data-small.tif" ]] || need_assets=true
+  [[ -f "$REPO_ROOT/assets/models/segformer_b5_full_epoch_100.safetensors" ]] || need_assets=true
+  [[ -f "$REPO_ROOT/assets/gadm/gadm_410.gpkg" ]] || need_assets=true
+
+  [[ -f "$REPO_ROOT/assets/biom/terres_ecosystems.gpkg" ]] || need_processor_assets=true
+  [[ -d "$REPO_ROOT/assets/pheno/modispheno_aggregated_normalized_filled.zarr" ]] || need_processor_assets=true
+  [[ -f "$REPO_ROOT/assets/test_data/worldview_uint16_crop.tif" ]] || need_processor_assets=true
+
+  [[ -f "$REPO_ROOT/.local/ssh/processing-to-storage" ]] || need_ssh=true
+  [[ -f "$REPO_ROOT/.local/ssh/processing-to-storage.pub" ]] || need_ssh=true
+
+  if [[ "$need_assets" == true ]]; then
+    make -C "$REPO_ROOT" download-assets
+  fi
+
+  if [[ "$need_processor_assets" == true ]]; then
+    make -C "$REPO_ROOT" download-processor-assets
+  fi
+
+  if [[ "$need_ssh" == true ]]; then
+    make -C "$REPO_ROOT" setup-local-test-ssh
+  fi
+}
+
+require_command git
+require_command python3
+require_command npm
+require_command make
+
+if [[ -z "$SHARED_ROOT" ]]; then
+  SHARED_ROOT="$(detect_default_shared_root)"
+fi
+
+if [[ -z "$SHARED_ROOT" ]]; then
+  SHARED_ROOT="$REPO_ROOT"
+fi
+
+[[ -d "$SHARED_ROOT" ]] || die "Shared root does not exist: $SHARED_ROOT"
+
+log "Repo root: $REPO_ROOT"
+log "Shared root: $SHARED_ROOT"
+
+git -C "$REPO_ROOT" submodule update --init --recursive
+
+ensure_file_from_example "$REPO_ROOT/.env" "$REPO_ROOT/.env.example"
+ensure_file_from_example "$REPO_ROOT/frontend/.env.local" "$REPO_ROOT/frontend/.env.local.example"
+ensure_env_line "$REPO_ROOT/.env" "COMPOSE_PROJECT_NAME" "$DEFAULT_COMPOSE_PROJECT_NAME"
+
+if [[ "$LINK_SHARED" == true ]]; then
+  link_shared_path "assets"
+  link_shared_path "data"
+  link_shared_path ".local/ssh"
+fi
+
+if [[ "$INSTALL_PYTHON" == true ]]; then
+  ensure_python_env
+fi
+
+if [[ "$INSTALL_FRONTEND" == true ]]; then
+  ensure_frontend_deps
+fi
+
+if [[ "$ENSURE_ASSETS" == true ]]; then
+  ensure_assets_and_keys
+fi
+
+cat <<EOF
+
+Worktree setup complete.
+
+What this prepared:
+  - repo env files
+  - stable Docker compose project name (${DEFAULT_COMPOSE_PROJECT_NAME})
+  - git submodules
+  - per-worktree Python CLI environment
+  - per-worktree frontend dependencies
+  - shared heavy paths where available (assets, data, .local/ssh)
+
+Typical next steps:
+  source "$REPO_ROOT/venv/bin/activate"
+  deadtrees dev start
+  deadtrees dev test api
+  deadtrees dev test processor
+  npm --prefix frontend test
+
+Notes:
+  - The local Supabase stack still needs to be running separately on port 54321.
+  - deadtrees dev start/test will reuse the single Docker compose project name above,
+    so one worktree can take over the shared test containers without duplicating them.
+EOF


### PR DESCRIPTION
## What changed

This adds a shared worktree bootstrap flow for local Dead Trees development and test runs.

- adds `scripts/setup-worktree.sh` to bootstrap new worktrees, reuse shared heavy paths, and prepare per-worktree dependencies
- makes `deadtrees dev test api` and `deadtrees dev test processor` start only the services they need under a stable shared compose project name
- fixes test-image rebuild detection so Docker rebuilds when real build inputs change
- updates nginx test config so processor-only runs do not fail when `api-test` is not running
- documents the Codex local-environment setup for new worktrees
- keeps the API requirements file authoritative while using distro geospatial packages in Docker to avoid slow/failing source builds on local arm64 setups

## Why

New worktrees were not reliably able to run the full local API and processor test flows without duplicating heavy assets or rebuilding isolated test stacks. The goal here is to let Codex-created and manual git worktrees reuse the same shared local test infrastructure.

## Impact

- new worktrees can bootstrap themselves with `bash scripts/setup-worktree.sh`
- API and processor tests can run from a fresh worktree against the shared `deadtrees-test` stack
- local Docker rebuild behavior is more predictable when image inputs change

## Validation

- `deadtrees dev test api` -> `156 passed in 76.30s`
- `deadtrees dev test processor` -> `93 passed, 35 skipped, 15 deselected in 34.34s`
- `bash -n scripts/setup-worktree.sh`
- `python3 -m py_compile deadtrees-cli/deadtrees_cli/dev.py`

## Note

The API Dockerfile change also affects the regular API image build path, not only the local test stack. Local validation is green, but CI should still validate the release image on `linux/amd64` as usual.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the API Docker base image/dependency installation and alters local test-stack orchestration/rebuild behavior, which could affect container builds and developer workflows across platforms.
> 
> **Overview**
> Adds a new `scripts/setup-worktree.sh` bootstrap flow for git worktrees, including creating env files, installing per-worktree Python/frontend deps, and optionally symlinking shared heavy directories (`assets`, `data`, `.local/ssh`) to avoid duplication.
> 
> Updates `deadtrees dev` test orchestration to use a stable `COMPOSE_PROJECT_NAME`, start only the service subset needed for `api-test` vs `processor-test`, and improve rebuild detection by tracking actual build inputs (not hardcoded image names). Also adjusts nginx test config to resolve/route `/api/v1` via a variable so processor-only runs don’t hard-fail when `api-test` isn’t up.
> 
> Switches the API Docker image to an OSGeo GDAL base and uses distro-provided geospatial Python packages while filtering them out of `pip` installs; `api/requirements.txt` adds `pyogrio`. `.gitignore` now ignores top-level `assets/`, `data/`, and `.local/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5ab6b8c9963bdadb404eaf9bd9db8dcdb959f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->