### PR TITLE
fix: shrink processor docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,11 +25,15 @@ frontend/
 # Exclude temporary files
 tmp/
 temp/
+processor/temp/
+processor/tmp/
+processor/.cache/
 .DS_Store
 Thumbs.db
 
 # Exclude test outputs
 tcd_test_output/
+processor/tcd_test_output/
 *.log
 
 # Keep only what we actually need for the container build:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The platform is deployed across two physical servers:
 
 All services are containerized using Docker Compose. Authentication and data management are handled through Supabase (PostgreSQL with row-level security).
 
+Processor deployment notes live in [docs/playbooks/processor-deploy.md](docs/playbooks/processor-deploy.md).
+
 ## Web Application
 
 The frontend is a React-based single-page application using OpenLayers for interactive map visualization. It provides:

--- a/docs/playbooks/processor-deploy.md
+++ b/docs/playbooks/processor-deploy.md
@@ -1,0 +1,13 @@
+# Processor Deploy Notes
+
+The processor image is built from the repository root with `docker-compose.processor.yaml`.
+Keep runtime output out of the git checkout so deploy builds only send source files as Docker
+context.
+
+Processor runtime artifacts should live under `/data`, for example `/data/processing_dir`, or
+another non-repo path mounted into the processor container. Do not leave ODM or tree-cover
+temporary output under the checkout, especially under `processor/temp/`, before rebuilding the
+processor image.
+
+Before cleaning old artifacts on `processing-server`, confirm no active processor or ODM task still
+depends on them.

--- a/processor/tests/test_dockerignore.py
+++ b/processor/tests/test_dockerignore.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def _dockerignore_patterns() -> set[str]:
+	return {
+		line.strip()
+		for line in Path('.dockerignore').read_text().splitlines()
+		if line.strip() and not line.lstrip().startswith('#')
+	}
+
+
+def test_processor_runtime_artifacts_are_excluded_from_docker_context():
+	patterns = _dockerignore_patterns()
+
+	assert 'processor/temp/' in patterns
+	assert 'processor/tmp/' in patterns
+	assert 'processor/.cache/' in patterns
+	assert 'processor/tcd_test_output/' in patterns


### PR DESCRIPTION
## Summary
- exclude processor runtime temp/cache/test-output directories from the root Docker build context
- add a regression test that keeps the critical .dockerignore patterns in place
- document processor deploy hygiene and link it from the README

## Verification
- venv/bin/python -m pytest -q processor/tests/test_dockerignore.py
- disposable Docker context probe: build context transferred 2.13MB and ignored probe files under processor/temp, processor/tmp, processor/.cache, and processor/tcd_test_output were absent inside the image

Closes DT-423.
Related: https://github.com/Deadwood-ai/internal/issues/327

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Docker build ignore patterns plus documentation and a lightweight test; no runtime application logic is modified.
> 
> **Overview**
> Shrinks the root Docker build context by adding `processor` runtime artifact directories (e.g., `processor/temp/`, `processor/tmp/`, `processor/.cache/`, `processor/tcd_test_output/`) to `.dockerignore`, avoiding accidental inclusion of large/ephemeral files in processor image builds.
> 
> Adds a small pytest regression test (`processor/tests/test_dockerignore.py`) to ensure these ignore patterns remain present, and documents processor deployment cleanup guidance in `docs/playbooks/processor-deploy.md` (linked from the README).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85190de041418e4c5c8f4546d66de065a56f6f58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->