### PR TITLE
[codex] Fix PostHog reinitialization for analytics v1

### DIFF
--- a/docs/analytics/aarrr-framework.md
+++ b/docs/analytics/aarrr-framework.md
@@ -1,0 +1,83 @@
+# Deadtrees AARRR Analytics
+
+This document is the source-of-truth for the current Deadtrees analytics v1 migration.
+
+## Current Production Status
+
+- The live website is reachable and core flows such as homepage, sign-in, and profile load normally.
+- Production analytics are currently undercounting because PostHog initialization can be skipped after deploys when old consent state is present in the browser.
+- The existing AARRR overview dashboard already exists in PostHog, but named product events are effectively absent in production history until the initialization fix is deployed.
+- The companion dashboards for contribution funnels, retention, and friction were created as shells but were not populated with insights.
+
+## AARRR Event Map
+
+### Acquisition
+
+- `$pageview`
+- `landing_cta_clicked`
+- `newsletter_signup_submitted`
+- `dataset_archive_viewed`
+- `dataset_search_used`
+- `dataset_filter_applied`
+- `dataset_map_interacted`
+- `dataset_opened`
+
+### Activation
+
+- `sign_up_started`
+- `sign_up_completed`
+- `sign_in_completed`
+- `upload_started`
+- `upload_completed`
+- `processing_result_viewed`
+
+### Retention / Value
+
+- `dataset_download_started`
+- `dataset_download_completed`
+- `edit_started`
+- `edit_saved`
+- `publish_started`
+- `publish_submitted`
+- `publish_completed`
+
+### Referral / Community
+
+- `newsletter_signup_submitted`
+- `email_link_clicked`
+
+### Core Team / Operations
+
+- `audit_queue_viewed`
+- `audit_started`
+- `audit_completed`
+- `correction_review_started`
+- `correction_approved`
+- `correction_reverted`
+- `reference_patch_editor_opened`
+- `flag_submitted`
+- `upload_failed`
+- `dataset_download_failed`
+- `publish_failed`
+
+## Existing PostHog Dashboards
+
+- `623122`: `Analytics V1 - AARRR Overview`
+- `623123`: `Analytics V1 - Contribution Funnel`
+- `623124`: `Analytics V1 - Retention and Cohorts`
+- `623125`: `Analytics V1 - Core Team Audit`
+- `623126`: `Analytics V1 - Friction and Errors`
+
+## What Was Broken
+
+- PostHog init treated persisted opt-in or opt-out state as if the current page had already initialized the SDK.
+- Returning browsers could therefore skip `posthog.init(...)` after the analytics rollout.
+- If consent changed from pending to accepted on the same page, PostHog could remain in limited mode instead of switching to cookie-backed persistence and autocapture.
+- The AARRR companion dashboards existed, but several were still empty and did not yet provide operational visibility.
+
+## What Needs To Happen
+
+- Deploy the frontend analytics initialization fix.
+- Verify that named events begin appearing in production again.
+- Keep the AARRR dashboards attached to the current event names instead of creating a second competing taxonomy.
+- Treat `Referral` as a light-weight stage for now; Deadtrees does not yet have a deeper invite or share loop instrumented.

--- a/frontend/src/utils/analytics.test.ts
+++ b/frontend/src/utils/analytics.test.ts
@@ -1,10 +1,61 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  createAnalyticsPayload,
-  deriveUserSegment,
-  sanitizeEventProperties,
-} from "./analytics";
+const posthogMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  has_opted_in_capturing: vi.fn(() => false),
+  has_opted_out_capturing: vi.fn(() => false),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: posthogMock,
+}));
+
+let createAnalyticsPayload: typeof import("./analytics").createAnalyticsPayload;
+let deriveUserSegment: typeof import("./analytics").deriveUserSegment;
+let initializePostHog: typeof import("./analytics").initializePostHog;
+let sanitizeEventProperties: typeof import("./analytics").sanitizeEventProperties;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.stubEnv("VITE_POSTHOG_PROJECT_KEY", "ph_test_key");
+  const storage = (() => {
+    const values = new Map<string, string>();
+    return {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+  })();
+  vi.stubGlobal("localStorage", storage);
+  vi.stubGlobal("window", {
+    location: {
+      href: "https://deadtrees.earth/",
+      origin: "https://deadtrees.earth",
+      pathname: "/",
+      search: "",
+    },
+    localStorage: storage,
+  });
+  storage.clear();
+  Object.values(posthogMock).forEach((value) => {
+    if ("mockReset" in value) {
+      value.mockReset();
+    }
+  });
+  posthogMock.has_opted_in_capturing.mockReturnValue(false);
+  posthogMock.has_opted_out_capturing.mockReturnValue(false);
+
+  const analytics = await import("./analytics");
+  createAnalyticsPayload = analytics.createAnalyticsPayload;
+  deriveUserSegment = analytics.deriveUserSegment;
+  initializePostHog = analytics.initializePostHog;
+  sanitizeEventProperties = analytics.sanitizeEventProperties;
+});
 
 describe("deriveUserSegment", () => {
   it("classifies anonymous users as visitors", () => {
@@ -97,5 +148,58 @@ describe("createAnalyticsPayload", () => {
     expect(payload.source_surface).toBe("profile");
     expect(payload.is_logged_in).toBe(true);
     expect(payload.user_segment).toBe("contributor");
+  });
+});
+
+describe("initializePostHog", () => {
+  it("initializes PostHog even when an old opt-in cookie exists", () => {
+    localStorage.setItem("cookieConsent", "accepted");
+    localStorage.setItem("cookieConsentVersion", "1.0");
+    posthogMock.has_opted_in_capturing.mockReturnValue(true);
+
+    initializePostHog();
+
+    expect(posthogMock.init).toHaveBeenCalledWith(
+      "ph_test_key",
+      expect.objectContaining({
+        persistence: "memory",
+        autocapture: false,
+        capture_pageview: true,
+      }),
+    );
+  });
+
+  it("initializes PostHog only once per page load", () => {
+    initializePostHog("accepted");
+    initializePostHog("accepted");
+
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
+  });
+
+  it("reinitializes PostHog when consent changes from limited to accepted", () => {
+    initializePostHog("pending");
+    initializePostHog("accepted");
+
+    expect(posthogMock.init).toHaveBeenCalledTimes(2);
+    expect(posthogMock.init).toHaveBeenNthCalledWith(
+      1,
+      "ph_test_key",
+      expect.objectContaining({
+        persistence: "memory",
+        autocapture: false,
+        capture_pageview: true,
+        capture_pageleave: false,
+      }),
+    );
+    expect(posthogMock.init).toHaveBeenNthCalledWith(
+      2,
+      "ph_test_key",
+      expect.objectContaining({
+        persistence: "cookie",
+        autocapture: true,
+        capture_pageview: true,
+        capture_pageleave: true,
+      }),
+    );
   });
 });

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -2,6 +2,7 @@ import { User } from "@supabase/supabase-js";
 import posthog from "posthog-js";
 
 const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_PROJECT_KEY as string | undefined;
+let initializedPostHogMode: "limited" | "accepted" | null = null;
 
 export const COOKIE_CONSENT_VERSION = "1.1";
 export const COOKIE_CONSENT_KEY = "cookieConsent";
@@ -314,13 +315,6 @@ export const saveConsent = (consent: "accepted" | "rejected"): void => {
 export const initializePostHog = (consent: string | null = null): void => {
   if (!isPostHogAvailable() || !POSTHOG_PROJECT_KEY) return;
 
-  if (
-    (consent === "accepted" && posthog.has_opted_in_capturing()) ||
-    (consent === "rejected" && posthog.has_opted_out_capturing())
-  ) {
-    return;
-  }
-
   if (consent === null) {
     const storage = getStorage();
     consent = storage?.getItem(COOKIE_CONSENT_KEY) ?? null;
@@ -330,14 +324,20 @@ export const initializePostHog = (consent: string | null = null): void => {
     }
   }
 
-  if (!posthog.has_opted_in_capturing() && !posthog.has_opted_out_capturing()) {
+  const mode = consent === "accepted" ? "accepted" : "limited";
+
+  // Persisted opt-in/out flags survive reloads, so they are not a safe proxy for whether
+  // the current page has actually initialized PostHog after a deploy. We also need to
+  // reconfigure PostHog when consent changes from limited mode to full cookie-backed mode.
+  if (initializedPostHogMode !== mode) {
     posthog.init(POSTHOG_PROJECT_KEY, {
       api_host: "https://eu.i.posthog.com",
-      persistence: consent === "accepted" ? "cookie" : "memory",
-      autocapture: consent === "accepted",
+      persistence: mode === "accepted" ? "cookie" : "memory",
+      autocapture: mode === "accepted",
       capture_pageview: true,
-      capture_pageleave: consent === "accepted",
+      capture_pageleave: mode === "accepted",
     });
+    initializedPostHogMode = mode;
   }
 
   if (consent === "accepted" && !posthog.has_opted_in_capturing()) {


### PR DESCRIPTION
## What changed

This PR fixes the Deadtrees analytics v1 bootstrap path so PostHog is initialized reliably after deploys and when cookie consent changes during a session.

It also adds regression tests for the broken reinitialization cases and documents the current AARRR event model and rollout state in the repo.

## Why it changed

Production PostHog data showed a sharp collapse in named product events after the analytics v1 rollout, while the live site itself still loaded and `$exception` events continued to flow.

The root cause was that `initializePostHog()` treated persisted opt-in or opt-out state as if the SDK had already been initialized on the current page. Returning browsers could therefore skip `posthog.init(...)` entirely after a deploy. There was also a second edge case where moving from pending consent to accepted consent on the same page could leave PostHog in limited mode.

## Impact

Once deployed, this should restore the named AARRR event stream in production so the existing PostHog dashboards become meaningful again.

The PR does not change the public product flow itself. It repairs analytics initialization and clarifies the current analytics framework.

## Validation

- `npm --prefix frontend test -- analytics.test.ts`
- Verified the live app in Chrome loads and sign-in works, which supports the conclusion that analytics were broken more than the site itself
- Populated the existing PostHog AARRR companion dashboards and added a regression annotation around `2026-04-15 13:00 UTC`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the analytics bootstrap/consent flow by reworking when `posthog.init` runs, which could affect event capture and cookie persistence behavior across sessions.
> 
> **Overview**
> Fixes PostHog undercounting by ensuring `initializePostHog()` no longer skips `posthog.init(...)` based on persisted opt-in/out flags, and by re-initializing when the page transitions between *limited* (memory/no autocapture) and *accepted* (cookie/autocapture) modes.
> 
> Adds Vitest coverage with a mocked `posthog-js` to lock in the regression cases (old consent state after deploy, init only once per page load, and reinit when consent changes). Also adds `docs/analytics/aarrr-framework.md` documenting the current AARRR event taxonomy, dashboard IDs, and rollout status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6e9260f6c47bb5bed90b9631eeaa3a13feaf81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->