### PR TITLE
[codex] Fix PostHog consent upgrade path

### DIFF
--- a/frontend/src/utils/analytics.test.ts
+++ b/frontend/src/utils/analytics.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const posthogMock = vi.hoisted(() => ({
   init: vi.fn(),
+  set_config: vi.fn(),
   capture: vi.fn(),
   identify: vi.fn(),
   opt_in_capturing: vi.fn(),
   opt_out_capturing: vi.fn(),
+  clear_opt_in_out_capturing: vi.fn(),
   has_opted_in_capturing: vi.fn(() => false),
   has_opted_out_capturing: vi.fn(() => false),
 }));
@@ -167,6 +169,7 @@ describe("initializePostHog", () => {
         capture_pageview: true,
       }),
     );
+    expect(posthogMock.clear_opt_in_out_capturing).toHaveBeenCalledTimes(1);
   });
 
   it("initializes PostHog only once per page load", () => {
@@ -174,13 +177,14 @@ describe("initializePostHog", () => {
     initializePostHog("accepted");
 
     expect(posthogMock.init).toHaveBeenCalledTimes(1);
+    expect(posthogMock.set_config).not.toHaveBeenCalled();
   });
 
-  it("reinitializes PostHog when consent changes from limited to accepted", () => {
+  it("updates PostHog config when consent changes from limited to accepted", () => {
     initializePostHog("pending");
     initializePostHog("accepted");
 
-    expect(posthogMock.init).toHaveBeenCalledTimes(2);
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
     expect(posthogMock.init).toHaveBeenNthCalledWith(
       1,
       "ph_test_key",
@@ -191,9 +195,8 @@ describe("initializePostHog", () => {
         capture_pageleave: false,
       }),
     );
-    expect(posthogMock.init).toHaveBeenNthCalledWith(
-      2,
-      "ph_test_key",
+    expect(posthogMock.set_config).toHaveBeenCalledTimes(1);
+    expect(posthogMock.set_config).toHaveBeenCalledWith(
       expect.objectContaining({
         persistence: "cookie",
         autocapture: true,
@@ -201,5 +204,14 @@ describe("initializePostHog", () => {
         capture_pageleave: true,
       }),
     );
+    expect(posthogMock.opt_in_capturing).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears stale opt status while consent is pending", () => {
+    posthogMock.has_opted_out_capturing.mockReturnValue(true);
+
+    initializePostHog("pending");
+
+    expect(posthogMock.clear_opt_in_out_capturing).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -2,6 +2,7 @@ import { User } from "@supabase/supabase-js";
 import posthog from "posthog-js";
 
 const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_PROJECT_KEY as string | undefined;
+let hasInitializedPostHog = false;
 let initializedPostHogMode: "limited" | "accepted" | null = null;
 
 export const COOKIE_CONSENT_VERSION = "1.1";
@@ -325,18 +326,24 @@ export const initializePostHog = (consent: string | null = null): void => {
   }
 
   const mode = consent === "accepted" ? "accepted" : "limited";
+  const posthogConfig = {
+    api_host: "https://eu.i.posthog.com",
+    persistence: mode === "accepted" ? "cookie" : "memory",
+    autocapture: mode === "accepted",
+    capture_pageview: true,
+    capture_pageleave: mode === "accepted",
+  } as const;
 
   // Persisted opt-in/out flags survive reloads, so they are not a safe proxy for whether
-  // the current page has actually initialized PostHog after a deploy. We also need to
-  // reconfigure PostHog when consent changes from limited mode to full cookie-backed mode.
-  if (initializedPostHogMode !== mode) {
-    posthog.init(POSTHOG_PROJECT_KEY, {
-      api_host: "https://eu.i.posthog.com",
-      persistence: mode === "accepted" ? "cookie" : "memory",
-      autocapture: mode === "accepted",
-      capture_pageview: true,
-      capture_pageleave: mode === "accepted",
-    });
+  // the current page has actually initialized PostHog after a deploy. We initialize the
+  // SDK once per page load, then use set_config for consent upgrades because posthog.init()
+  // becomes a no-op after the first successful initialization.
+  if (!hasInitializedPostHog) {
+    posthog.init(POSTHOG_PROJECT_KEY, posthogConfig);
+    hasInitializedPostHog = true;
+    initializedPostHogMode = mode;
+  } else if (initializedPostHogMode !== mode) {
+    posthog.set_config(posthogConfig);
     initializedPostHogMode = mode;
   }
 
@@ -344,6 +351,8 @@ export const initializePostHog = (consent: string | null = null): void => {
     posthog.opt_in_capturing();
   } else if (consent === "rejected" && !posthog.has_opted_out_capturing()) {
     posthog.opt_out_capturing();
+  } else if (consent !== "accepted" && (posthog.has_opted_in_capturing() || posthog.has_opted_out_capturing())) {
+    posthog.clear_opt_in_out_capturing();
   }
 };
 


### PR DESCRIPTION
## What changed
- switch PostHog initialization to a single real `init()` per page load
- upgrade consent changes from limited to accepted mode via `posthog.set_config(...)`
- clear stale opt-in/opt-out state when consent is pending or outdated
- add regression tests for stale consent state and consent-mode upgrades

## Why
The previous fix still relied on calling `posthog.init(...)` a second time after cookie acceptance. In `posthog-js`, re-initialization is a no-op once the client is loaded, so production browsers stayed stuck in the initial limited in-memory mode.

## Impact
This restores full accepted-consent tracking so non-essential AARRR events like `dataset_archive_viewed` and `dataset_opened` can resume reaching PostHog in production.

## Root cause
We were treating `posthog.init(...)` as a supported runtime reconfiguration mechanism, but the SDK only allows the first init call to take effect. That meant pageviews and some essential events could appear while full consent-based tracking never actually switched on.

## Validation
- `npm --prefix frontend test -- analytics.test.ts`
- live production verification before this patch showed deploy healthy but PostHog still stuck in stub/limited mode after cookie acceptance
- `npm --prefix frontend run build` is currently blocked by many unrelated pre-existing TypeScript errors elsewhere in the frontend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime PostHog consent/initialization behavior; mistakes could lead to incorrect tracking state or unintentionally capturing events, though scope is limited to analytics configuration.
> 
> **Overview**
> Fixes the PostHog consent upgrade path by **initializing the SDK only once per page load** and switching from re-calling `posthog.init()` to using `posthog.set_config()` when consent moves from limited/pending to accepted.
> 
> Adds logic to **clear stale PostHog opt-in/opt-out flags** when consent is pending/outdated, and updates `analytics.test.ts` with regression coverage for single-init behavior, config upgrades, and stale opt-state clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0702abd1bebfe836ead960375d6088952e8f8cf9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->