### PR TITLE
fix(api): correct process priority description

### DIFF
--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -44,7 +44,7 @@ class ProcessRequest(BaseModel):
 			'Use deadwood_v1, treecover_v1, and deadwood_treecover_combined_v2 together when comparing old and new models.'
 		)
 	)
-	priority: Optional[int] = Field(default=2, ge=1, le=5, description='Task priority (1=highest, 5=lowest)')
+	priority: Optional[int] = Field(default=2, ge=1, le=5, description='Task priority (5=highest, 1=lowest)')
 
 
 @router.put('/datasets/{dataset_id}/process')

--- a/api/tests/db/test_process_priority.py
+++ b/api/tests/db/test_process_priority.py
@@ -84,6 +84,14 @@ def test_process_custom_priority(test_dataset, auth_token):
 	assert data['priority'] == 5
 
 
+def test_process_priority_schema_documents_descending_priority():
+	"""OpenAPI docs should match v2_queue_positions priority DESC ordering."""
+	schema = app.openapi()
+	priority_schema = schema['components']['schemas']['ProcessRequest']['properties']['priority']
+
+	assert priority_schema['description'] == 'Task priority (5=highest, 1=lowest)'
+
+
 def test_process_invalid_priority(test_dataset, auth_token):
 	"""Test that process request rejects invalid priority values"""
 	response = client.put(

--- a/api/tests/routers/test_process.py
+++ b/api/tests/routers/test_process.py
@@ -156,6 +156,14 @@ def test_process_custom_priority(test_dataset, auth_token):
 	assert data['priority'] == 5
 
 
+def test_process_priority_schema_documents_descending_priority():
+	"""OpenAPI docs should match v2_queue_positions priority DESC ordering."""
+	schema = app.openapi()
+	priority_schema = schema['components']['schemas']['ProcessRequest']['properties']['priority']
+
+	assert priority_schema['description'] == 'Task priority (5=highest, 1=lowest)'
+
+
 def test_process_invalid_priority(test_dataset, auth_token):
 	"""Test that process request rejects invalid priority values"""
 	response = client.put(


### PR DESCRIPTION
## Summary
- correct the process API priority description to match production queue ordering
- add OpenAPI schema regression coverage for the priority text

## Tests
- venv/bin/deadtrees dev test api api/tests/routers/test_process.py::test_process_priority_schema_documents_descending_priority
- venv/bin/deadtrees dev test api api/tests/db/test_process_priority.py::test_process_priority_schema_documents_descending_priority

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 72c4ff9ad340ee1a4ab8426f3a6371c4a0b4721e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->