### PR TITLE
fix(frontend): restore clean TypeScript build

### DIFF
--- a/frontend/src/api/download.ts
+++ b/frontend/src/api/download.ts
@@ -1,6 +1,6 @@
 import { Settings } from "../config";
 
-const download = async (dataset_id, token) => {
+const download = async (dataset_id: number, token: string) => {
   try {
     const response = await fetch(
       // `${Settings.API_URL}/download/datasets/${dataset_id}/dataset.zip`,

--- a/frontend/src/components/Corrections/CorrectionEditorView.tsx
+++ b/frontend/src/components/Corrections/CorrectionEditorView.tsx
@@ -165,7 +165,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
       if (mapRef.current) {
         // Properly dispose layers and sources before disposing map
         mapRef.current.getLayers().forEach((layer) => {
-          const source = layer.getSource?.();
+          const source = (layer as { getSource?: () => { clear?: () => void; dispose?: () => void } | null }).getSource?.();
           if (source) {
             if ("clear" in source && typeof source.clear === "function") {
               source.clear();
@@ -512,8 +512,9 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
       {/* Map Area */}
       <div className="relative flex-1">
         {isLoading && (
-          <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/50">
-            <Spin size="large" tip="Loading..." />
+          <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-white/50 text-gray-500">
+            <Spin size="large" />
+            <span>Loading...</span>
           </div>
         )}
 

--- a/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
@@ -111,19 +111,6 @@ const QualityValue = ({ quality }: QualityValueProps) => {
   );
 };
 
-const BooleanValue = ({ value }: { value: boolean | null | undefined }) => {
-  if (value === null || value === undefined) {
-    return <Typography.Text className="text-gray-400">—</Typography.Text>;
-  }
-
-  return (
-    <span className="flex items-center gap-1.5">
-      <Typography.Text>{value ? "Yes" : "No"}</Typography.Text>
-      <span>{value ? "🟢" : "🔴"}</span>
-    </span>
-  );
-};
-
 interface AuditSectionProps {
   audit: AuditInfo | null | undefined;
 }

--- a/frontend/src/components/DatasetDetailsMap/DatasetNavigation.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetNavigation.tsx
@@ -39,9 +39,9 @@ export default function DatasetNavigation({
 
   const formatDate = (dataset: IDataset) => {
     return new Date(
-      dataset.aquisition_year,
-      dataset.aquisition_month ? dataset.aquisition_month - 1 : 0,
-      dataset.aquisition_day || 1,
+      Number(dataset.aquisition_year),
+      dataset.aquisition_month ? Number(dataset.aquisition_month) - 1 : 0,
+      dataset.aquisition_day ? Number(dataset.aquisition_day) : 1,
     ).toLocaleDateString("en-US", {
       year: "numeric",
       month: "short",

--- a/frontend/src/components/DatasetDetailsMap/createVectorLayer.ts
+++ b/frontend/src/components/DatasetDetailsMap/createVectorLayer.ts
@@ -6,9 +6,12 @@ import { Fill, Stroke, Style } from "ol/style";
 import MVT from "ol/format/MVT";
 import GeoJSON from "ol/format/GeoJSON";
 import { Polygon } from "ol/geom";
+import type Geometry from "ol/geom/Geometry";
 import { supabase } from "../../hooks/useSupabase";
 import { base64ToArrayBuffer } from "../../utils/base64ToArrayBuffer";
 import Feature from "ol/Feature";
+import VectorTile from "ol/VectorTile";
+import type { FeatureLike } from "ol/Feature";
 import { palette } from "../../theme/palette";
 import { mapColors } from "../../theme/mapColors";
 
@@ -26,23 +29,23 @@ interface VectorLayerConfig {
 }
 
 const createVectorLayer = (config: VectorLayerConfig) => {
-  const vectorSource = new VectorTileSource({
-    format: new MVT({
+  const vectorSource = new VectorTileSource<Feature<Geometry>>({
+    format: new MVT<Feature<Geometry>>({
       featureClass: Feature,
       geometryName: "geom",
     }),
     tileLoadFunction: async (tile, url) => {
+      const vectorTile = tile as VectorTile<Feature<Geometry>>;
       const [z, x, y] = url.split("/").slice(-3).map(Number);
       // console.log(`[Tile Request] z=${z}, x=${x}, y=${y}`);
       // Skip API call completely if no labelId is provided
       if (!config.labelId) {
         // Set empty features for the tile when no label ID exists
-        tile.setFeatures([]);
+        vectorTile.setFeatures([]);
         return;
       }
 
       try {
-        const startTime = performance.now();
         const rpcParams: Record<string, unknown> = {
           z,
           x,
@@ -63,10 +66,10 @@ const createVectorLayer = (config: VectorLayerConfig) => {
           // console.log(`[Tile Success] z=${z}, x=${x}, y=${y}, fetch=${fetchTime.toFixed(0)}ms`);
           // const decodeStart = performance.now();
           const uint8Array = base64ToArrayBuffer(data);
-          const format = tile.getFormat();
+          const format = vectorTile.getFormat();
 
           const features = format.readFeatures(uint8Array, {
-            extent: tile.extent,
+            extent: vectorTile.extent,
             featureProjection: "EPSG:3857",
           });
 
@@ -81,7 +84,7 @@ const createVectorLayer = (config: VectorLayerConfig) => {
           //   }
           // });
 
-          tile.setFeatures(features);
+          vectorTile.setFeatures(features);
         } else {
           tile.setState(3); // ERROR
         }
@@ -98,7 +101,7 @@ const createVectorLayer = (config: VectorLayerConfig) => {
   });
 
   // Create style function for correction-aware styling
-  const getFeatureStyle = (feature: Feature) => {
+  const getFeatureStyle = (feature: FeatureLike) => {
     // Get correction status from feature properties (only available with corrections-aware MVT)
     const correctionStatus = feature.get("correction_status") as string | undefined;
     const correctionOperation = feature.get("correction_operation") as string | undefined;

--- a/frontend/src/components/DatasetMap/DatasetMap.tsx
+++ b/frontend/src/components/DatasetMap/DatasetMap.tsx
@@ -381,7 +381,7 @@ const DatasetMapOL = ({
               }
 
               const hoverStyle = hoveredFeature.get("hoverStyle");
-              if (hoverStyle) {
+              if (hoverStyle && hoveredFeature instanceof Feature) {
                 hoveredFeature.setStyle(hoverStyle);
               }
             } else {
@@ -394,11 +394,11 @@ const DatasetMapOL = ({
 
               vectorLayerExtendRef.current
                 ?.getSource()
-                .getFeatures()
+                ?.getFeatures()
                 .forEach((f) => f.setStyle(f.get("baseStyle")));
               vectorLayerMarkerRef.current
                 ?.getSource()
-                .getFeatures()
+                ?.getFeatures()
                 .forEach((f) => f.setStyle(f.get("baseStyle")));
             }
           };
@@ -448,8 +448,8 @@ const DatasetMapOL = ({
             map.tooltip.dispose();
           }
 
-          vectorLayerExtendRef.current?.getSource().dispose();
-          vectorLayerMarkerRef.current?.getSource().dispose();
+          vectorLayerExtendRef.current?.getSource()?.dispose();
+          vectorLayerMarkerRef.current?.getSource()?.dispose();
 
           vectorLayerExtendRef.current?.dispose();
           vectorLayerMarkerRef.current?.dispose();
@@ -466,8 +466,10 @@ const DatasetMapOL = ({
           }
 
           map.getLayers().forEach((layer) => {
-            const source = layer?.getSource?.();
-            if (source && "dispose" in source) {
+            if (!layer) return;
+
+            const source = (layer as { getSource?: () => { dispose?: () => void } | null }).getSource?.();
+            if (source?.dispose) {
               source.dispose();
             }
             map.removeLayer(layer);
@@ -476,14 +478,14 @@ const DatasetMapOL = ({
           map.getControls().clear();
           map.getInteractions().clear();
           map.getOverlays().clear();
-          map.setTarget(null);
+          map.setTarget(undefined);
 
           mapRef.current = null;
           vectorLayerExtendRef.current = null;
           vectorLayerMarkerRef.current = null;
           setMapLayersReady(false);
         } else {
-          map.setTarget(null);
+          map.setTarget(undefined);
           map.dispose();
         }
       };
@@ -495,6 +497,8 @@ const DatasetMapOL = ({
     if (mapLayersReady && vectorLayerExtendRef.current && vectorLayerMarkerRef.current && mapRef.current) {
       const vectorSourceExtend = vectorLayerExtendRef.current.getSource();
       const vectorSourceMarker = vectorLayerMarkerRef.current.getSource();
+
+      if (!vectorSourceExtend || !vectorSourceMarker) return;
 
       vectorSourceExtend.clear();
       vectorSourceMarker.clear();
@@ -520,7 +524,9 @@ const DatasetMapOL = ({
             extentFeature.setStyle(extentStyle);
             vectorSourceExtend.addFeature(extentFeature);
 
-            const point = extentFeature.getGeometry().getInteriorPoint();
+            const extentGeometry = extentFeature.getGeometry();
+            if (!extentGeometry) return;
+            const point = extentGeometry.getInteriorPoint();
             const pointFeature = new Feature(point);
             pointFeature.setProperties({
               id: dataset.id,
@@ -539,7 +545,7 @@ const DatasetMapOL = ({
         prevZoomTriggerRef.current = filterZoomTrigger;
         if (vectorLayerExtendRef.current && mapRef.current) {
           const source = vectorLayerExtendRef.current.getSource();
-          if (source.getFeatures().length > 0) {
+          if (source && source.getFeatures().length > 0) {
             const extent = source.getExtent();
             mapRef.current.getView().fit(extent, {
               padding: [50, 50, 50, 50],
@@ -557,6 +563,8 @@ const DatasetMapOL = ({
     if (vectorLayerExtendRef.current && vectorLayerMarkerRef.current) {
       const vectorSourceExtend = vectorLayerExtendRef.current.getSource();
       const vectorSourceMarker = vectorLayerMarkerRef.current.getSource();
+
+      if (!vectorSourceExtend || !vectorSourceMarker) return;
 
       vectorSourceExtend.getFeatures().forEach((feature) => {
         const featureId = feature.get("id");

--- a/frontend/src/components/DeadwoodMap/PolygonStatsModal.tsx
+++ b/frontend/src/components/DeadwoodMap/PolygonStatsModal.tsx
@@ -180,8 +180,9 @@ const PolygonStatsModal = ({
       }}
     >
       {loading && (
-        <div className="flex items-center justify-center py-16">
-          <Spin size="large" tip="Computing statistics from COG data..." />
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-gray-500">
+          <Spin size="large" />
+          <span>Computing statistics from COG data...</span>
         </div>
       )}
 

--- a/frontend/src/components/DeadwoodMap/YearSelector.tsx
+++ b/frontend/src/components/DeadwoodMap/YearSelector.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { Segmented, Typography } from "antd";
 import { LeftOutlined, RightOutlined } from "@ant-design/icons";
 

--- a/frontend/src/components/DeadwoodMap/createDeadwoodGeotiffLayer.ts
+++ b/frontend/src/components/DeadwoodMap/createDeadwoodGeotiffLayer.ts
@@ -44,7 +44,7 @@ const createDeadwoodGeotiffLayer = (year: string) => {
       ],
     },
     visible: year === "2025",
-  });
+  }) as TileLayerWebGL & { cleanup: () => void };
 
   layer.cleanup = () => {
     source.clear();

--- a/frontend/src/components/DeadwoodMap/createForestGeotiffLayer.ts
+++ b/frontend/src/components/DeadwoodMap/createForestGeotiffLayer.ts
@@ -42,7 +42,7 @@ const createForestGeotiffLayer = (year: string) => {
       ],
     },
     visible: year === "2025",
-  });
+  }) as TileLayerWebGL & { cleanup: () => void };
 
   layer.cleanup = () => {
     source.clear();

--- a/frontend/src/components/FilterModal.tsx
+++ b/frontend/src/components/FilterModal.tsx
@@ -45,7 +45,7 @@ const FilterModal: React.FC<FilterModalProps> = ({ isVisible, onClose, onApplyFi
   }, [isVisible, form, currentFilters, defaultDateRange]);
 
   // Apply filters immediately on any change
-  const handleFormChange = (changedValues: Partial<AdvancedFilters>, allValues: AdvancedFilters) => {
+  const handleFormChange = (_changedValues: Partial<AdvancedFilters>, allValues: AdvancedFilters) => {
     onApplyFilters(allValues);
   };
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,6 +1,5 @@
 import { Layout } from "antd";
 import { Link } from "react-router-dom";
-import { useLocation } from "react-router-dom";
 const { Footer: AntFooter } = Layout;
 
 interface FooterProps {
@@ -8,7 +7,6 @@ interface FooterProps {
 }
 
 export default function Footer({ className = "" }: FooterProps) {
-  const location = useLocation();
   return (
     <AntFooter style={{ margin: 0, padding: 2 }} className={`bg-slate-100 ${className}`}>
       <div className="mx-auto px-4">

--- a/frontend/src/components/Home/DataGallery.tsx
+++ b/frontend/src/components/Home/DataGallery.tsx
@@ -138,7 +138,7 @@ const DataGallery = ({ hideHeader = false }: { hideHeader?: boolean }) => {
 
     // Take only the first entry for each author in the authors array
     filtered.forEach((item) => {
-      item.authors.forEach((author: string) => {
+      item.authors?.forEach((author: string) => {
         const authorKey = author.trim().toLowerCase();
         if (!authorMap.has(authorKey)) {
           authorMap.set(authorKey, item);

--- a/frontend/src/components/MLTiles/MLTileMap.tsx
+++ b/frontend/src/components/MLTiles/MLTileMap.tsx
@@ -164,7 +164,7 @@ export default function MLTileMap({
       style: (feature) => {
         const status = feature.get("status") as string;
         const isSelected = feature.get("isSelected") as boolean;
-        let strokeColor = palette.state.pending;
+        let strokeColor: string = palette.state.pending;
         let strokeWidth = 3; // Thicker borders for better visibility
 
         if (status === "good") {
@@ -239,7 +239,7 @@ export default function MLTileMap({
         // Use the same style as the vector layer (no fill, just stroke)
         const status = feature.get("status") as string;
         const isSelected = feature.get("isSelected") as boolean;
-        let strokeColor = palette.state.pending;
+        let strokeColor: string = palette.state.pending;
         let strokeWidth = 3;
 
         if (status === "good") {

--- a/frontend/src/components/MLTiles/placement/MLTilePlacementPhase.tsx
+++ b/frontend/src/components/MLTiles/placement/MLTilePlacementPhase.tsx
@@ -1,17 +1,14 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import { Button, Divider, List, Space, Tag, Typography, message } from "antd";
 import { PlusOutlined, DeleteOutlined } from "@ant-design/icons";
 import { IDataset } from "../../../types/dataset";
-import { IMLTile, TileResolution } from "../../../types/mlTiles";
+import { IMLTile } from "../../../types/mlTiles";
 import { useCreateMLTile, useDeleteMLTile, useMLTiles } from "../../../hooks/useMLTiles";
 import { useDatasetAOI } from "../../../hooks/useDatasetAudit";
 import {
   polygon as turfPolygon,
   multiPolygon as turfMultiPolygon,
-  area,
-  intersect,
   centroid,
-  feature,
 } from "@turf/turf";
 import GeoJSON from "ol/format/GeoJSON";
 
@@ -63,35 +60,6 @@ export default function MLTilePlacementPhase({ dataset, onUnsavedChanges, onNavi
         : turfMultiPolygon(aoiGeoJSON.coordinates as GeoJSON.Position[][][]);
     return centroid(turfGeom).geometry.coordinates as [number, number];
   }, [aoiGeoJSON]);
-
-  const validateTilePlacement = useCallback(
-    (geometry: GeoJSON.Polygon, resolution: TileResolution) => {
-      if (!aoiGeoJSON) return { ok: true };
-
-      try {
-        const tileFeat = feature(geometry);
-        const aoiFeat = feature(aoiGeoJSON);
-
-        const overlap = intersect(tileFeat, aoiFeat);
-        if (!overlap) {
-          return { ok: false, message: "Tile does not intersect the AOI." };
-        }
-        const overlapPct = (area(overlap) / area(tileFeat)) * 100;
-        if (overlapPct < 60) {
-          return { ok: false, message: `Tile AOI overlap is only ${overlapPct.toFixed(1)}%. Minimum is 60%.` };
-        }
-        if (tiles.some((t) => t.resolution_cm === resolution && intersectsTile(t.geometry as any, geometry))) {
-          return { ok: false, message: "Tile overlaps an existing tile." };
-        }
-
-        return { ok: true, overlap: overlapPct };
-      } catch (error) {
-        console.error("Validation error:", error);
-        return { ok: false, message: `Validation error: ${error}` };
-      }
-    },
-    [aoiGeoJSON, tiles],
-  );
 
   const handleCreateTile = async () => {
     if (!aoiGeoJSON || !aoiCentroid) {
@@ -215,35 +183,4 @@ export default function MLTilePlacementPhase({ dataset, onUnsavedChanges, onNavi
       />
     </div>
   );
-}
-
-function boundingBoxFromGeoJSON(geometry: GeoJSON.Geometry): {
-  minx: number;
-  miny: number;
-  maxx: number;
-  maxy: number;
-} {
-  let minx = Infinity;
-  let miny = Infinity;
-  let maxx = -Infinity;
-  let maxy = -Infinity;
-
-  const polygons =
-    geometry.type === "Polygon" ? [geometry.coordinates] : (geometry as GeoJSON.MultiPolygon).coordinates;
-  polygons.forEach((poly) => {
-    poly[0].forEach(([x, y]) => {
-      minx = Math.min(minx, x);
-      miny = Math.min(miny, y);
-      maxx = Math.max(maxx, x);
-      maxy = Math.max(maxy, y);
-    });
-  });
-
-  return { minx, miny, maxx, maxy };
-}
-
-function intersectsTile(a: GeoJSON.Polygon, b: GeoJSON.Polygon) {
-  const ap = turfPolygon(a.coordinates as GeoJSON.Position[][]);
-  const bp = turfPolygon(b.coordinates as GeoJSON.Position[][]);
-  return !!intersect(ap, bp);
 }

--- a/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
@@ -184,7 +184,7 @@ export default function ReferencePatchMap({
       style: (feature) => {
         const status = feature.get("status") as string;
         const isSelected = feature.get("isSelected") as boolean;
-        let strokeColor = palette.state.pending;
+        let strokeColor: string = palette.state.pending;
         let strokeWidth = 3; // Thicker borders for better visibility
 
         if (status === "good") {
@@ -259,7 +259,7 @@ export default function ReferencePatchMap({
         // Use the same style as the vector layer (no fill, just stroke)
         const status = feature.get("status") as string;
         const isSelected = feature.get("isSelected") as boolean;
-        let strokeColor = palette.state.pending;
+        let strokeColor: string = palette.state.pending;
         let strokeWidth = 3;
 
         if (status === "good") {

--- a/frontend/src/components/Upload/PickerWithType.tsx
+++ b/frontend/src/components/Upload/PickerWithType.tsx
@@ -1,4 +1,4 @@
-import { DatePicker, Select, Space } from "antd";
+import { DatePicker, Select } from "antd";
 import { Dayjs } from "dayjs";
 
 interface PickerWithTypeProps {

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -164,7 +164,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
       }
 
       setUploadValidationError(null);
-      return beforeUpload(file);
+      return beforeUpload(file, []);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "File validation failed. Please choose a different file.";

--- a/frontend/src/hooks/useAuditNavigationGuard.ts
+++ b/frontend/src/hooks/useAuditNavigationGuard.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useRef, useState } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Modal } from "antd";
 

--- a/frontend/src/hooks/useAuthProvider.tsx
+++ b/frontend/src/hooks/useAuthProvider.tsx
@@ -173,12 +173,11 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       ]);
 
       if (authRequestRef.current !== requestId) {
-        return null;
+        return { status: "invalid" } satisfies SessionValidationResult;
       }
 
       if (validationResult === authValidationTimeout) {
-        const outcome = classifySessionValidationResult({ timedOut: true });
-        throw new Error(outcome.reason);
+        throw new Error("Auth session validation timed out.");
       }
 
       const {
@@ -197,6 +196,11 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
       if (outcome.status === "invalid_session") {
         recoverInvalidSession(error ?? new Error(outcome.reason), requestId);
+        return { status: "invalid" } satisfies SessionValidationResult;
+      }
+
+      if (!validatedUser) {
+        recoverInvalidSession(new Error("Supabase returned no authenticated user for the restored session."), requestId);
         return { status: "invalid" } satisfies SessionValidationResult;
       }
 

--- a/frontend/src/hooks/useAuthorOptions.ts
+++ b/frontend/src/hooks/useAuthorOptions.ts
@@ -1,6 +1,4 @@
-import { useState, useEffect } from "react";
 import { useData } from "../hooks/useDataProvider";
-import { useSupabase } from "../useSupabase";
 
 interface AuthorOption {
   label: string;
@@ -8,21 +6,6 @@ interface AuthorOption {
 }
 
 export const useAuthorOptions = () => {
-  const [options, setOptions] = useState<AuthorOption[]>([]);
   const { authors } = useData();
-
-  useEffect(() => {
-    if (authors) {
-      const authorsUnique = [...new Set(authors)];
-
-      const newOptions = authorsUnique.map((author) => ({
-        label: author,
-        value: author,
-      }));
-
-      setOptions(newOptions);
-    }
-  }, [authors]);
-
-  return options;
+  return (authors ?? []) as AuthorOption[];
 };

--- a/frontend/src/hooks/useDatasetAudit.ts
+++ b/frontend/src/hooks/useDatasetAudit.ts
@@ -3,7 +3,6 @@ import { supabase } from "./useSupabase";
 import { useAuth } from "./useAuthProvider";
 import { useCanAudit } from "./useUserPrivileges";
 import { useMemo } from "react";
-import { IDataset } from "../types/dataset";
 
 // Update the enum type to match your backend
 export type PredictionQuality = "great" | "sentinel_ok" | "bad";
@@ -243,7 +242,6 @@ export function useSaveDatasetAOI() {
 
 // Hook to set audit lock with auto-recovery for stale locks
 export function useSetAuditLock() {
-  const { user } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -310,7 +308,6 @@ export function useSetAuditLock() {
 
 // Hook to clear audit lock
 export function useClearAuditLock() {
-  const { user } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/frontend/src/hooks/useDatasetLabelTypes.ts
+++ b/frontend/src/hooks/useDatasetLabelTypes.ts
@@ -17,7 +17,7 @@ export function useDatasetLabelTypes({ datasetId, enabled = true }: UseDatasetLa
     isLoading: isLoadingDeadwood,
     error: deadwoodError,
   } = useDatasetLabels({
-    datasetId,
+    datasetId: datasetId ?? 0,
     labelData: ILabelData.DEADWOOD,
     enabled: enabled && !!datasetId,
   });
@@ -28,7 +28,7 @@ export function useDatasetLabelTypes({ datasetId, enabled = true }: UseDatasetLa
     isLoading: isLoadingForestCover,
     error: forestCoverError,
   } = useDatasetLabels({
-    datasetId,
+    datasetId: datasetId ?? 0,
     labelData: ILabelData.FOREST_COVER,
     enabled: enabled && !!datasetId,
   });

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,11 +1,11 @@
 import { useState } from "react";
-import type { UploadFile } from "antd";
+import type { UploadFile, UploadProps } from "antd";
 
 export const useFileUpload = () => {
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [fileName, setFileName] = useState<string>("");
   const [fileNameFull, setFileNameFull] = useState<string>("");
-  const onFileChange = ({ fileList: newFileList }) => {
+  const onFileChange: UploadProps["onChange"] = ({ fileList: newFileList }) => {
     // console.log("newFileList", newFileList);
     setFileList(newFileList.slice(-1));
     if (newFileList.length > 0) {
@@ -18,7 +18,7 @@ export const useFileUpload = () => {
     }
   };
 
-  const beforeUpload = (file) => {
+  const beforeUpload: UploadProps["beforeUpload"] = (file) => {
     setFileList([file]);
     return false;
   };

--- a/frontend/src/hooks/useLabelsFileUpload.ts
+++ b/frontend/src/hooks/useLabelsFileUpload.ts
@@ -1,13 +1,13 @@
 import { useState } from "react";
-import type { UploadFile } from "antd";
+import type { UploadFile, UploadProps } from "antd";
 
 const useLabelsFileUpload = () => {
   const [labelsFileList, setLabelsFileList] = useState<UploadFile[]>([]);
-  const onLabelsFileChange = ({ fileList: newFileList }) => {
+  const onLabelsFileChange: UploadProps["onChange"] = ({ fileList: newFileList }) => {
     setLabelsFileList(newFileList.slice(-1));
   };
 
-  const beforeLabelsUpload = (file) => {
+  const beforeLabelsUpload: UploadProps["beforeUpload"] = (file) => {
     setLabelsFileList([file]);
     return false;
   };

--- a/frontend/src/hooks/useMLTiles.ts
+++ b/frontend/src/hooks/useMLTiles.ts
@@ -5,6 +5,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+  ReferencePatchCreateInput,
   useClearPatchSessionLock,
   useCompletePatchGeneration,
   useCreateReferencePatch,
@@ -50,28 +51,15 @@ export {
   useReopenPatchGeneration as useReopenTileGeneration,
 };
 
-const normalizeTileInput = (
-  tile: CreateMLTileInput,
-) => {
-  const patch = mlTileToReferencePatch({
-    ...tile,
-    id: 0,
-    user_id: "",
-    created_at: "",
-    updated_at: "",
-    status: tile.status ?? "pending",
-    utm_zone: tile.utm_zone ?? "31N",
-    epsg_code: tile.epsg_code ?? 32631,
-  });
-  const { id, user_id, created_at, updated_at, ...createPayload } = patch;
-  void id;
-  void user_id;
-  void created_at;
-  void updated_at;
+const normalizeTileInput = (tile: CreateMLTileInput): ReferencePatchCreateInput => {
+  const { tile_index, ...tilePayload } = tile;
+
   return {
-    ...createPayload,
-    deadwood_validated: createPayload.deadwood_validated ?? null,
-    forest_cover_validated: createPayload.forest_cover_validated ?? null,
+    ...tilePayload,
+    patch_index: tile_index,
+    status: tilePayload.status ?? "pending",
+    deadwood_validated: tilePayload.deadwood_validated ?? null,
+    forest_cover_validated: tilePayload.forest_cover_validated ?? null,
   };
 };
 

--- a/frontend/src/hooks/useMLTiles.ts
+++ b/frontend/src/hooks/useMLTiles.ts
@@ -3,19 +3,181 @@
 // Use hooks/useReferencePatches.ts for new code.
 // ============================================================================
 
-// Re-export all hooks with old names for backward compatibility
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useClearPatchSessionLock,
+  useCompletePatchGeneration,
+  useCreateReferencePatch,
+  useDeleteReferencePatch,
+  useGenerateNestedPatches,
+  useNestedPatches,
+  usePatchProgress,
+  usePatchSessionLock,
+  useReferencePatches,
+  useReopenPatchGeneration,
+  useSetPatchSessionLock,
+  useUpdatePatchGeometry,
+  useUpdatePatchStatus,
+} from "./useReferencePatches";
+import { IMLTile, mlTileToReferencePatch, referencePatchToMLTile, TileStatus } from "../types/mlTiles";
+
+type CreateMLTileInput = Omit<
+  Partial<IMLTile> &
+    Pick<
+      IMLTile,
+      | "dataset_id"
+      | "resolution_cm"
+      | "geometry"
+      | "parent_tile_id"
+      | "tile_index"
+      | "bbox_minx"
+      | "bbox_miny"
+      | "bbox_maxx"
+      | "bbox_maxy"
+      | "aoi_coverage_percent"
+      | "deadwood_prediction_coverage_percent"
+      | "forest_cover_prediction_coverage_percent"
+    >,
+  "id" | "created_at" | "updated_at" | "user_id" | "patch_index"
+>;
+
 export {
-  useReferencePatches as useMLTiles,
-  useNestedPatches as useNestedTiles,
   usePatchSessionLock as useTileSessionLock,
   useSetPatchSessionLock as useSetTileSessionLock,
   useClearPatchSessionLock as useClearTileSessionLock,
-  useCreateReferencePatch as useCreateMLTile,
-  useUpdatePatchStatus as useUpdateTileStatus,
-  useUpdatePatchGeometry as useUpdateTileGeometry,
-  useDeleteReferencePatch as useDeleteMLTile,
-  useGenerateNestedPatches as useGenerateNestedTiles,
   usePatchProgress as useTileProgress,
   useCompletePatchGeneration as useCompleteTileGeneration,
   useReopenPatchGeneration as useReopenTileGeneration,
-} from "./useReferencePatches";
+};
+
+const normalizeTileInput = (
+  tile: CreateMLTileInput,
+) => {
+  const patch = mlTileToReferencePatch({
+    ...tile,
+    id: 0,
+    user_id: "",
+    created_at: "",
+    updated_at: "",
+    status: tile.status ?? "pending",
+    utm_zone: tile.utm_zone ?? "31N",
+    epsg_code: tile.epsg_code ?? 32631,
+  });
+  const { id, user_id, created_at, updated_at, ...createPayload } = patch;
+  void id;
+  void user_id;
+  void created_at;
+  void updated_at;
+  return {
+    ...createPayload,
+    deadwood_validated: createPayload.deadwood_validated ?? null,
+    forest_cover_validated: createPayload.forest_cover_validated ?? null,
+  };
+};
+
+export function useMLTiles(datasetId: number | undefined, resolution?: IMLTile["resolution_cm"]) {
+  const query = useReferencePatches(datasetId, resolution);
+
+  return {
+    ...query,
+    data: query.data?.map(referencePatchToMLTile),
+  };
+}
+
+export function useNestedTiles(parentTileId: number | undefined) {
+  const query = useNestedPatches(parentTileId);
+
+  return {
+    ...query,
+    data: query.data?.map(referencePatchToMLTile),
+  };
+}
+
+export function useCreateMLTile() {
+  const mutation = useCreateReferencePatch();
+
+  return {
+    ...mutation,
+    mutate: (
+      tile: CreateMLTileInput,
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate(normalizeTileInput(tile), options),
+    mutateAsync: async (
+      tile: CreateMLTileInput,
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => referencePatchToMLTile(await mutation.mutateAsync(normalizeTileInput(tile), options)),
+  };
+}
+
+export function useUpdateTileStatus() {
+  const mutation = useUpdatePatchStatus();
+
+  return {
+    ...mutation,
+    mutate: (
+      variables: { tileId: number; status: TileStatus },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ patchId: variables.tileId, status: variables.status }, options),
+    mutateAsync: async (
+      variables: { tileId: number; status: TileStatus },
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => referencePatchToMLTile(await mutation.mutateAsync({ patchId: variables.tileId, status: variables.status }, options)),
+  };
+}
+
+export function useUpdateTileGeometry() {
+  const mutation = useUpdatePatchGeometry();
+
+  return {
+    ...mutation,
+    mutate: (
+      variables: Parameters<typeof mutation.mutate>[0] extends infer T
+        ? Omit<T, "patchId"> & { tileId: number }
+        : never,
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => {
+      const { tileId, ...rest } = variables;
+      return mutation.mutate({ ...rest, patchId: tileId }, options);
+    },
+    mutateAsync: async (
+      variables: Parameters<typeof mutation.mutateAsync>[0] extends infer T
+        ? Omit<T, "patchId"> & { tileId: number }
+        : never,
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => {
+      const { tileId, ...rest } = variables;
+      return referencePatchToMLTile(await mutation.mutateAsync({ ...rest, patchId: tileId }, options));
+    },
+  };
+}
+
+export function useDeleteMLTile() {
+  const mutation = useDeleteReferencePatch();
+
+  return {
+    ...mutation,
+    mutate: (
+      variables: { tileId: number; datasetId: number },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ patchId: variables.tileId, datasetId: variables.datasetId }, options),
+    mutateAsync: (variables: { tileId: number; datasetId: number }, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
+      mutation.mutateAsync({ patchId: variables.tileId, datasetId: variables.datasetId }, options),
+  };
+}
+
+export function useGenerateNestedTiles() {
+  const mutation = useGenerateNestedPatches();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (tile: IMLTile) => {
+      const patches = await mutation.mutateAsync(mlTileToReferencePatch(tile));
+      return patches.map(referencePatchToMLTile);
+    },
+    onSuccess: (_data, tile) => {
+      queryClient.invalidateQueries({ queryKey: ["reference-patches", tile.dataset_id] });
+      queryClient.invalidateQueries({ queryKey: ["reference-patches", "nested", tile.id] });
+      queryClient.invalidateQueries({ queryKey: ["patch-progress", tile.dataset_id] });
+    },
+  });
+}

--- a/frontend/src/hooks/useReferencePatches.ts
+++ b/frontend/src/hooks/useReferencePatches.ts
@@ -9,8 +9,13 @@ import {
   IPatchGenerationProgress,
 } from "../types/referencePatches";
 
-type ReferencePatchCreateInput = Omit<IReferencePatch, "id" | "created_at" | "updated_at" | "user_id" | "status"> & {
+export type ReferencePatchCreateInput = Omit<
+  IReferencePatch,
+  "id" | "created_at" | "updated_at" | "user_id" | "status" | "utm_zone" | "epsg_code"
+> & {
   status?: PatchStatus;
+  utm_zone?: string | null;
+  epsg_code?: number | null;
 };
 
 const getPatchStatus = (patch: Partial<IReferencePatch> & { status?: PatchStatus | null }): PatchStatus => {
@@ -414,7 +419,7 @@ export function useUpdatePatchStatus() {
           .eq("id", updatedPatch.parent_tile_id);
       }
 
-      return normalizeReferencePatch(updatedPatch);
+      return updatedPatch;
     },
     onSuccess: (data) => {
       const datasetId = (data as IReferencePatch).dataset_id;

--- a/frontend/src/hooks/useReferencePatches.ts
+++ b/frontend/src/hooks/useReferencePatches.ts
@@ -9,6 +9,27 @@ import {
   IPatchGenerationProgress,
 } from "../types/referencePatches";
 
+type ReferencePatchCreateInput = Omit<IReferencePatch, "id" | "created_at" | "updated_at" | "user_id" | "status"> & {
+  status?: PatchStatus;
+};
+
+const getPatchStatus = (patch: Partial<IReferencePatch> & { status?: PatchStatus | null }): PatchStatus => {
+  if (patch.status) return patch.status;
+  if (patch.deadwood_validated === false || patch.forest_cover_validated === false) return "bad";
+  if (patch.deadwood_validated === true && patch.forest_cover_validated === true) return "good";
+  return "pending";
+};
+
+const normalizeReferencePatch = (patch: unknown): IReferencePatch => {
+  const normalized = patch as IReferencePatch;
+  return {
+    ...normalized,
+    status: getPatchStatus(normalized),
+    deadwood_validated: normalized.deadwood_validated ?? null,
+    forest_cover_validated: normalized.forest_cover_validated ?? null,
+  };
+};
+
 // Fetch all patches for a dataset
 export function useReferencePatches(datasetId: number | undefined, resolution?: PatchResolution) {
   return useQuery({
@@ -25,7 +46,7 @@ export function useReferencePatches(datasetId: number | undefined, resolution?: 
       const { data, error } = await query.order("patch_index");
 
       if (error) throw error;
-      return (data || []) as unknown as IReferencePatch[];
+      return (data || []).map(normalizeReferencePatch);
     },
     enabled: !!datasetId,
   });
@@ -45,7 +66,7 @@ export function useNestedPatches(parentPatchId: number | undefined) {
         .order("patch_index");
 
       if (error) throw error;
-      return (data || []) as unknown as IReferencePatch[];
+      return (data || []).map(normalizeReferencePatch);
     },
     enabled: !!parentPatchId,
   });
@@ -154,7 +175,7 @@ export function useCreateReferencePatch() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (patch: Omit<IReferencePatch, "id" | "created_at" | "updated_at" | "user_id">) => {
+    mutationFn: async (patch: ReferencePatchCreateInput) => {
       const { data, error } = await supabase
         .from("reference_patches")
         .insert({
@@ -165,7 +186,7 @@ export function useCreateReferencePatch() {
         .single();
 
       if (error) throw error;
-      return data as IReferencePatch;
+      return normalizeReferencePatch(data);
     },
     onSuccess: (data) => {
       const datasetId = (data as IReferencePatch).dataset_id;
@@ -261,7 +282,7 @@ export function useUpdatePatchLayerValidation() {
 
       if (error) throw error;
 
-      const updatedPatch = data as IReferencePatch;
+      const updatedPatch = normalizeReferencePatch(data);
 
       // Auto-propagate validation to parent patches
       // If this is a 5cm patch, update its parent 10cm patch validation
@@ -343,7 +364,7 @@ export function useUpdatePatchStatus() {
 
       if (error) throw error;
 
-      const updatedPatch = data as IReferencePatch;
+      const updatedPatch = normalizeReferencePatch(data);
 
       // If this is a 5cm patch, update its parent 10cm patch status
       if (updatedPatch.resolution_cm === 5 && updatedPatch.parent_tile_id) {
@@ -393,7 +414,7 @@ export function useUpdatePatchStatus() {
           .eq("id", updatedPatch.parent_tile_id);
       }
 
-      return updatedPatch;
+      return normalizeReferencePatch(updatedPatch);
     },
     onSuccess: (data) => {
       const datasetId = (data as IReferencePatch).dataset_id;
@@ -435,7 +456,7 @@ export function useUpdatePatchGeometry() {
         .single();
 
       if (error) throw error;
-      return data as IReferencePatch;
+      return normalizeReferencePatch(data);
     },
     onSuccess: (data) => {
       const datasetId = (data as IReferencePatch).dataset_id;
@@ -471,7 +492,7 @@ export function useGenerateNestedPatches() {
   return useMutation({
     mutationFn: async (parentPatch: IReferencePatch) => {
       const childResolution: PatchResolution = parentPatch.resolution_cm === 20 ? 10 : 5;
-      const childPatches: Omit<IReferencePatch, "id" | "created_at" | "updated_at" | "user_id">[] = [];
+      const childPatches: ReferencePatchCreateInput[] = [];
 
       const { bbox_minx, bbox_miny, bbox_maxx, bbox_maxy } = parentPatch;
       const midX = (bbox_minx + bbox_maxx) / 2;
@@ -526,7 +547,7 @@ export function useGenerateNestedPatches() {
         .select();
 
       if (error) throw error;
-      return data as IReferencePatch[];
+      return (data || []).map(normalizeReferencePatch);
     },
     onSuccess: (_data, parentPatch) => {
       const datasetId = parentPatch.dataset_id;

--- a/frontend/src/hooks/useSupabase.ts
+++ b/frontend/src/hooks/useSupabase.ts
@@ -6,7 +6,7 @@ import { isInvalidSessionError } from "../utils/authSession";
 export const supabase = createClient(Settings.SUPABASE_URL, Settings.SUPABASE_ANON_KEY);
 
 export function clearSupabaseAuthStorage() {
-  const storageKey = `sb-${new URL(Settings.SUPABASE_URL).hostname.split(".")[0]}-auth-token`;
+  const storageKey = (supabase as unknown as { storageKey?: string }).storageKey;
 
   if (typeof window !== "undefined" && storageKey) {
     window.localStorage.removeItem(storageKey);

--- a/frontend/src/hooks/useSupabase.ts
+++ b/frontend/src/hooks/useSupabase.ts
@@ -6,7 +6,7 @@ import { isInvalidSessionError } from "../utils/authSession";
 export const supabase = createClient(Settings.SUPABASE_URL, Settings.SUPABASE_ANON_KEY);
 
 export function clearSupabaseAuthStorage() {
-  const storageKey = supabase.auth.storageKey;
+  const storageKey = `sb-${new URL(Settings.SUPABASE_URL).hostname.split(".")[0]}-auth-token`;
 
   if (typeof window !== "undefined" && storageKey) {
     window.localStorage.removeItem(storageKey);

--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -258,8 +258,9 @@ export default function Dataset() {
           filterByViewport={filterByViewport}
         />
       ) : (
-        <div className="flex h-full items-center justify-center">
-          <Spin size="large" tip="Loading data..." />
+        <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-500">
+          <Spin size="large" />
+          <span>Loading data...</span>
         </div>
       )}
     </div>
@@ -334,8 +335,9 @@ export default function Dataset() {
           )}
         </div>
         {!displayData ? (
-          <div className="flex h-full items-center justify-center">
-            <Spin size="large" tip="Loading map..." />
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-500">
+            <Spin size="large" />
+            <span>Loading map...</span>
           </div>
         ) : displayData.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center rounded-lg bg-white">

--- a/frontend/src/pages/DatasetCorrections.tsx
+++ b/frontend/src/pages/DatasetCorrections.tsx
@@ -30,8 +30,9 @@ export default function DatasetCorrections() {
   // Check authentication
   if (authLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spin size="large" tip="Loading..." />
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-500">
+        <Spin size="large" />
+        <span>Loading...</span>
       </div>
     );
   }
@@ -53,8 +54,9 @@ export default function DatasetCorrections() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spin size="large" tip="Loading dataset..." />
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-500">
+        <Spin size="large" />
+        <span>Loading dataset...</span>
       </div>
     );
   }

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -2,7 +2,7 @@
 // import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { supabase } from "../../hooks/useSupabase";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import Input from "antd/es/input/Input";
 import { Button, Form, message } from "antd";
 
@@ -10,7 +10,7 @@ const ResetPassword = () => {
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
 
-  const handleChange = (e) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
   };
 

--- a/frontend/src/types/ambient-modules.d.ts
+++ b/frontend/src/types/ambient-modules.d.ts
@@ -1,0 +1,6 @@
+declare module "utf8" {
+  export function encode(input: string): string;
+  export function decode(input: string): string;
+}
+
+declare module "proj4";

--- a/frontend/src/types/labels.ts
+++ b/frontend/src/types/labels.ts
@@ -1,4 +1,4 @@
-import { GeoJSON } from "geojson";
+import type * as GeoJSON from "geojson";
 
 export enum ILabelSource {
   MANUAL = "manual",

--- a/frontend/src/types/referencePatches.ts
+++ b/frontend/src/types/referencePatches.ts
@@ -7,6 +7,7 @@ export interface IReferencePatch {
   dataset_id: number;
   user_id: string;
   resolution_cm: PatchResolution;
+  status: PatchStatus;
   geometry: GeoJSON.Polygon; // In UTM projection (specified by utm_zone)
   parent_tile_id: number | null; // TODO: Rename to parent_patch_id in future migration
   patch_index: string; // Renamed from tile_index in DB
@@ -29,8 +30,8 @@ export interface IReferencePatch {
   reference_forest_cover_label_id?: number | null;
 
   // Layer-specific validation (null = pending, true = good, false = bad)
-  deadwood_validated: boolean | null;
-  forest_cover_validated: boolean | null;
+  deadwood_validated?: boolean | null;
+  forest_cover_validated?: boolean | null;
 
   created_at: string;
   updated_at: string;

--- a/frontend/src/types/supabase.ts
+++ b/frontend/src/types/supabase.ts
@@ -9,10 +9,10 @@ interface Dataset {
   file_name: string;
   file_size: number;
   id: number;
-  license: Dataset["public"]["Enums"]["License"];
-  platform: Dataset["public"]["Enums"]["Platform"];
+  license: string;
+  platform: string;
   sha256: string;
-  status: Dataset["public"]["Enums"]["Status"];
+  status: string;
   target_path: string;
   upload_date: string;
   user_id: string;

--- a/frontend/src/utils/canvasOptimization.ts
+++ b/frontend/src/utils/canvasOptimization.ts
@@ -10,19 +10,20 @@
 export function applyCanvasOptimization() {
   const originalGetContext = HTMLCanvasElement.prototype.getContext;
   HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
     contextType: string,
-    contextAttributes?: CanvasRenderingContext2DSettings,
+    contextAttributes?: CanvasRenderingContext2DSettings | ImageBitmapRenderingContextSettings | WebGLContextAttributes,
   ) {
     // Only modify 2d context
     if (contextType === "2d") {
       // Create attributes object if it doesn't exist
-      contextAttributes = contextAttributes || {};
+      contextAttributes = (contextAttributes || {}) as CanvasRenderingContext2DSettings;
       // Set willReadFrequently to true for all 2d contexts
-      contextAttributes.willReadFrequently = true;
+      (contextAttributes as CanvasRenderingContext2DSettings).willReadFrequently = true;
     }
     // Call the original method with our modified attributes
     return originalGetContext.call(this, contextType, contextAttributes);
-  };
+  } as typeof HTMLCanvasElement.prototype.getContext;
 
   console.debug("[Canvas Optimization] Applied willReadFrequently=true to all 2D canvas contexts");
 }

--- a/frontend/src/utils/fileValidation.ts
+++ b/frontend/src/utils/fileValidation.ts
@@ -65,7 +65,7 @@ const describeColorModel = (samplesPerPixel: number, photometricInterpretation: 
 };
 
 const getBandDescriptions = (image: {
-  getGDALMetadata?: (sample?: number | null) => Record<string, string> | null;
+  getGDALMetadata?: (sample?: number) => Record<string, string> | null;
 }, samplesPerPixel: number): string[] => {
   const descriptions: string[] = [];
 

--- a/frontend/src/utils/getThumbnails.tsx
+++ b/frontend/src/utils/getThumbnails.tsx
@@ -1,4 +1,4 @@
-import { supabase } from "../useSupabase";
+import { supabase } from "../hooks/useSupabase";
 
 const getThumbnailURL = (file_name: string | null) => {
   if (!file_name) return "/assets/tree-icon.png";

--- a/frontend/src/utils/parseBBox.tsx
+++ b/frontend/src/utils/parseBBox.tsx
@@ -1,4 +1,4 @@
-type BBox = [[number, number], [number, number]]; // [minLongitude, minLatitude, maxLongitude, maxLatitude]
+type BBox = [number, number, number, number]; // [minLongitude, minLatitude, maxLongitude, maxLatitude]
 
 function parseBBox(boxString: string): BBox | null {
   // console.log("boxString: ", boxString);

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -110,6 +110,36 @@ ensure_file_from_example() {
   log "Created $(relative_to_repo_root "$target") from example"
 }
 
+ensure_file_from_shared() {
+  local relative_path="$1"
+  local target="$REPO_ROOT/$relative_path"
+  local source="$SHARED_ROOT/$relative_path"
+
+  if [[ -e "$target" ]]; then
+    return
+  fi
+
+  if [[ "$SHARED_ROOT" == "$REPO_ROOT" || ! -f "$source" ]]; then
+    log "Shared local file missing, skipping copy: $relative_path"
+    return
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  cp "$source" "$target"
+  log "Copied local file from shared root: $relative_path"
+}
+
+ensure_frontend_env_profiles() {
+  ensure_file_from_shared "frontend/.env.dev.local"
+  ensure_file_from_shared "frontend/.env.prod.local"
+
+  if [[ ! -e "$REPO_ROOT/frontend/.env.dev.local" ]]; then
+    ensure_file_from_example "$REPO_ROOT/frontend/.env.dev.local" "$REPO_ROOT/frontend/.env.local.example"
+  fi
+
+  ensure_file_from_example "$REPO_ROOT/frontend/.env.local" "$REPO_ROOT/frontend/.env.local.example"
+}
+
 ensure_env_line() {
   local file="$1"
   local key="$2"
@@ -235,7 +265,7 @@ log "Shared root: $SHARED_ROOT"
 git -C "$REPO_ROOT" submodule update --init --recursive
 
 ensure_file_from_example "$REPO_ROOT/.env" "$REPO_ROOT/.env.example"
-ensure_file_from_example "$REPO_ROOT/frontend/.env.local" "$REPO_ROOT/frontend/.env.local.example"
+ensure_frontend_env_profiles
 ensure_env_line "$REPO_ROOT/.env" "COMPOSE_PROJECT_NAME" "$DEFAULT_COMPOSE_PROJECT_NAME"
 
 if [[ "$LINK_SHARED" == true ]]; then
@@ -262,6 +292,7 @@ Worktree setup complete.
 
 What this prepared:
   - repo env files
+  - frontend local/prod env profiles where available
   - stable Docker compose project name (${DEFAULT_COMPOSE_PROJECT_NAME})
   - git submodules
   - per-worktree Python CLI environment


### PR DESCRIPTION
## Summary
- fix frontend TypeScript errors across map, upload, auth, ML tile, reference patch, and utility code paths
- add ambient declarations needed by the current frontend dependency set
- harden DatasetMap teardown so route changes from the archive map no longer throw `getSource` runtime errors
- copy frontend dev/prod env profiles during worktree setup when available from the shared root
- replace standalone Ant Design `Spin tip` usage with normal loading text to avoid runtime console warnings

## Why
The frontend build had drifted into TypeScript failures, and the Codex worktree setup was missing frontend profile env files needed for prod-connected local verification. Browser smoke testing also exposed a DatasetMap cleanup crash when navigating from `/dataset` to `/about`.

## Validation
- `npm --prefix frontend run build`
- `git diff --check HEAD~1..HEAD`
- Browser Use smoke against `http://127.0.0.1:5176`: `/`, `/dataset`, `/dataset/2185`, `/deadtrees`, `/about`, `/sign-in`, `/profile`, `/impressum`, `/datenschutzerklaerung`, `/terms-of-service`
- Fresh browser console delta after final smoke: no new errors, no DatasetMap `getSource` crash, no Ant Design `Spin tip` warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes touch authentication session validation, Supabase local-storage key handling, and map layer teardown/feature loading logic, which could affect login persistence and map stability if edge cases were missed.
> 
> **Overview**
> Restores a clean frontend TypeScript build by tightening types across OpenLayers map code, upload hooks, and utilities, including safer `getSource()`/`getGeometry()` access and improved map teardown to avoid runtime errors on route changes.
> 
> Refactors ML tile/reference patch compatibility: `useMLTiles` is reintroduced as a backward-compatible wrapper over `useReferencePatches`, and reference patch reads/writes now normalize `status`/validation fields for consistent UI behavior.
> 
> Hardens auth/session handling by treating aborted validations as invalid, adding an explicit “no user returned” recovery path, and updating `clearSupabaseAuthStorage()` to remove the correct Supabase auth token key.
> 
> Cleans up UI loading states to avoid Ant Design `Spin tip` warnings, adds ambient module declarations (`utf8`, `proj4`), and updates worktree setup to copy frontend `.env.dev.local`/`.env.prod.local` from a shared root when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ba7e7ba2e9b3da081b8fbfe3b47066b56ef63b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->