### PR TITLE
fix(frontend): enqueue old and new models on upload

### DIFF
--- a/api/src/automation/daily_summary.py
+++ b/api/src/automation/daily_summary.py
@@ -217,9 +217,16 @@ def fetch_upload_metrics(client: Client, period_start: datetime) -> dict:
 	# Using PostgREST embedding to join v2_datasets with v2_statuses
 	period_str = period_start.isoformat()
 	
-	response = client.table(settings.datasets_table).select(
-		'id, v2_statuses(has_error, current_status, is_deadwood_done, is_forest_cover_done, is_odm_done)'
-	).gte('created_at', period_str).execute()
+	response = (
+		client.table(settings.datasets_table)
+		.select(
+			'id, v2_statuses('
+			'has_error, current_status, is_deadwood_done, '
+			'is_forest_cover_done, is_combined_model_done, is_odm_done)'
+		)
+		.gte('created_at', period_str)
+		.execute()
+	)
 	
 	if response.data:
 		for row in response.data:
@@ -239,7 +246,7 @@ def fetch_upload_metrics(client: Client, period_start: datetime) -> dict:
 				current_status = status.get("current_status", "idle")
 				is_processed = any(
 					status.get(flag, False)
-					for flag in ("is_deadwood_done", "is_forest_cover_done", "is_odm_done")
+					for flag in ("is_deadwood_done", "is_forest_cover_done", "is_combined_model_done", "is_odm_done")
 				)
 				
 				if has_error:

--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -28,7 +28,11 @@ _TASK_TYPE_STATUS_FLAGS = {
 	TaskTypeEnum.thumbnail: ('is_thumbnail_done',),
 	TaskTypeEnum.deadwood_v1: ('is_deadwood_done',),
 	TaskTypeEnum.treecover_v1: ('is_forest_cover_done',),
-	TaskTypeEnum.deadwood_treecover_combined_v2: ('is_deadwood_done', 'is_forest_cover_done'),
+	TaskTypeEnum.deadwood_treecover_combined_v2: (
+		'is_deadwood_done',
+		'is_forest_cover_done',
+		'is_combined_model_done',
+	),
 }
 
 
@@ -37,7 +41,13 @@ def _task_type_to_status_flags(task_type: TaskTypeEnum) -> tuple[str, ...]:
 
 
 class ProcessRequest(BaseModel):
-	task_types: List[str]
+	task_types: List[str] = Field(
+		description=(
+			'Processing stages to enqueue. Include geotiff before model prediction stages '
+			'when rerunning predictions on an existing dataset so the standardized ortho is refreshed. '
+			'Use deadwood_v1, treecover_v1, and deadwood_treecover_combined_v2 together when comparing old and new models.'
+		)
+	)
 	priority: Optional[int] = Field(default=2, ge=1, le=5, description='Task priority (1=highest, 5=lowest)')
 
 

--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -28,11 +28,7 @@ _TASK_TYPE_STATUS_FLAGS = {
 	TaskTypeEnum.thumbnail: ('is_thumbnail_done',),
 	TaskTypeEnum.deadwood_v1: ('is_deadwood_done',),
 	TaskTypeEnum.treecover_v1: ('is_forest_cover_done',),
-	TaskTypeEnum.deadwood_treecover_combined_v2: (
-		'is_deadwood_done',
-		'is_forest_cover_done',
-		'is_combined_model_done',
-	),
+	TaskTypeEnum.deadwood_treecover_combined_v2: ('is_combined_model_done',),
 }
 
 
@@ -147,7 +143,8 @@ def create_processing_task(
 					for task_type in validated_task_types:
 						for flag in _task_type_to_status_flags(task_type):
 							reset_fields[flag] = False
-					client.table(settings.statuses_table).update(reset_fields).eq('dataset_id', dataset_id).execute()
+					with use_client() as service_client:
+						service_client.table(settings.statuses_table).update(reset_fields).eq('dataset_id', dataset_id).execute()
 					logger.info(
 						f'Cleared error state for dataset {dataset_id} (requeue)',
 						LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token),

--- a/api/tests/db/test_odm_database.py
+++ b/api/tests/db/test_odm_database.py
@@ -314,6 +314,7 @@ def test_all_status_completion_flags_exist(auth_token, test_user):
 				'is_thumbnail_done': True,
 				'is_deadwood_done': True,
 				'is_forest_cover_done': True,
+				'is_combined_model_done': True,
 				'is_metadata_done': True,
 				'is_odm_done': True,
 			}
@@ -330,6 +331,7 @@ def test_all_status_completion_flags_exist(auth_token, test_user):
 				'is_thumbnail_done',
 				'is_deadwood_done',
 				'is_forest_cover_done',
+				'is_combined_model_done',
 				'is_metadata_done',
 				'is_odm_done',
 			]

--- a/api/tests/routers/test_process.py
+++ b/api/tests/routers/test_process.py
@@ -10,12 +10,8 @@ from shared.models import TaskTypeEnum, LicenseEnum, PlatformEnum, DatasetAccess
 client = TestClient(app)
 
 
-def test_combined_task_maps_to_dedicated_and_legacy_status_flags():
-	assert _task_type_to_status_flags(TaskTypeEnum.deadwood_treecover_combined_v2) == (
-		'is_deadwood_done',
-		'is_forest_cover_done',
-		'is_combined_model_done',
-	)
+def test_combined_task_maps_to_dedicated_status_flag():
+	assert _task_type_to_status_flags(TaskTypeEnum.deadwood_treecover_combined_v2) == ('is_combined_model_done',)
 
 
 @pytest.fixture(scope='function')
@@ -352,9 +348,9 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 		assert response.data[0]['is_processing'] is False
 
 
-def test_rerun_combined_task_resets_both_prediction_flags(test_dataset, auth_token):
-	"""Rerunning the combined model after an error must reset both labels it produces."""
-	with use_client(auth_token) as supabaseClient:
+def test_rerun_combined_task_resets_only_combined_prediction_flag(test_dataset, auth_token):
+	"""Rerunning the combined model should not reset legacy model completion flags."""
+	with use_client() as supabaseClient:
 		supabaseClient.table(settings.statuses_table).update(
 			{
 				'has_error': True,
@@ -379,8 +375,8 @@ def test_rerun_combined_task_resets_both_prediction_flags(test_dataset, auth_tok
 		status = response.data[0]
 		assert status['has_error'] is False
 		assert status['error_message'] is None
-		assert status['is_deadwood_done'] is False
-		assert status['is_forest_cover_done'] is False
+		assert status['is_deadwood_done'] is True
+		assert status['is_forest_cover_done'] is True
 		assert status['is_combined_model_done'] is False
 
 

--- a/api/tests/routers/test_process.py
+++ b/api/tests/routers/test_process.py
@@ -2,11 +2,20 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.src.server import app
+from api.src.routers.process import _task_type_to_status_flags
 from shared.db import use_client, login
 from shared.settings import settings
 from shared.models import TaskTypeEnum, LicenseEnum, PlatformEnum, DatasetAccessEnum, StatusEnum
 
 client = TestClient(app)
+
+
+def test_combined_task_maps_to_dedicated_and_legacy_status_flags():
+	assert _task_type_to_status_flags(TaskTypeEnum.deadwood_treecover_combined_v2) == (
+		'is_deadwood_done',
+		'is_forest_cover_done',
+		'is_combined_model_done',
+	)
 
 
 @pytest.fixture(scope='function')
@@ -353,6 +362,7 @@ def test_rerun_combined_task_resets_both_prediction_flags(test_dataset, auth_tok
 				'current_status': StatusEnum.idle,
 				'is_deadwood_done': True,
 				'is_forest_cover_done': True,
+				'is_combined_model_done': True,
 			}
 		).eq('dataset_id', test_dataset).execute()
 
@@ -371,6 +381,7 @@ def test_rerun_combined_task_resets_both_prediction_flags(test_dataset, auth_tok
 		assert status['error_message'] is None
 		assert status['is_deadwood_done'] is False
 		assert status['is_forest_cover_done'] is False
+		assert status['is_combined_model_done'] is False
 
 
 def test_rerun_multiple_old_queue_items(test_dataset, auth_token, test_user):

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -203,6 +203,41 @@ This writes an ignored keypair to `.local/ssh/processing-to-storage` and `.local
 If you prefer a different key location, set absolute paths in `LOCAL_TEST_SSH_PRIVATE_KEY_PATH` and
 `LOCAL_TEST_SSH_PUBLIC_KEY_PATH` before running `docker compose -f docker-compose.test.yaml ...`.
 
+## Processor-server validation workflow
+
+This local laptop/worktree is good for API, shared, frontend, docs, and
+non-GPU checks. Processor tests that need NVIDIA runtime, model checkpoints, or
+full combined-model execution should run on the processing server dev checkout:
+
+```bash
+ssh processing-server
+cd /home/jj1049/dev/deadtrees
+git fetch origin <branch>
+git checkout -B <branch> origin/<branch>
+source venv/bin/activate
+deadtrees dev test processor processor/tests/test_processor.py
+deadtrees dev test processor processor/tests/test_process_deadwood_treecover_combined_v2.py::test_model_loads
+```
+
+If `/home/jj1049/dev/deadtrees` is dirty or not the current monorepo checkout,
+move it aside first instead of deleting it:
+
+```bash
+cd /home/jj1049/dev
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+mv deadtrees "deadtrees.backup-$ts"
+git clone https://github.com/Deadwood-ai/deadtrees.git deadtrees
+cd deadtrees
+git fetch origin <branch>
+git checkout -B <branch> origin/<branch>
+```
+
+Copy ignored local test assets or `.env` from the backup only when needed. For
+new status columns or tables, apply the migration to the dev/test Supabase DB
+before running processor tests and reload the PostgREST schema cache. Never use
+this workflow against `/home/jj1049/prod/deadtrees` unless the user explicitly
+asks for a production operation.
+
 ## Codex app worktrees
 
 If you use the Codex desktop app, configure a project Local Environment so new

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -88,6 +88,26 @@ deadtrees dev debug api specific_test.py
 deadtrees dev debug processor specific_test.py
 ```
 
+#### **Local vs Processor-Server Test Routing**
+
+Use this split for large processor/model changes:
+
+- Run API, shared-model, frontend, docs, and non-GPU checks on the local
+  machine/worktree.
+- Run processor tests that need NVIDIA runtime, model checkpoints, or
+  comprehensive combined-model validation on the processing server dev checkout
+  at `/home/jj1049/dev/deadtrees`.
+- Keep the processing-server validation checkout on the PR branch being tested.
+  If the dev checkout is dirty or stale, move it aside as a timestamped backup
+  and clone/fetch the current monorepo branch again; do not edit
+  `/home/jj1049/prod/deadtrees`.
+- Use the same `deadtrees dev test processor ...` commands on the processing
+  server. Apply new migrations only to the local/dev Supabase instance before
+  processor tests that require new columns, then reload PostgREST schema cache
+  if needed.
+- Leave prod processors and prod queue state alone unless the user explicitly
+  asks for a production operation.
+
 #### **Testing Workflow for Each Task**
 
 1. **Implement the feature** as described in the current task

--- a/docs/odm-processing/design.md
+++ b/docs/odm-processing/design.md
@@ -364,6 +364,12 @@ task_types = [
 Add `cog`, `thumbnail`, and `metadata` only when those derived products also
 need to be regenerated. Add `odm_processing` only for raw ZIP reprocessing.
 
+Legacy model stages use `is_deadwood_done` and `is_forest_cover_done` as their
+completion flags. The combined v2 stage has its own `is_combined_model_done`
+flag, and also sets the legacy flags when it finishes so existing layer/status
+surfaces keep working. Use the model-prediction labels and their `model_config`
+when you need to verify which model variant actually produced a layer.
+
 ---
 
 ## 📁 **STORAGE ARCHITECTURE**

--- a/docs/odm-processing/design.md
+++ b/docs/odm-processing/design.md
@@ -1,7 +1,7 @@
 # ODM Raw Drone Image Processing - Technical Design
 
-**Version:** 2.1  
-**Date:** December 2024  
+**Version:** 2.1
+**Date:** December 2024
 **Status:** ✅ Ready for Implementation - Processor-Centric Architecture
 
 ---
@@ -16,8 +16,8 @@
 
 ### **Processing Flows (Processor-Centric)**
 ```
-GeoTIFF: Upload (store only) → [geotiff→cog→thumb→metadata→deadwood]
-ZIP:     Upload (extract only) → [odm→geotiff→cog→thumb→metadata→deadwood]
+GeoTIFF: Upload (store only) → [geotiff→cog→thumb→metadata→deadwood_v1→treecover_v1→deadwood_treecover_combined_v2]
+ZIP:     Upload (extract only) → [odm→geotiff→cog→thumb→metadata→deadwood_v1→treecover_v1→deadwood_treecover_combined_v2]
 
 Both paths converge at geotiff processing where ortho entries are created
 ```
@@ -39,7 +39,7 @@ Clean separation following existing v2_* table architecture:
 CREATE TABLE "public"."v2_raw_images" (
     "dataset_id" bigint NOT NULL REFERENCES "public"."v2_datasets"(id) ON DELETE CASCADE,
     "raw_image_count" integer NOT NULL,
-    "raw_image_size_mb" integer NOT NULL, 
+    "raw_image_size_mb" integer NOT NULL,
     "raw_images_path" text NOT NULL, -- Contains both images and RTK files
     "camera_metadata" jsonb, -- Comprehensive EXIF metadata in structured format
     "has_rtk_data" boolean NOT NULL DEFAULT false,
@@ -85,7 +85,7 @@ Extend v2_statuses table using established patterns:
 -- Add ODM processing status to enum (matches existing pattern)
 ALTER TYPE "public"."v2_status" ADD VALUE 'odm_processing';
 
--- Add ODM completion flag (matches is_*_done pattern)  
+-- Add ODM completion flag (matches is_*_done pattern)
 ALTER TABLE "public"."v2_statuses" ADD COLUMN "is_odm_done" boolean NOT NULL DEFAULT false;
 ```
 
@@ -96,7 +96,7 @@ ALTER TABLE "public"."v2_statuses" ADD COLUMN "is_odm_done" boolean NOT NULL DEF
 
 **Storage Path Convention:**
 - GeoTIFF uploads: `archive/{dataset_id}_ortho.tif` (no ortho entry until processing)
-- ZIP uploads: `raw_images/{dataset_id}/` (extracted contents) 
+- ZIP uploads: `raw_images/{dataset_id}/` (extracted contents)
 - ODM output: `archive/{dataset_id}_ortho.tif` (moved from ODM temp location)
 - Processing: Creates ortho entries for files found in `archive/` directory
 
@@ -145,23 +145,23 @@ async def upload_chunk(
     upload_type: Annotated[Optional[UploadType], Form()] = None,
 ):
     # ... existing chunk logic ...
-    
+
     # Final chunk processing - SIMPLIFIED (no technical analysis)
     if chunk_index == chunks_total - 1:
         detected_type = upload_type or detect_upload_type(upload_target_path)
-        
+
         dataset = create_dataset_entry(...)  # Same for both types
-        
+
         if detected_type == UploadType.GEOTIFF:
             # Store file only - NO ortho entry creation
             target_path = settings.archive_path / f"{dataset.id}_ortho.tif"
             upload_target_path.rename(target_path)
-            
+
         elif detected_type == UploadType.RAW_IMAGES_ZIP:
             # Extract and store - NO technical analysis
             extract_zip_to_raw_images(dataset.id, upload_target_path)
             create_raw_images_entry(dataset.id, ...)
-        
+
         update_status(token, dataset.id, is_upload_done=True)
         return dataset
 ```
@@ -173,17 +173,17 @@ async def upload_chunk(
 # processor/src/process_geotiff.py - NOW handles ortho creation for both sources
 def process_geotiff(task: QueueTask, temp_dir: Path):
     """Enhanced to handle ortho creation for both direct upload and ODM-generated files"""
-    
+
     # 1. Find orthomosaic file (could be direct upload or ODM output)
     ortho_file_path = settings.archive_path / f"{task.dataset_id}_ortho.tif"
-    
+
     if not ortho_file_path.exists():
         raise ProcessingError(f"No orthomosaic found for dataset {task.dataset_id}")
-    
+
     # 2. Create ortho entry (moved from upload logic)
     sha256 = get_file_identifier(ortho_file_path)
     ortho_info = cog_info(ortho_file_path)
-    
+
     upsert_ortho_entry(
         dataset_id=task.dataset_id,
         file_path=ortho_file_path,
@@ -193,13 +193,13 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
         ortho_upload_runtime=0.0,  # Set during upload in old flow, now N/A
         token=token,
     )
-    
+
     # 3. Continue with standardization (existing logic)
     standardise_geotiff(str(ortho_file_path), str(processed_path), token, task.dataset_id)
-    
+
     # 4. Create processed ortho entry (existing logic)
     upsert_processed_ortho_entry(...)
-    
+
     update_status(token, task.dataset_id, is_ortho_done=True)
 ```
 
@@ -208,41 +208,41 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 # processor/src/process_odm.py
 def process_odm(task: QueueTask, temp_dir: Path):
     """Generate ODM orthomosaic with comprehensive EXIF metadata extraction"""
-    
+
     # 1. Pull raw images from storage
     raw_images_dir = temp_dir / f"raw_images_{task.dataset_id}"
     pull_raw_images_from_storage(task.dataset_id, raw_images_dir)
-    
+
     # 2. Extract ZIP file locally for processing
     extraction_dir = temp_dir / f'raw_images_{task.dataset_id}'
     extract_zip_locally(task.dataset_id, extraction_dir)
-    
+
     # 2.5. Extract comprehensive EXIF metadata - NEW STEP
     extract_and_store_exif_metadata(extraction_dir, task.dataset_id, token)
-    
+
     # 3. Execute ODM container
     odm_output_dir = temp_dir / f"odm_{task.dataset_id}"
     execute_odm_container(extraction_dir, odm_output_dir, task.dataset_id)
-    
+
     # 4. Move generated orthomosaic to standard archive location
     odm_ortho = odm_output_dir / task.dataset_id / "odm_orthophoto" / "odm_orthophoto.tif"
     final_ortho = settings.archive_path / f"{task.dataset_id}_ortho.tif"
-    
+
     shutil.move(str(odm_ortho), str(final_ortho))
-    
+
     # 5. Update status only - NO ortho entry creation (geotiff processor will handle)
     update_status(token, task.dataset_id, is_odm_done=True)
-    
+
     # NOTE: geotiff processing task will find the file and create ortho entry
 
 def extract_and_store_exif_metadata(extraction_dir: Path, dataset_id: int, token: str):
     """Extract comprehensive EXIF metadata and store in v2_raw_images.camera_metadata"""
     from api.src.upload.exif_utils import extract_comprehensive_exif
-    
+
     # Find image files
     image_files = list(extraction_dir.glob('*.jpg')) + list(extraction_dir.glob('*.JPG'))
     image_files += list(extraction_dir.glob('*.jpeg')) + list(extraction_dir.glob('*.JPEG'))
-    
+
     # Sample first 3 images to find representative EXIF data
     camera_metadata = {}
     for image_file in image_files[:3]:
@@ -250,7 +250,7 @@ def extract_and_store_exif_metadata(extraction_dir: Path, dataset_id: int, token
         if exif_data:
             camera_metadata = exif_data
             break
-    
+
     # Update v2_raw_images with comprehensive EXIF metadata
     if camera_metadata:
         with use_client(token) as client:
@@ -268,25 +268,25 @@ async def process_geotiff_upload(dataset: Dataset, upload_target_path: Path) -> 
     # 1. Move to standard location - NO technical analysis
     final_path = settings.archive_path / f"{dataset.id}_ortho.tif"
     upload_target_path.rename(final_path)
-    
+
     # 2. Update status - NO ortho entry creation
     update_status(token, dataset.id, is_upload_done=True)
-    
+
     return dataset
 
-# api/src/upload/raw_images_processor.py - SIMPLIFIED  
+# api/src/upload/raw_images_processor.py - SIMPLIFIED
 async def process_raw_images_upload(dataset: Dataset, upload_target_path: Path) -> Dataset:
     """Simplified ZIP upload - extraction and storage only"""
     # 1. Extract ZIP - NO technical analysis during extraction
     raw_images_dir = settings.raw_images_path / str(dataset.id)
     extract_zip_safely(upload_target_path, raw_images_dir)
-    
+
     # 2. Create raw_images entry - basic metadata only
     create_raw_images_entry(dataset.id, raw_images_dir)
-    
+
     # 3. Update status - NO technical analysis
     update_status(token, dataset.id, is_upload_done=True)
-    
+
     return dataset
 ```
 
@@ -295,34 +295,74 @@ async def process_raw_images_upload(dataset: Dataset, upload_target_path: Path) 
 # processor/src/processor.py - Updated execution order
 def process_task(task: QueueTask, token: str):
     """Process tasks with unified ortho creation"""
-    
+
     # 1. ODM processing (if ZIP upload)
     if TaskTypeEnum.odm_processing in task.task_types:
         process_odm(task, temp_dir)
-    
+
     # 2. GeoTIFF processing (ALWAYS - creates ortho entry for both sources)
     if TaskTypeEnum.geotiff in task.task_types:  # Required for both upload types
         process_geotiff(task, temp_dir)  # NOW handles ortho creation
-    
+
     # 3. Rest of pipeline continues identically
     if TaskTypeEnum.cog in task.task_types:
         process_cog(task, temp_dir)
-    
+
     # ... other tasks unchanged
 ```
 
 ### **5. Queue Management Requirements**
 ```python
-# Frontend must ensure geotiff processing included for ALL uploads:
+# Frontend must ensure geotiff processing is included for ALL uploads:
 
 # GeoTIFF upload task list:
-task_types = ['geotiff', 'cog', 'thumbnail', 'metadata']
+task_types = [
+    'geotiff',
+    'cog',
+    'thumbnail',
+    'metadata',
+    'deadwood_v1',
+    'treecover_v1',
+    'deadwood_treecover_combined_v2',
+]
 
-# ZIP upload task list:  
-task_types = ['odm_processing', 'geotiff', 'cog', 'thumbnail', 'metadata']
+# ZIP upload task list:
+task_types = [
+    'odm_processing',
+    'geotiff',
+    'cog',
+    'thumbnail',
+    'metadata',
+    'deadwood_v1',
+    'treecover_v1',
+    'deadwood_treecover_combined_v2',
+]
 
-# Both include 'geotiff' - ensures ortho entry creation
+# Both include 'geotiff' - ensures standardization and ortho entry creation.
 ```
+
+### **6. Model Rerun Quirk: Include GeoTIFF First**
+
+Future agents: do not enqueue prediction stages alone when validating or
+rerunning model outputs. The prediction processors
+(`deadwood_v1`, `treecover_v1`, and `deadwood_treecover_combined_v2`) call
+`ensure_local_ortho()` so they can fetch an existing orthomosaic, but they do
+not run GeoTIFF standardization themselves. The `geotiff` task is the step that
+standardizes the raster and refreshes the ortho entry used downstream.
+
+For a model-only validation rerun on an already processed dataset, use:
+
+```python
+task_types = [
+    'geotiff',
+    'deadwood_v1',
+    'treecover_v1',
+    'deadwood_treecover_combined_v2',
+]
+```
+
+Add `cog`, `thumbnail`, and `metadata` only when those derived products also
+need to be regenerated. Add `odm_processing` only for raw ZIP reprocessing.
 
 ---
 
@@ -338,7 +378,7 @@ Upload Results (No Technical Analysis):
         ├── {dataset_id}_raw_images.zip # Original ZIP file (preserved)
         └── images/
             ├── DJI_001.JPG            # Extracted drone images
-            ├── DJI_002.JPG        
+            ├── DJI_002.JPG
             ├── DJI_timestamp.MRK      # RTK timestamp data
             └── ...                    # All extracted ZIP contents
 ```
@@ -399,14 +439,14 @@ Following established codebase patterns for integration-focused testing with rea
 def test_geotiff_upload_no_ortho_creation(test_geotiff_file, auth_token, test_user):
     """Test GeoTIFF upload creates dataset but NO ortho entry"""
     dataset = upload_geotiff_chunked(test_geotiff_file, auth_token)
-    
+
     # Verify dataset created
     assert dataset is not None
-    
+
     # Verify file stored in archive
     ortho_file = settings.archive_path / f"{dataset.id}_ortho.tif"
     assert ortho_file.exists()
-    
+
     # Verify NO ortho entry created (key change)
     with use_client(auth_token) as client:
         response = client.table(settings.orthos_table).select('*').eq('dataset_id', dataset.id).execute()
@@ -415,15 +455,15 @@ def test_geotiff_upload_no_ortho_creation(test_geotiff_file, auth_token, test_us
 def test_zip_upload_no_technical_analysis(test_raw_images_zip, auth_token, test_user):
     """Test ZIP upload creates dataset and raw_images entry only"""
     dataset = upload_zip_chunked(test_raw_images_zip, auth_token)
-    
+
     # Verify dataset created
     assert dataset is not None
-    
+
     # Verify raw_images entry created
     with use_client(auth_token) as client:
         response = client.table('v2_raw_images').select('*').eq('dataset_id', dataset.id).execute()
         assert len(response.data) == 1
-        
+
     # Verify NO ortho entry created (key change)
     with use_client(auth_token) as client:
         response = client.table(settings.orthos_table).select('*').eq('dataset_id', dataset.id).execute()
@@ -437,10 +477,10 @@ def test_geotiff_processing_creates_ortho_entry(test_dataset_geotiff_upload, aut
     """Test geotiff processing creates ortho entry for direct upload"""
     # Setup: Dataset exists with file in archive/, no ortho entry
     task = create_task(['geotiff'], test_dataset_geotiff_upload)
-    
+
     # Execute geotiff processing
     process_geotiff(task, temp_dir)
-    
+
     # Verify ortho entry created
     with use_client(auth_token) as client:
         response = client.table(settings.orthos_table).select('*').eq('dataset_id', task.dataset_id).execute()
@@ -453,10 +493,10 @@ def test_geotiff_processing_after_odm(test_dataset_with_odm_output, auth_token):
     """Test geotiff processing creates ortho entry for ODM-generated file"""
     # Setup: ODM has moved file to archive/, no ortho entry yet
     task = create_task(['geotiff'], test_dataset_with_odm_output)
-    
+
     # Execute geotiff processing
     process_geotiff(task, temp_dir)
-    
+
     # Verify ortho entry created (same logic as direct upload)
     with use_client(auth_token) as client:
         response = client.table(settings.orthos_table).select('*').eq('dataset_id', task.dataset_id).execute()
@@ -466,22 +506,22 @@ def test_geotiff_processing_after_odm(test_dataset_with_odm_output, auth_token):
 
 #### **3. Complete Pipeline Tests**
 ```python
-# processor/tests/test_complete_pipeline.py  
+# processor/tests/test_complete_pipeline.py
 def test_complete_geotiff_pipeline(test_geotiff_upload, auth_token):
     """Test complete pipeline starting from uploaded GeoTIFF"""
     task = create_task(['geotiff', 'cog', 'thumbnail', 'metadata'], test_geotiff_upload)
-    
+
     process_task(task, auth_token)
-    
+
     # Verify all database entries created
     verify_complete_pipeline_state(task.dataset_id, auth_token)
 
 def test_complete_odm_pipeline(test_zip_upload, auth_token):
     """Test complete pipeline starting from ZIP upload"""
     task = create_task(['odm_processing', 'geotiff', 'cog', 'thumbnail', 'metadata'], test_zip_upload)
-    
+
     process_task(task, auth_token)
-    
+
     # Verify identical end state as GeoTIFF pipeline
     verify_complete_pipeline_state(task.dataset_id, auth_token)
 ```
@@ -526,7 +566,7 @@ def test_odm_output_ready():
 # processor/requirements.txt
 docker>=6.1.0
 
-# api/requirements.txt  
+# api/requirements.txt
 Pillow>=10.0.0  # Only if EXIF processing kept in backend
 ```
 
@@ -545,7 +585,7 @@ Pillow>=10.0.0  # Only if EXIF processing kept in backend
 - **Verification**: Same ortho table structure regardless of source
 - **Testing**: Comprehensive validation of unified processing paths
 
-### **Task Queue Requirements**  
+### **Task Queue Requirements**
 - **Frontend responsibility**: Must include 'geotiff' in task list for ALL uploads
 - **Processor validation**: Ensure geotiff processing always executes before other tasks
 - **Error handling**: Clear messaging if geotiff task missing from queue
@@ -558,6 +598,6 @@ Pillow>=10.0.0  # Only if EXIF processing kept in backend
 
 ---
 
-**Implementation Status**: Ready to begin Phase 1  
-**Architecture Benefits**: Simplified upload, unified processing, eliminated code duplication  
-**Next Step**: Update implementation.md with revised task breakdown 
+**Implementation Status**: Ready to begin Phase 1
+**Architecture Benefits**: Simplified upload, unified processing, eliminated code duplication
+**Next Step**: Update implementation.md with revised task breakdown

--- a/docs/odm-processing/design.md
+++ b/docs/odm-processing/design.md
@@ -366,9 +366,10 @@ need to be regenerated. Add `odm_processing` only for raw ZIP reprocessing.
 
 Legacy model stages use `is_deadwood_done` and `is_forest_cover_done` as their
 completion flags. The combined v2 stage has its own `is_combined_model_done`
-flag, and also sets the legacy flags when it finishes so existing layer/status
-surfaces keep working. Use the model-prediction labels and their `model_config`
-when you need to verify which model variant actually produced a layer.
+flag and its own `deadwood_treecover_combined_segmentation` current status.
+It does not mark the legacy model flags as complete. Use the model-prediction
+labels and their `model_config` when you need to verify which model variant
+actually produced a layer.
 
 ---
 

--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -112,7 +112,7 @@ The processor executes `geotiff` before `cog`, `thumbnail`, metadata, and model
 stages regardless of the array order, but keep the order explicit in docs and
 manual API calls so humans can see the intended pipeline. Legacy model stages
 use `is_deadwood_done` and `is_forest_cover_done`; the combined v2 stage uses
-`is_combined_model_done` and also sets the legacy flags for UI compatibility.
+`is_combined_model_done` and does not mark the legacy model flags as complete.
 Label rows and `model_config` are still the reliable way to confirm which model
 variants were actually produced.
 

--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -76,6 +76,45 @@ If `/home/jj1049/prod/deadtrees` is dirty or `git pull` conflicts, the cron
 auto-deploy may fail even though GitHub Actions succeeded. Check
 `auto-deploy.log` before assuming production is on the merged commit.
 
+## Processor Queue Task-Type Quirk
+
+When manually requeueing production datasets to validate segmentation models,
+include `geotiff` before any prediction task unless you intentionally want to
+reuse the already-standardized raster without refreshing it. The prediction
+processors can fetch an existing ortho, but they do not run GeoTIFF
+standardization themselves. `geotiff` is the task that standardizes the raster
+and refreshes the ortho entry that model stages consume.
+
+Use this task list for an already-uploaded, already-ODM-processed dataset when
+you want to compare old and new model outputs:
+
+```json
+["geotiff", "deadwood_v1", "treecover_v1", "deadwood_treecover_combined_v2"]
+```
+
+Use this full task list for new/raw ZIP processing when all derived products
+should be regenerated:
+
+```json
+[
+  "odm_processing",
+  "geotiff",
+  "cog",
+  "thumbnail",
+  "metadata",
+  "deadwood_v1",
+  "treecover_v1",
+  "deadwood_treecover_combined_v2"
+]
+```
+
+The processor executes `geotiff` before `cog`, `thumbnail`, metadata, and model
+stages regardless of the array order, but keep the order explicit in docs and
+manual API calls so humans can see the intended pipeline. The legacy and
+combined model stages share `is_deadwood_done` / `is_forest_cover_done` status
+flags, so label rows and `model_config` are the reliable way to confirm which
+model variants were actually produced.
+
 ## Source Of Truth
 
 - release version: repo-wide CalVer tag such as `v2026.04.17`

--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -110,10 +110,11 @@ should be regenerated:
 
 The processor executes `geotiff` before `cog`, `thumbnail`, metadata, and model
 stages regardless of the array order, but keep the order explicit in docs and
-manual API calls so humans can see the intended pipeline. The legacy and
-combined model stages share `is_deadwood_done` / `is_forest_cover_done` status
-flags, so label rows and `model_config` are the reliable way to confirm which
-model variants were actually produced.
+manual API calls so humans can see the intended pipeline. Legacy model stages
+use `is_deadwood_done` and `is_forest_cover_done`; the combined v2 stage uses
+`is_combined_model_done` and also sets the legacy flags for UI compatibility.
+Label rows and `model_config` are still the reliable way to confirm which model
+variants were actually produced.
 
 ## Source Of Truth
 

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -54,6 +54,7 @@ interface Dataset {
   is_metadata_done: boolean;
   is_deadwood_done: boolean;
   is_forest_cover_done: boolean;
+  is_combined_model_done: boolean;
   isInPublication?: boolean; // Track if dataset is in publication process
   data_access?: "public" | "private" | "viewonly";
   archived?: boolean;
@@ -164,7 +165,8 @@ const DataTable: React.FC<DataTableProps> = ({
       record.is_thumbnail_done &&
       record.is_metadata_done &&
       record.is_deadwood_done &&
-      record.is_forest_cover_done
+      record.is_forest_cover_done &&
+      record.is_combined_model_done
     );
   };
 

--- a/frontend/src/components/ProcessingProgress.tsx
+++ b/frontend/src/components/ProcessingProgress.tsx
@@ -43,7 +43,8 @@ const ProcessingProgress: React.FC<ProcessingProgressProps> = ({ dataset, showDe
     dataset.is_metadata_done ||
     dataset.is_cog_done ||
     dataset.is_deadwood_done ||
-    dataset.is_forest_cover_done,
+    dataset.is_forest_cover_done ||
+    dataset.is_combined_model_done,
   );
 
   const isQueued = Boolean(

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -113,10 +113,10 @@ const PREDICTION_PROCESSING_STEPS = [
 ];
 
 const GEOTIFF_PROCESSING_STEPS = [
+  "geotiff",
   "cog",
   "thumbnail",
   "metadata",
-  "geotiff",
   ...PREDICTION_PROCESSING_STEPS,
 ];
 

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -106,6 +106,25 @@ const PrivacyLink = () => (
   </Typography.Link>
 );
 
+const PREDICTION_PROCESSING_STEPS = [
+  "deadwood_v1",
+  "treecover_v1",
+  "deadwood_treecover_combined_v2",
+];
+
+const GEOTIFF_PROCESSING_STEPS = [
+  "cog",
+  "thumbnail",
+  "metadata",
+  "geotiff",
+  ...PREDICTION_PROCESSING_STEPS,
+];
+
+const RAW_IMAGES_PROCESSING_STEPS = [
+  "odm_processing",
+  ...GEOTIFF_PROCESSING_STEPS,
+];
+
 const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey }) => {
   const pickerTypeOptions = ["Year/Month/Day", "Year/Month", "Year"];
   const [form] = Form.useForm();
@@ -274,8 +293,8 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
       // Process dataset with appropriate steps based on upload type
       const processingSteps =
         uploadType === UploadType.RAW_IMAGES_ZIP
-          ? ["odm_processing", "cog", "thumbnail", "metadata", "geotiff", "deadwood_treecover_combined_v2"] // Raw images workflow includes ODM
-          : ["cog", "thumbnail", "metadata", "geotiff", "deadwood_treecover_combined_v2"]; // GeoTIFF workflow (no ODM needed)
+          ? RAW_IMAGES_PROCESSING_STEPS
+          : GEOTIFF_PROCESSING_STEPS;
 
       await processDataset(Number(uploadResponse.id), validAccessToken, processingSteps);
       track("upload_completed", {

--- a/frontend/src/hooks/useDatasetSubscription.ts
+++ b/frontend/src/hooks/useDatasetSubscription.ts
@@ -15,6 +15,7 @@ interface StatusPayloadData {
   is_metadata_done: boolean;
   is_deadwood_done: boolean;
   is_forest_cover_done: boolean;
+  is_combined_model_done: boolean;
   has_error: boolean;
   error_message?: string;
 }
@@ -79,7 +80,8 @@ export function useDatasetSubscription() {
                 data.is_thumbnail_done &&
                 data.is_metadata_done &&
                 data.is_deadwood_done &&
-                data.is_forest_cover_done
+                data.is_forest_cover_done &&
+                data.is_combined_model_done
               );
             };
 

--- a/frontend/src/hooks/useProcessingOverview.ts
+++ b/frontend/src/hooks/useProcessingOverview.ts
@@ -25,6 +25,7 @@ export interface ProcessingOverviewRow {
 	is_metadata_done: boolean | null;
 	is_deadwood_done: boolean | null;
 	is_forest_cover_done: boolean | null;
+	is_combined_model_done: boolean | null;
 	last_20_logs: string | null;
 }
 

--- a/frontend/src/types/dataset.ts
+++ b/frontend/src/types/dataset.ts
@@ -1,10 +1,5 @@
 import { FeatureCollection } from "geojson";
 
-interface ICentroid {
-  lng: number;
-  lat: number;
-}
-
 export interface IThumbnail {
   file_name: string;
   url: string;
@@ -74,6 +69,7 @@ export interface IDataset {
   is_thumbnail_done: boolean;
   is_deadwood_done: boolean;
   is_forest_cover_done: boolean;
+  is_combined_model_done: boolean;
   is_metadata_done: boolean;
   is_audited: boolean;
   has_error: boolean;
@@ -158,4 +154,3 @@ export interface IStats {
   countries_count: number;
   contributors_count: number;
 }
-

--- a/frontend/src/utils/processingSteps.ts
+++ b/frontend/src/utils/processingSteps.ts
@@ -12,6 +12,7 @@ export const GEOTIFF_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
   { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
   { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
+  { key: "combined_model", label: "Combined AI Analysis", description: "Running combined deadwood and tree cover model" },
 ];
 
 export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
@@ -23,6 +24,7 @@ export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
   { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
   { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
+  { key: "combined_model", label: "Combined AI Analysis", description: "Running combined deadwood and tree cover model" },
 ];
 
 export interface DatasetProgress {
@@ -34,6 +36,7 @@ export interface DatasetProgress {
   is_cog_done?: boolean;
   is_deadwood_done?: boolean;
   is_forest_cover_done?: boolean;
+  is_combined_model_done?: boolean;
   has_error?: boolean;
   current_status?: string;
   final_assessment?: "ready" | "fixable_issues" | "no_issues" | "exclude_completely" | null;
@@ -123,6 +126,7 @@ export function calculateProcessingProgress(dataset: DatasetProgress): {
     dataset.is_cog_done || false,
     isDeadwoodProcessingComplete(dataset), // Smart deadwood completion check
     isTreecoverProcessingComplete(dataset), // Smart treecover completion check
+    dataset.is_combined_model_done || false,
   ];
 
   // Find the current step (first incomplete step)

--- a/processor/src/process_deadwood_treecover_combined_v2.py
+++ b/processor/src/process_deadwood_treecover_combined_v2.py
@@ -43,7 +43,7 @@ def process_deadwood_treecover_combined_v2(task: QueueTask, token: str, temp_dir
     update_status(
         token,
         dataset_id=ortho.dataset_id,
-        current_status=StatusEnum.deadwood_segmentation,
+        current_status=StatusEnum.deadwood_treecover_combined_segmentation,
         is_combined_model_done=False,
     )
     logger.info(
@@ -87,8 +87,6 @@ def process_deadwood_treecover_combined_v2(task: QueueTask, token: str, temp_dir
             token,
             dataset_id=ortho.dataset_id,
             current_status=StatusEnum.idle,
-            is_deadwood_done=True,
-            is_forest_cover_done=True,
             is_combined_model_done=True,
         )
         logger.info(

--- a/processor/src/process_deadwood_treecover_combined_v2.py
+++ b/processor/src/process_deadwood_treecover_combined_v2.py
@@ -40,7 +40,12 @@ def process_deadwood_treecover_combined_v2(task: QueueTask, token: str, temp_dir
         )
         raise DatasetError(f'Error fetching dataset: {e}')
 
-    update_status(token, dataset_id=ortho.dataset_id, current_status=StatusEnum.deadwood_segmentation)
+    update_status(
+        token,
+        dataset_id=ortho.dataset_id,
+        current_status=StatusEnum.deadwood_segmentation,
+        is_combined_model_done=False,
+    )
     logger.info(
         'Starting combined deadwood+treecover segmentation',
         LogContext(category=LogCategory.DEADWOOD, dataset_id=task.dataset_id, user_id=user.id, token=token),
@@ -84,6 +89,7 @@ def process_deadwood_treecover_combined_v2(task: QueueTask, token: str, temp_dir
             current_status=StatusEnum.idle,
             is_deadwood_done=True,
             is_forest_cover_done=True,
+            is_combined_model_done=True,
         )
         logger.info(
             'Combined segmentation completed successfully',

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -2,7 +2,7 @@ import shutil
 from pathlib import Path
 from processor.src.process_geotiff import process_geotiff
 from processor.src.process_odm import process_odm
-from shared.models import QueueTask, TaskTypeEnum, StatusEnum
+from shared.models import COMBINED_MODEL_CONFIG, LabelDataEnum, LabelSourceEnum, QueueTask, TaskTypeEnum, StatusEnum
 from shared.settings import settings
 from shared.db import use_client, login, login_verified, verify_token
 from shared.status import update_status
@@ -19,6 +19,24 @@ from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandl
 # Initialize logger with proper cleanup
 logger = UnifiedLogger(__name__)
 logger.add_supabase_handler(SupabaseHandler())
+
+DEADWOOD_V1_MODEL_CONFIG = {
+	'module': 'deadwood_segmentation_v1_moehring',
+	'checkpoint_name': 'segformer_b5_full_epoch_100.safetensors',
+}
+TREECOVER_V1_MODEL_CONFIG = {
+	'module': 'treecover_segmentation_oam_tcd',
+	'checkpoint_name': 'restor/tcd-segformer-mit-b5',
+}
+
+MODEL_STAGE_LABEL_REQUIREMENTS = {
+	TaskTypeEnum.deadwood_v1: ((LabelDataEnum.deadwood, DEADWOOD_V1_MODEL_CONFIG),),
+	TaskTypeEnum.treecover_v1: ((LabelDataEnum.forest_cover, TREECOVER_V1_MODEL_CONFIG),),
+	TaskTypeEnum.deadwood_treecover_combined_v2: (
+		(LabelDataEnum.deadwood, COMBINED_MODEL_CONFIG),
+		(LabelDataEnum.forest_cover, COMBINED_MODEL_CONFIG),
+	),
+}
 
 
 # Maps each task type to its corresponding is_*_done flag and human-readable stage name.
@@ -43,6 +61,46 @@ def _stage_done_flags(done_flags: str | tuple[str, ...]) -> tuple[str, ...]:
 	return (done_flags,) if isinstance(done_flags, str) else done_flags
 
 
+def _model_label_key(label_data: LabelDataEnum | str, model_config: dict) -> tuple[str, str | None, str | None]:
+	return (
+		label_data.value if isinstance(label_data, LabelDataEnum) else label_data,
+		model_config.get('module'),
+		model_config.get('checkpoint_name'),
+	)
+
+
+def _model_stage_complete(
+	task_type: TaskTypeEnum,
+	completed_model_labels: set[tuple[str, str | None, str | None]] | None,
+) -> bool | None:
+	requirements = MODEL_STAGE_LABEL_REQUIREMENTS.get(task_type)
+	if not requirements or completed_model_labels is None:
+		return None
+	return all(_model_label_key(label_data, config) in completed_model_labels for label_data, config in requirements)
+
+
+def get_completed_model_labels(token: str, dataset_id: int) -> set[tuple[str, str | None, str | None]]:
+	"""Return completed model-prediction label variants for a dataset.
+
+	The shared status flags only say whether deadwood/tree-cover outputs exist.
+	They cannot distinguish legacy v1 predictions from the combined v2 model, so
+	crash recovery must also inspect model_config before dropping stale queue rows.
+	"""
+	with use_client(token) as client:
+		response = (
+			client.table(settings.labels_table)
+			.select('label_data,model_config')
+			.eq('dataset_id', dataset_id)
+			.eq('label_source', LabelSourceEnum.model_prediction.value)
+			.execute()
+		)
+
+	return {
+		_model_label_key(label['label_data'], label.get('model_config') or {})
+		for label in response.data
+	}
+
+
 def refresh_processor_token(task: QueueTask, fallback_token: str | None = None) -> str:
 	"""Best-effort token refresh for stage-boundary logging and updates."""
 	try:
@@ -53,7 +111,11 @@ def refresh_processor_token(task: QueueTask, fallback_token: str | None = None) 
 		raise AuthenticationError('Invalid processor token', token=fallback_token, task_id=task.id)
 
 
-def detect_crashed_stage(status_data: dict, task_types: list) -> str:
+def detect_crashed_stage(
+	status_data: dict,
+	task_types: list,
+	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
+) -> str:
 	"""Determine which pipeline stage a previous crash occurred during.
 
 	Walks the pipeline in order and returns the first stage that was requested
@@ -67,12 +129,18 @@ def detect_crashed_stage(status_data: dict, task_types: list) -> str:
 		str: Human-readable stage name where the crash occurred
 	"""
 	for task_type, done_flags, stage_name in PIPELINE_STAGE_MAP:
+		model_complete = _model_stage_complete(task_type, completed_model_labels)
+		if task_type in task_types and model_complete is False:
+			return stage_name
 		if task_type in task_types and not all(status_data.get(flag, False) for flag in _stage_done_flags(done_flags)):
 			return stage_name
 	return 'unknown'
 
 
-def get_completed_stages(status_data: dict) -> list[str]:
+def get_completed_stages(
+	status_data: dict,
+	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
+) -> list[str]:
 	"""Get list of pipeline stages that completed successfully before the crash.
 
 	Args:
@@ -82,14 +150,26 @@ def get_completed_stages(status_data: dict) -> list[str]:
 		list[str]: Human-readable names of completed stages
 	"""
 	completed = []
-	for _, done_flags, stage_name in PIPELINE_STAGE_MAP:
+	for task_type, done_flags, stage_name in PIPELINE_STAGE_MAP:
+		model_complete = _model_stage_complete(task_type, completed_model_labels)
+		if model_complete is False:
+			continue
 		if all(status_data.get(flag, False) for flag in _stage_done_flags(done_flags)):
 			completed.append(stage_name)
 	return completed
 
 
-def are_requested_stages_complete(status_data: dict, task_types: list) -> bool:
+def are_requested_stages_complete(
+	status_data: dict,
+	task_types: list,
+	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
+) -> bool:
 	"""Return True when all requested pipeline stages are already marked complete."""
+	for task_type in task_types:
+		model_complete = _model_stage_complete(task_type, completed_model_labels)
+		if model_complete is False:
+			return False
+
 	requested = [
 		flag
 		for task_type, done_flags, _ in PIPELINE_STAGE_MAP
@@ -504,8 +584,9 @@ def background_process():
 			should_mark_error = True
 			if status_resp.data:
 				status = status_resp.data[0]
-				completed = get_completed_stages(status)
-				if are_requested_stages_complete(status, active_task.task_types):
+				completed_model_labels = get_completed_model_labels(token, active_task.dataset_id)
+				completed = get_completed_stages(status, completed_model_labels)
+				if are_requested_stages_complete(status, active_task.task_types, completed_model_labels):
 					logger.info(
 						f'Removing stale completed queue task {active_task.id} for dataset {active_task.dataset_id}',
 						LogContext(
@@ -519,10 +600,10 @@ def background_process():
 					crashed_stage = 'completed'
 					error_msg = ''
 				elif status['current_status'] != 'idle':
-					crashed_stage = detect_crashed_stage(status, active_task.task_types)
+					crashed_stage = detect_crashed_stage(status, active_task.task_types, completed_model_labels)
 					error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
 				elif completed:
-					crashed_stage = detect_crashed_stage(status, active_task.task_types)
+					crashed_stage = detect_crashed_stage(status, active_task.task_types, completed_model_labels)
 					error_msg = f'Processing container crashed after completing {completed} and before starting {crashed_stage}.'
 				else:
 					crashed_stage = 'startup'
@@ -592,8 +673,9 @@ def background_process():
 			status = status_resp.data[0]
 			if status['current_status'] != 'idle':
 				# Previous crash detected - current_status is still set to a processing stage
-				crashed_stage = detect_crashed_stage(status, task.task_types)
-				completed = get_completed_stages(status)
+				completed_model_labels = get_completed_model_labels(token, task.dataset_id)
+				crashed_stage = detect_crashed_stage(status, task.task_types, completed_model_labels)
+				completed = get_completed_stages(status, completed_model_labels)
 				error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
 
 				logger.warning(

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -2,7 +2,7 @@ import shutil
 from pathlib import Path
 from processor.src.process_geotiff import process_geotiff
 from processor.src.process_odm import process_odm
-from shared.models import COMBINED_MODEL_CONFIG, LabelDataEnum, LabelSourceEnum, QueueTask, TaskTypeEnum, StatusEnum
+from shared.models import QueueTask, TaskTypeEnum, StatusEnum
 from shared.settings import settings
 from shared.db import use_client, login, login_verified, verify_token
 from shared.status import update_status
@@ -20,25 +20,6 @@ from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandl
 logger = UnifiedLogger(__name__)
 logger.add_supabase_handler(SupabaseHandler())
 
-DEADWOOD_V1_MODEL_CONFIG = {
-	'module': 'deadwood_segmentation_v1_moehring',
-	'checkpoint_name': 'segformer_b5_full_epoch_100.safetensors',
-}
-TREECOVER_V1_MODEL_CONFIG = {
-	'module': 'treecover_segmentation_oam_tcd',
-	'checkpoint_name': 'restor/tcd-segformer-mit-b5',
-}
-
-MODEL_STAGE_LABEL_REQUIREMENTS = {
-	TaskTypeEnum.deadwood_v1: ((LabelDataEnum.deadwood, DEADWOOD_V1_MODEL_CONFIG),),
-	TaskTypeEnum.treecover_v1: ((LabelDataEnum.forest_cover, TREECOVER_V1_MODEL_CONFIG),),
-	TaskTypeEnum.deadwood_treecover_combined_v2: (
-		(LabelDataEnum.deadwood, COMBINED_MODEL_CONFIG),
-		(LabelDataEnum.forest_cover, COMBINED_MODEL_CONFIG),
-	),
-}
-
-
 # Maps each task type to its corresponding is_*_done flag and human-readable stage name.
 # Used by crash detection to determine exactly which stage a previous run crashed during.
 PIPELINE_STAGE_MAP = [
@@ -51,7 +32,7 @@ PIPELINE_STAGE_MAP = [
 	(TaskTypeEnum.treecover_v1, 'is_forest_cover_done', 'forest_cover_segmentation'),
 	(
 		TaskTypeEnum.deadwood_treecover_combined_v2,
-		('is_deadwood_done', 'is_forest_cover_done'),
+		'is_combined_model_done',
 		'deadwood_treecover_combined_segmentation',
 	),
 ]
@@ -59,46 +40,6 @@ PIPELINE_STAGE_MAP = [
 
 def _stage_done_flags(done_flags: str | tuple[str, ...]) -> tuple[str, ...]:
 	return (done_flags,) if isinstance(done_flags, str) else done_flags
-
-
-def _model_label_key(label_data: LabelDataEnum | str, model_config: dict) -> tuple[str, str | None, str | None]:
-	return (
-		label_data.value if isinstance(label_data, LabelDataEnum) else label_data,
-		model_config.get('module'),
-		model_config.get('checkpoint_name'),
-	)
-
-
-def _model_stage_complete(
-	task_type: TaskTypeEnum,
-	completed_model_labels: set[tuple[str, str | None, str | None]] | None,
-) -> bool | None:
-	requirements = MODEL_STAGE_LABEL_REQUIREMENTS.get(task_type)
-	if not requirements or completed_model_labels is None:
-		return None
-	return all(_model_label_key(label_data, config) in completed_model_labels for label_data, config in requirements)
-
-
-def get_completed_model_labels(token: str, dataset_id: int) -> set[tuple[str, str | None, str | None]]:
-	"""Return completed model-prediction label variants for a dataset.
-
-	The shared status flags only say whether deadwood/tree-cover outputs exist.
-	They cannot distinguish legacy v1 predictions from the combined v2 model, so
-	crash recovery must also inspect model_config before dropping stale queue rows.
-	"""
-	with use_client(token) as client:
-		response = (
-			client.table(settings.labels_table)
-			.select('label_data,model_config')
-			.eq('dataset_id', dataset_id)
-			.eq('label_source', LabelSourceEnum.model_prediction.value)
-			.execute()
-		)
-
-	return {
-		_model_label_key(label['label_data'], label.get('model_config') or {})
-		for label in response.data
-	}
 
 
 def refresh_processor_token(task: QueueTask, fallback_token: str | None = None) -> str:
@@ -111,11 +52,7 @@ def refresh_processor_token(task: QueueTask, fallback_token: str | None = None) 
 		raise AuthenticationError('Invalid processor token', token=fallback_token, task_id=task.id)
 
 
-def detect_crashed_stage(
-	status_data: dict,
-	task_types: list,
-	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
-) -> str:
+def detect_crashed_stage(status_data: dict, task_types: list) -> str:
 	"""Determine which pipeline stage a previous crash occurred during.
 
 	Walks the pipeline in order and returns the first stage that was requested
@@ -129,18 +66,12 @@ def detect_crashed_stage(
 		str: Human-readable stage name where the crash occurred
 	"""
 	for task_type, done_flags, stage_name in PIPELINE_STAGE_MAP:
-		model_complete = _model_stage_complete(task_type, completed_model_labels)
-		if task_type in task_types and model_complete is False:
-			return stage_name
 		if task_type in task_types and not all(status_data.get(flag, False) for flag in _stage_done_flags(done_flags)):
 			return stage_name
 	return 'unknown'
 
 
-def get_completed_stages(
-	status_data: dict,
-	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
-) -> list[str]:
+def get_completed_stages(status_data: dict) -> list[str]:
 	"""Get list of pipeline stages that completed successfully before the crash.
 
 	Args:
@@ -151,25 +82,13 @@ def get_completed_stages(
 	"""
 	completed = []
 	for task_type, done_flags, stage_name in PIPELINE_STAGE_MAP:
-		model_complete = _model_stage_complete(task_type, completed_model_labels)
-		if model_complete is False:
-			continue
 		if all(status_data.get(flag, False) for flag in _stage_done_flags(done_flags)):
 			completed.append(stage_name)
 	return completed
 
 
-def are_requested_stages_complete(
-	status_data: dict,
-	task_types: list,
-	completed_model_labels: set[tuple[str, str | None, str | None]] | None = None,
-) -> bool:
+def are_requested_stages_complete(status_data: dict, task_types: list) -> bool:
 	"""Return True when all requested pipeline stages are already marked complete."""
-	for task_type in task_types:
-		model_complete = _model_stage_complete(task_type, completed_model_labels)
-		if model_complete is False:
-			return False
-
 	requested = [
 		flag
 		for task_type, done_flags, _ in PIPELINE_STAGE_MAP
@@ -177,7 +96,6 @@ def are_requested_stages_complete(
 		for flag in _stage_done_flags(done_flags)
 	]
 	return bool(requested) and all(status_data.get(done_flag, False) for done_flag in requested)
-
 
 
 def get_next_task(token: str) -> QueueTask:
@@ -584,9 +502,8 @@ def background_process():
 			should_mark_error = True
 			if status_resp.data:
 				status = status_resp.data[0]
-				completed_model_labels = get_completed_model_labels(token, active_task.dataset_id)
-				completed = get_completed_stages(status, completed_model_labels)
-				if are_requested_stages_complete(status, active_task.task_types, completed_model_labels):
+				completed = get_completed_stages(status)
+				if are_requested_stages_complete(status, active_task.task_types):
 					logger.info(
 						f'Removing stale completed queue task {active_task.id} for dataset {active_task.dataset_id}',
 						LogContext(
@@ -600,10 +517,10 @@ def background_process():
 					crashed_stage = 'completed'
 					error_msg = ''
 				elif status['current_status'] != 'idle':
-					crashed_stage = detect_crashed_stage(status, active_task.task_types, completed_model_labels)
+					crashed_stage = detect_crashed_stage(status, active_task.task_types)
 					error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
 				elif completed:
-					crashed_stage = detect_crashed_stage(status, active_task.task_types, completed_model_labels)
+					crashed_stage = detect_crashed_stage(status, active_task.task_types)
 					error_msg = f'Processing container crashed after completing {completed} and before starting {crashed_stage}.'
 				else:
 					crashed_stage = 'startup'
@@ -673,9 +590,8 @@ def background_process():
 			status = status_resp.data[0]
 			if status['current_status'] != 'idle':
 				# Previous crash detected - current_status is still set to a processing stage
-				completed_model_labels = get_completed_model_labels(token, task.dataset_id)
-				crashed_stage = detect_crashed_stage(status, task.task_types, completed_model_labels)
-				completed = get_completed_stages(status, completed_model_labels)
+				crashed_stage = detect_crashed_stage(status, task.task_types)
+				completed = get_completed_stages(status)
 				error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
 
 				logger.warning(

--- a/processor/src/utils/linear_issues.py
+++ b/processor/src/utils/linear_issues.py
@@ -35,6 +35,7 @@ def get_stage_display_name(stage: str) -> str:
 	legacy_mapping = {
 		'deadwood_segmentation': 'Deadwood',
 		'treecover_segmentation': 'Tree Cover',
+		'deadwood_treecover_combined_segmentation': 'Combined Deadwood+Treecover',
 		'processing': 'Processing',
 	}
 	return legacy_mapping.get(stage, stage)

--- a/processor/tests/test_process_deadwood_treecover_combined_v2.py
+++ b/processor/tests/test_process_deadwood_treecover_combined_v2.py
@@ -101,8 +101,8 @@ def test_process_combined_segmentation_success(combined_task, auth_token):
 
 	status = status_response.data[0]
 	assert status['is_combined_model_done'] is True
-	assert status['is_deadwood_done'] is True
-	assert status['is_forest_cover_done'] is True
+	assert status['is_deadwood_done'] is False
+	assert status['is_forest_cover_done'] is False
 
 	label_data_values = {label['label_data'] for label in response.data}
 	# The model must save at least one of the two layers (empty predictions are skipped)

--- a/processor/tests/test_process_deadwood_treecover_combined_v2.py
+++ b/processor/tests/test_process_deadwood_treecover_combined_v2.py
@@ -95,6 +95,14 @@ def test_process_combined_segmentation_success(combined_task, auth_token):
 		response = (
 			client.table(settings.labels_table).select('*').eq('dataset_id', combined_task.dataset_id).execute()
 		)
+		status_response = (
+			client.table(settings.statuses_table).select('*').eq('dataset_id', combined_task.dataset_id).execute()
+		)
+
+	status = status_response.data[0]
+	assert status['is_combined_model_done'] is True
+	assert status['is_deadwood_done'] is True
+	assert status['is_forest_cover_done'] is True
 
 	label_data_values = {label['label_data'] for label in response.data}
 	# The model must save at least one of the two layers (empty predictions are skipped)

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -4,11 +4,10 @@ from pathlib import Path
 import processor.src.processor as processor_module
 from shared.db import use_client
 from shared.settings import settings
-from shared.models import COMBINED_MODEL_CONFIG, LabelDataEnum, TaskTypeEnum, QueueTask, StatusEnum
+from shared.models import TaskTypeEnum, QueueTask, StatusEnum
 from processor.src.processor import (
 	background_process, process_task, get_next_task,
 	detect_crashed_stage, get_completed_stages, are_requested_stages_complete, PIPELINE_STAGE_MAP,
-	DEADWOOD_V1_MODEL_CONFIG, TREECOVER_V1_MODEL_CONFIG,
 )
 
 
@@ -164,7 +163,7 @@ def test_pipeline_stage_map_is_stable_and_ordered():
 		(TaskTypeEnum.treecover_v1, 'is_forest_cover_done', 'forest_cover_segmentation'),
 		(
 			TaskTypeEnum.deadwood_treecover_combined_v2,
-			('is_deadwood_done', 'is_forest_cover_done'),
+			'is_combined_model_done',
 			'deadwood_treecover_combined_segmentation',
 		),
 	]
@@ -482,10 +481,11 @@ def test_are_requested_stages_complete_only_returns_true_when_all_requested_flag
 	assert are_requested_stages_complete(status_data, []) is False
 
 
-def test_combined_stage_requires_both_deadwood_and_forest_cover_flags():
+def test_combined_stage_requires_combined_model_flag():
 	status_data = {
 		'is_deadwood_done': True,
-		'is_forest_cover_done': False,
+		'is_forest_cover_done': True,
+		'is_combined_model_done': False,
 	}
 
 	assert (
@@ -494,85 +494,49 @@ def test_combined_stage_requires_both_deadwood_and_forest_cover_flags():
 	)
 	assert are_requested_stages_complete(status_data, [TaskTypeEnum.deadwood_treecover_combined_v2]) is False
 
-	status_data['is_forest_cover_done'] = True
+	status_data['is_combined_model_done'] = True
 	assert detect_crashed_stage(status_data, [TaskTypeEnum.deadwood_treecover_combined_v2]) == 'unknown'
 	assert are_requested_stages_complete(status_data, [TaskTypeEnum.deadwood_treecover_combined_v2]) is True
 	assert 'deadwood_treecover_combined_segmentation' in get_completed_stages(status_data)
 
 
-def test_mixed_legacy_and_combined_recovery_requires_combined_model_labels():
+def test_mixed_legacy_and_combined_recovery_requires_combined_model_flag():
 	status_data = {
 		'is_deadwood_done': True,
 		'is_forest_cover_done': True,
+		'is_combined_model_done': False,
 	}
 	task_types = [
 		TaskTypeEnum.deadwood_v1,
 		TaskTypeEnum.treecover_v1,
 		TaskTypeEnum.deadwood_treecover_combined_v2,
 	]
-	completed_model_labels = {
-		(
-			LabelDataEnum.deadwood.value,
-			DEADWOOD_V1_MODEL_CONFIG['module'],
-			DEADWOOD_V1_MODEL_CONFIG['checkpoint_name'],
-		),
-		(
-			LabelDataEnum.forest_cover.value,
-			TREECOVER_V1_MODEL_CONFIG['module'],
-			TREECOVER_V1_MODEL_CONFIG['checkpoint_name'],
-		),
-	}
 
-	assert are_requested_stages_complete(status_data, task_types, completed_model_labels) is False
+	assert are_requested_stages_complete(status_data, task_types) is False
 	assert (
-		detect_crashed_stage(status_data, task_types, completed_model_labels)
+		detect_crashed_stage(status_data, task_types)
 		== 'deadwood_treecover_combined_segmentation'
 	)
-	assert 'deadwood_segmentation' in get_completed_stages(status_data, completed_model_labels)
-	assert 'forest_cover_segmentation' in get_completed_stages(status_data, completed_model_labels)
-	assert 'deadwood_treecover_combined_segmentation' not in get_completed_stages(
-		status_data, completed_model_labels
-	)
+	assert 'deadwood_segmentation' in get_completed_stages(status_data)
+	assert 'forest_cover_segmentation' in get_completed_stages(status_data)
+	assert 'deadwood_treecover_combined_segmentation' not in get_completed_stages(status_data)
 
 
-def test_mixed_legacy_and_combined_recovery_accepts_all_model_labels():
+def test_mixed_legacy_and_combined_recovery_accepts_combined_model_flag():
 	status_data = {
 		'is_deadwood_done': True,
 		'is_forest_cover_done': True,
+		'is_combined_model_done': True,
 	}
 	task_types = [
 		TaskTypeEnum.deadwood_v1,
 		TaskTypeEnum.treecover_v1,
 		TaskTypeEnum.deadwood_treecover_combined_v2,
 	]
-	completed_model_labels = {
-		(
-			LabelDataEnum.deadwood.value,
-			DEADWOOD_V1_MODEL_CONFIG['module'],
-			DEADWOOD_V1_MODEL_CONFIG['checkpoint_name'],
-		),
-		(
-			LabelDataEnum.forest_cover.value,
-			TREECOVER_V1_MODEL_CONFIG['module'],
-			TREECOVER_V1_MODEL_CONFIG['checkpoint_name'],
-		),
-		(
-			LabelDataEnum.deadwood.value,
-			COMBINED_MODEL_CONFIG['module'],
-			COMBINED_MODEL_CONFIG['checkpoint_name'],
-		),
-		(
-			LabelDataEnum.forest_cover.value,
-			COMBINED_MODEL_CONFIG['module'],
-			COMBINED_MODEL_CONFIG['checkpoint_name'],
-		),
-	}
 
-	assert are_requested_stages_complete(status_data, task_types, completed_model_labels) is True
-	assert detect_crashed_stage(status_data, task_types, completed_model_labels) == 'unknown'
-	assert 'deadwood_treecover_combined_segmentation' in get_completed_stages(
-		status_data, completed_model_labels
-	)
+	assert are_requested_stages_complete(status_data, task_types) is True
+	assert detect_crashed_stage(status_data, task_types) == 'unknown'
+	assert 'deadwood_treecover_combined_segmentation' in get_completed_stages(status_data)
 
 
 @pytest.fixture

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -4,10 +4,11 @@ from pathlib import Path
 import processor.src.processor as processor_module
 from shared.db import use_client
 from shared.settings import settings
-from shared.models import TaskTypeEnum, QueueTask, StatusEnum
+from shared.models import COMBINED_MODEL_CONFIG, LabelDataEnum, TaskTypeEnum, QueueTask, StatusEnum
 from processor.src.processor import (
 	background_process, process_task, get_next_task,
 	detect_crashed_stage, get_completed_stages, are_requested_stages_complete, PIPELINE_STAGE_MAP,
+	DEADWOOD_V1_MODEL_CONFIG, TREECOVER_V1_MODEL_CONFIG,
 )
 
 
@@ -497,6 +498,81 @@ def test_combined_stage_requires_both_deadwood_and_forest_cover_flags():
 	assert detect_crashed_stage(status_data, [TaskTypeEnum.deadwood_treecover_combined_v2]) == 'unknown'
 	assert are_requested_stages_complete(status_data, [TaskTypeEnum.deadwood_treecover_combined_v2]) is True
 	assert 'deadwood_treecover_combined_segmentation' in get_completed_stages(status_data)
+
+
+def test_mixed_legacy_and_combined_recovery_requires_combined_model_labels():
+	status_data = {
+		'is_deadwood_done': True,
+		'is_forest_cover_done': True,
+	}
+	task_types = [
+		TaskTypeEnum.deadwood_v1,
+		TaskTypeEnum.treecover_v1,
+		TaskTypeEnum.deadwood_treecover_combined_v2,
+	]
+	completed_model_labels = {
+		(
+			LabelDataEnum.deadwood.value,
+			DEADWOOD_V1_MODEL_CONFIG['module'],
+			DEADWOOD_V1_MODEL_CONFIG['checkpoint_name'],
+		),
+		(
+			LabelDataEnum.forest_cover.value,
+			TREECOVER_V1_MODEL_CONFIG['module'],
+			TREECOVER_V1_MODEL_CONFIG['checkpoint_name'],
+		),
+	}
+
+	assert are_requested_stages_complete(status_data, task_types, completed_model_labels) is False
+	assert (
+		detect_crashed_stage(status_data, task_types, completed_model_labels)
+		== 'deadwood_treecover_combined_segmentation'
+	)
+	assert 'deadwood_segmentation' in get_completed_stages(status_data, completed_model_labels)
+	assert 'forest_cover_segmentation' in get_completed_stages(status_data, completed_model_labels)
+	assert 'deadwood_treecover_combined_segmentation' not in get_completed_stages(
+		status_data, completed_model_labels
+	)
+
+
+def test_mixed_legacy_and_combined_recovery_accepts_all_model_labels():
+	status_data = {
+		'is_deadwood_done': True,
+		'is_forest_cover_done': True,
+	}
+	task_types = [
+		TaskTypeEnum.deadwood_v1,
+		TaskTypeEnum.treecover_v1,
+		TaskTypeEnum.deadwood_treecover_combined_v2,
+	]
+	completed_model_labels = {
+		(
+			LabelDataEnum.deadwood.value,
+			DEADWOOD_V1_MODEL_CONFIG['module'],
+			DEADWOOD_V1_MODEL_CONFIG['checkpoint_name'],
+		),
+		(
+			LabelDataEnum.forest_cover.value,
+			TREECOVER_V1_MODEL_CONFIG['module'],
+			TREECOVER_V1_MODEL_CONFIG['checkpoint_name'],
+		),
+		(
+			LabelDataEnum.deadwood.value,
+			COMBINED_MODEL_CONFIG['module'],
+			COMBINED_MODEL_CONFIG['checkpoint_name'],
+		),
+		(
+			LabelDataEnum.forest_cover.value,
+			COMBINED_MODEL_CONFIG['module'],
+			COMBINED_MODEL_CONFIG['checkpoint_name'],
+		),
+	}
+
+	assert are_requested_stages_complete(status_data, task_types, completed_model_labels) is True
+	assert detect_crashed_stage(status_data, task_types, completed_model_labels) == 'unknown'
+	assert 'deadwood_treecover_combined_segmentation' in get_completed_stages(
+		status_data, completed_model_labels
+	)
 
 
 @pytest.fixture

--- a/shared/models.py
+++ b/shared/models.py
@@ -74,6 +74,7 @@ class StatusEnum(str, Enum):
 	thumbnail_processing = 'thumbnail_processing'
 	deadwood_segmentation = 'deadwood_segmentation'
 	forest_cover_segmentation = 'forest_cover_segmentation'
+	deadwood_treecover_combined_segmentation = 'deadwood_treecover_combined_segmentation'
 	audit_in_progress = 'audit_in_progress'
 
 

--- a/shared/models.py
+++ b/shared/models.py
@@ -182,6 +182,7 @@ class Status(BaseModel):
 	is_thumbnail_done: bool = False
 	is_deadwood_done: bool = False
 	is_forest_cover_done: bool = False
+	is_combined_model_done: bool = False
 	is_metadata_done: bool = False
 	is_odm_done: bool = False
 	is_audited: bool = False

--- a/shared/status.py
+++ b/shared/status.py
@@ -16,6 +16,7 @@ def update_status(
 	is_thumbnail_done: Optional[bool] = None,
 	is_deadwood_done: Optional[bool] = None,
 	is_forest_cover_done: Optional[bool] = None,
+	is_combined_model_done: Optional[bool] = None,
 	is_metadata_done: Optional[bool] = None,
 	is_odm_done: Optional[bool] = None,
 	is_audited: Optional[bool] = None,
@@ -35,6 +36,7 @@ def update_status(
 	    is_thumbnail_done (bool, optional): Thumbnail generation completion status
 	    is_deadwood_done (bool, optional): Deadwood segmentation completion status
 	    is_forest_cover_done (bool, optional): Forest cover completion status
+	    is_combined_model_done (bool, optional): Combined model completion status
 	    is_metadata_done (bool, optional): Metadata processing completion status
 	    is_odm_done (bool, optional): ODM processing completion status
 	    is_audited (bool, optional): Audit completion status
@@ -57,6 +59,8 @@ def update_status(
 			update_data['is_deadwood_done'] = is_deadwood_done
 		if is_forest_cover_done is not None:
 			update_data['is_forest_cover_done'] = is_forest_cover_done
+		if is_combined_model_done is not None:
+			update_data['is_combined_model_done'] = is_combined_model_done
 		if is_metadata_done is not None:
 			update_data['is_metadata_done'] = is_metadata_done
 		if is_odm_done is not None:

--- a/shared/tests/test_odm_models.py
+++ b/shared/tests/test_odm_models.py
@@ -137,6 +137,14 @@ def test_status_model_is_odm_done_serialization():
 	assert status_dict['is_odm_done'] is True
 
 
+def test_status_model_is_combined_model_done_serialization():
+	"""Test that the dedicated combined-model flag serializes correctly."""
+	status = Status(dataset_id=1, is_combined_model_done=True)
+	status_dict = status.model_dump()
+	assert 'is_combined_model_done' in status_dict
+	assert status_dict['is_combined_model_done'] is True
+
+
 def test_status_model_all_odm_flags():
 	"""Test that Status model has all expected completion flags"""
 	status = Status(dataset_id=1)
@@ -147,6 +155,7 @@ def test_status_model_all_odm_flags():
 		'is_thumbnail_done',
 		'is_deadwood_done',
 		'is_forest_cover_done',
+		'is_combined_model_done',
 		'is_metadata_done',
 		'is_odm_done',
 	]

--- a/shared/tests/test_odm_models.py
+++ b/shared/tests/test_odm_models.py
@@ -111,6 +111,7 @@ def test_all_expected_status_values_present():
 		'metadata_processing',
 		'odm_processing',
 		'thumbnail_processing',
+		'deadwood_treecover_combined_segmentation',
 	}
 	actual_values = {status.value for status in StatusEnum}
 	assert expected_values.issubset(actual_values)

--- a/supabase/migrations/20260429100000_add-combined-model-status.sql
+++ b/supabase/migrations/20260429100000_add-combined-model-status.sql
@@ -1,0 +1,15 @@
+alter table public.v2_statuses
+  add column if not exists is_combined_model_done boolean not null default false;
+
+update public.v2_statuses as status
+set is_combined_model_done = true
+where exists (
+  select 1
+  from public.v2_labels as label
+  where label.dataset_id = status.dataset_id
+    and label.label_source::text = 'model_prediction'
+    and label.model_config ->> 'module' = 'deadwood_treecover_combined_v2'
+    and label.label_data::text in ('deadwood', 'forest_cover')
+  group by label.dataset_id
+  having count(distinct label.label_data::text) = 2
+);

--- a/supabase/migrations/20260429110000_combined-model-status-first-class.sql
+++ b/supabase/migrations/20260429110000_combined-model-status-first-class.sql
@@ -1,0 +1,392 @@
+alter type public.v2_status
+  add value if not exists 'deadwood_treecover_combined_segmentation';
+
+create or replace view "public"."v2_full_dataset_view" as
+with ds as (
+    select
+        v2_datasets.id,
+        v2_datasets.user_id,
+        v2_datasets.created_at,
+        v2_datasets.file_name,
+        v2_datasets.license,
+        v2_datasets.platform,
+        v2_datasets.project_id,
+        v2_datasets.authors,
+        v2_datasets.aquisition_year,
+        v2_datasets.aquisition_month,
+        v2_datasets.aquisition_day,
+        v2_datasets.additional_information,
+        v2_datasets.data_access,
+        v2_datasets.citation_doi,
+        v2_datasets.archived
+    from v2_datasets
+    where (
+        (v2_datasets.data_access <> 'private'::access)
+        or (auth.uid() = v2_datasets.user_id)
+        or can_view_all_private_data()
+    )
+    and (
+        v2_datasets.archived = false
+        or auth.uid() = v2_datasets.user_id
+    )
+), ortho as (
+    select
+        v2_orthos.dataset_id,
+        v2_orthos.ortho_file_name,
+        v2_orthos.ortho_file_size,
+        v2_orthos.bbox,
+        v2_orthos.sha256,
+        v2_orthos.ortho_upload_runtime
+    from v2_orthos
+), status as (
+    select
+        v2_statuses.dataset_id,
+        v2_statuses.current_status,
+        v2_statuses.is_upload_done,
+        v2_statuses.is_ortho_done,
+        v2_statuses.is_cog_done,
+        v2_statuses.is_thumbnail_done,
+        v2_statuses.is_deadwood_done,
+        v2_statuses.is_forest_cover_done,
+        v2_statuses.is_metadata_done,
+        v2_statuses.is_odm_done,
+        (
+            exists (
+                select 1
+                from dataset_audit da
+                where da.dataset_id = v2_statuses.dataset_id
+            )
+        ) as is_audited,
+        v2_statuses.has_error,
+        v2_statuses.error_message,
+        v2_statuses.has_ml_tiles,
+        v2_statuses.ml_tiles_completed_at,
+        v2_statuses.is_combined_model_done
+    from v2_statuses
+), extra as (
+    select
+        ds_1.id as dataset_id,
+        cog.cog_file_name,
+        cog.cog_path,
+        cog.cog_file_size,
+        thumb.thumbnail_file_name,
+        thumb.thumbnail_path,
+        (meta.metadata ->> 'gadm'::text) as admin_metadata,
+        (meta.metadata ->> 'biome'::text) as biome_metadata
+    from v2_datasets ds_1
+    left join v2_cogs cog on cog.dataset_id = ds_1.id
+    left join v2_thumbnails thumb on thumb.dataset_id = ds_1.id
+    left join v2_metadata meta on meta.dataset_id = ds_1.id
+    where (
+        (ds_1.data_access <> 'private'::access)
+        or (auth.uid() = ds_1.user_id)
+        or can_view_all_private_data()
+    )
+    and (
+        ds_1.archived = false
+        or auth.uid() = ds_1.user_id
+    )
+), label_info as (
+    select
+        dataset.id as dataset_id,
+        (
+            exists (
+                select 1
+                from v2_labels
+                where v2_labels.dataset_id = dataset.id
+                    and v2_labels.label_source = 'visual_interpretation'::"LabelSource"
+                    and v2_labels.label_data = 'deadwood'::"LabelData"
+            )
+        ) as has_labels,
+        (
+            exists (
+                select 1
+                from v2_labels
+                where v2_labels.dataset_id = dataset.id
+                    and v2_labels.label_source = 'model_prediction'::"LabelSource"
+                    and v2_labels.label_data = 'deadwood'::"LabelData"
+            )
+        ) as has_deadwood_prediction
+    from v2_datasets dataset
+    where (
+        (dataset.data_access <> 'private'::access)
+        or (auth.uid() = dataset.user_id)
+        or can_view_all_private_data()
+    )
+    and (
+        dataset.archived = false
+        or auth.uid() = dataset.user_id
+    )
+), freidata_doi as (
+    select
+        jt.dataset_id,
+        dp.doi as freidata_doi
+    from jt_data_publication_datasets jt
+    join data_publication dp on dp.id = jt.publication_id
+    where dp.doi is not null
+), correction_stats as (
+    select
+        gc.dataset_id,
+        count(*) filter (where gc.review_status = 'pending'::text) as pending_corrections_count,
+        count(*) filter (where gc.review_status = 'approved'::text) as approved_corrections_count,
+        count(*) filter (where gc.review_status = 'rejected'::text) as rejected_corrections_count,
+        count(*) as total_corrections_count
+    from v2_geometry_corrections gc
+    group by gc.dataset_id
+)
+select
+    ds.id,
+    ds.user_id,
+    ds.created_at,
+    ds.file_name,
+    ds.license,
+    ds.platform,
+    ds.project_id,
+    ds.authors,
+    ds.aquisition_year,
+    ds.aquisition_month,
+    ds.aquisition_day,
+    ds.additional_information,
+    ds.data_access,
+    ds.citation_doi,
+    ds.archived,
+    ortho.ortho_file_name,
+    ortho.ortho_file_size,
+    ortho.bbox,
+    ortho.sha256,
+    status.current_status,
+    status.is_upload_done,
+    status.is_ortho_done,
+    status.is_cog_done,
+    status.is_thumbnail_done,
+    status.is_deadwood_done,
+    status.is_forest_cover_done,
+    status.is_metadata_done,
+    status.is_odm_done,
+    status.is_audited,
+    status.has_error,
+    status.error_message,
+    extra.cog_file_name,
+    extra.cog_path,
+    extra.cog_file_size,
+    extra.thumbnail_file_name,
+    extra.thumbnail_path,
+    ((extra.admin_metadata)::jsonb ->> 'admin_level_1'::text) as admin_level_1,
+    ((extra.admin_metadata)::jsonb ->> 'admin_level_2'::text) as admin_level_2,
+    ((extra.admin_metadata)::jsonb ->> 'admin_level_3'::text) as admin_level_3,
+    ((extra.biome_metadata)::jsonb ->> 'biome_name'::text) as biome_name,
+    label_info.has_labels,
+    label_info.has_deadwood_prediction,
+    freidata_doi.freidata_doi,
+    status.has_ml_tiles,
+    status.ml_tiles_completed_at,
+    coalesce(correction_stats.pending_corrections_count, 0::bigint) as pending_corrections_count,
+    coalesce(correction_stats.approved_corrections_count, 0::bigint) as approved_corrections_count,
+    coalesce(correction_stats.rejected_corrections_count, 0::bigint) as rejected_corrections_count,
+    coalesce(correction_stats.total_corrections_count, 0::bigint) as total_corrections_count,
+    status.is_combined_model_done
+from ds
+left join ortho on ortho.dataset_id = ds.id
+left join status on status.dataset_id = ds.id
+left join extra on extra.dataset_id = ds.id
+left join label_info on label_info.dataset_id = ds.id
+left join freidata_doi on freidata_doi.dataset_id = ds.id
+left join correction_stats on correction_stats.dataset_id = ds.id;
+
+alter view public.v2_full_dataset_view set (security_invoker = true);
+
+create or replace view "public"."v2_full_dataset_view_public" as
+select
+  base.id,
+  base.user_id,
+  base.created_at,
+  base.file_name,
+  base.license,
+  base.platform,
+  base.project_id,
+  base.authors,
+  base.aquisition_year,
+  base.aquisition_month,
+  base.aquisition_day,
+  base.additional_information,
+  base.data_access,
+  base.citation_doi,
+  base.archived,
+  base.ortho_file_name,
+  base.ortho_file_size,
+  base.bbox,
+  base.sha256,
+  base.current_status,
+  base.is_upload_done,
+  base.is_ortho_done,
+  base.is_cog_done,
+  base.is_thumbnail_done,
+  base.is_deadwood_done,
+  base.is_forest_cover_done,
+  base.is_metadata_done,
+  base.is_odm_done,
+  base.is_audited,
+  base.has_error,
+  base.error_message,
+  base.cog_file_name,
+  base.cog_path,
+  base.cog_file_size,
+  base.thumbnail_file_name,
+  base.thumbnail_path,
+  base.admin_level_1,
+  base.admin_level_2,
+  base.admin_level_3,
+  base.biome_name,
+  base.has_labels,
+  base.has_deadwood_prediction,
+  base.freidata_doi,
+  base.has_ml_tiles,
+  base.ml_tiles_completed_at,
+  base.pending_corrections_count,
+  base.approved_corrections_count,
+  base.rejected_corrections_count,
+  base.total_corrections_count,
+  audit_data.final_assessment,
+  audit_data.deadwood_quality,
+  audit_data.forest_cover_quality,
+  audit_data.has_major_issue,
+  audit_data.audit_date,
+  audit_data.has_valid_phenology,
+  audit_data.has_valid_acquisition_date,
+  case
+    when audit_data.deadwood_quality in ('great', 'sentinel_ok') then true
+    else false
+  end as show_deadwood_predictions,
+  case
+    when audit_data.forest_cover_quality in ('great', 'sentinel_ok') then true
+    else false
+  end as show_forest_cover_predictions,
+  base.is_combined_model_done
+from v2_full_dataset_view base
+left join (
+  select
+    da.dataset_id,
+    da.final_assessment,
+    da.deadwood_quality::text,
+    da.forest_cover_quality::text,
+    da.has_major_issue,
+    da.audit_date,
+    da.has_valid_phenology,
+    da.has_valid_acquisition_date
+  from dataset_audit da
+) audit_data on audit_data.dataset_id = base.id
+where (
+  (audit_data.final_assessment is null)
+  or (audit_data.final_assessment <> 'exclude_completely'::text)
+)
+and base.archived = false;
+
+alter view public.v2_full_dataset_view_public set (security_invoker = true);
+
+grant select on table "public"."v2_full_dataset_view_public" to "anon";
+grant select on table "public"."v2_full_dataset_view_public" to "authenticated";
+grant select on table "public"."v2_full_dataset_view_public" to "service_role";
+
+create or replace view "public"."v2_processing_overview" as
+select distinct on (d.id)
+    d.id as dataset_id,
+    d.file_name,
+    d.created_at as dataset_created_at,
+    case
+        when ((coalesce(ri.raw_image_count, 0) > 0) or s.is_odm_done) then 'odm'::text
+        else 'geotiff'::text
+    end as processing_source,
+    case
+        when ((s.current_status <> 'idle'::v2_status) and (s.has_error is distinct from true)) then 'PROCESSING'::text
+        when (exists (select 1 from v2_queue q where q.dataset_id = d.id)) then 'QUEUED'::text
+        when s.has_error then 'FAILED'::text
+        else 'COMPLETED'::text
+    end as processing_status,
+    s.current_status,
+    s.has_error,
+    s.error_message,
+    (extract(epoch from (now() - s.updated_at)) / 3600::numeric) as hours_since_status_update,
+    case
+        when (s.current_status <> 'idle'::v2_status) then (extract(epoch from (now() - s.updated_at)) / 3600::numeric)
+        else null::numeric
+    end as hours_in_current_status,
+    s.updated_at as status_last_updated,
+    exists (select 1 from v2_queue q where q.dataset_id = d.id) as is_in_queue,
+    (select min(q.created_at) from v2_queue q where q.dataset_id = d.id) as queued_at,
+    (select min(q.priority) from v2_queue q where q.dataset_id = d.id) as queue_priority,
+    au.email as user_email,
+    ui.organisation,
+    s.is_upload_done,
+    s.is_ortho_done,
+    s.is_cog_done,
+    s.is_thumbnail_done,
+    s.is_deadwood_done,
+    s.is_forest_cover_done,
+    s.is_metadata_done,
+    s.is_odm_done,
+    exists (select 1 from dataset_audit da where da.dataset_id = d.id) as is_audited,
+    (select count(*) from v2_aois a where a.dataset_id = d.id) as aoi_count,
+    (
+        select count(dg.id)
+        from v2_labels l
+        left join v2_deadwood_geometries dg on dg.label_id = l.id
+        where l.dataset_id = d.id
+    ) as deadwood_geometry_count,
+    (
+        select count(fg.id)
+        from v2_labels l
+        left join v2_forest_cover_geometries fg on fg.label_id = l.id
+        where l.dataset_id = d.id
+    ) as forest_cover_geometry_count,
+    ri.raw_images_path,
+    ri.raw_image_count,
+    ri.raw_image_size_mb,
+    o.ortho_file_size,
+    c.cog_file_size,
+    coalesce(((o.ortho_info -> 'Profile'::text) ->> 'Width'::text)::integer, (o.ortho_info ->> 'Width'::text)::integer) as ortho_width,
+    coalesce(((o.ortho_info -> 'Profile'::text) ->> 'Height'::text)::integer, (o.ortho_info ->> 'Height'::text)::integer) as ortho_height,
+    ((o.ortho_info -> 'GEO'::text) ->> 'CRS'::text) as ortho_crs,
+    ((c.cog_info -> 'GEO'::text) ->> 'CRS'::text) as cog_crs,
+    jsonb_strip_nulls((coalesce(ri.camera_metadata, '{}'::jsonb) || jsonb_build_object('has_rtk_data', ri.has_rtk_data, 'rtk_precision_cm', ri.rtk_precision_cm, 'rtk_quality_indicator', ri.rtk_quality_indicator, 'rtk_file_count', ri.rtk_file_count))) as raw_images_metadata,
+    o.ortho_info as ortho_metadata,
+    c.cog_info as cog_metadata,
+    (
+        select string_agg(((((((recent_logs.level || '|'::text) || coalesce(recent_logs.category, 'general'::text)) || '|'::text) || to_char(recent_logs.created_at, 'MM-DD HH24:MI'::text)) || '|'::text) || substring(recent_logs.message, 1, 100)), chr(10) order by recent_logs.created_at desc)
+        from (
+            select v2_logs.level, v2_logs.category, v2_logs.message, v2_logs.created_at
+            from v2_logs
+            where v2_logs.dataset_id = d.id
+            order by v2_logs.created_at desc
+            limit 20
+        ) recent_logs
+    ) as last_20_logs,
+    s.is_combined_model_done
+from v2_datasets d
+left join v2_statuses s on s.dataset_id = d.id
+left join auth.users au on au.id = d.user_id
+left join user_info ui on ui."user" = d.user_id
+left join lateral (
+    select o_1.dataset_id, o_1.ortho_file_name, o_1.version, o_1.created_at, o_1.bbox, o_1.sha256, o_1.ortho_upload_runtime, o_1.ortho_file_size, o_1.ortho_info
+    from v2_orthos o_1
+    where o_1.dataset_id = d.id
+    order by o_1.created_at desc, o_1.version desc
+    limit 1
+) o on true
+left join lateral (
+    select c_1.dataset_id, c_1.cog_file_name, c_1.version, c_1.created_at, c_1.cog_info, c_1.cog_processing_runtime, c_1.cog_path, c_1.cog_file_size
+    from v2_cogs c_1
+    where c_1.dataset_id = d.id
+    order by c_1.created_at desc, c_1.version desc
+    limit 1
+) c on true
+left join lateral (
+    select ri_1.dataset_id, ri_1.raw_image_count, ri_1.raw_image_size_mb, ri_1.raw_images_path, ri_1.camera_metadata, ri_1.has_rtk_data, ri_1.rtk_precision_cm, ri_1.rtk_quality_indicator, ri_1.rtk_file_count, ri_1.version, ri_1.created_at
+    from v2_raw_images ri_1
+    where ri_1.dataset_id = d.id
+    order by ri_1.created_at desc, ri_1.version desc
+    limit 1
+) ri on true
+order by d.id desc, coalesce(s.updated_at, d.created_at) desc
+limit 100;
+
+alter view public.v2_processing_overview set (security_invoker = true);


### PR DESCRIPTION
## Summary
- Update upload-created processing tasks to run legacy deadwood, legacy treecover, and the combined deadwood/treecover model.
- Keep raw-image workflows adding ODM first and keep GeoTIFF standardization before derived products/model stages.
- Document the processor queue quirk: prediction reruns should include `geotiff` first because model stages fetch an ortho but do not standardize it themselves.
- Fix crash recovery for mixed old+new model queues by checking model-specific `v2_labels.model_config`, so old v1 status flags cannot make an unfinished combined run look complete.

## Validation
- Passed: `python3 -m py_compile processor/src/processor.py processor/tests/test_processor.py`.
- Passed: `git diff --check`.
- Passed: direct in-container processor helper check covering legacy-only labels vs legacy+combined labels.
- Blocked locally: `deadtrees dev test processor ...` requires local Docker NVIDIA runtime / local Supabase test services in this isolated worktree.
- Known existing issue: full frontend `npm run build` is already failing on unrelated TypeScript errors across maps/ML tiles/auth utilities; no new UploadModal error was introduced.