### PR TITLE
fix(frontend): correct legacy processing status

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -20,6 +20,7 @@ import { supabase } from "../hooks/useSupabase";
 import { useAuth } from "../hooks/useAuthProvider";
 import EditDatasetModal from "./EditDatasetModal";
 import ProcessingProgress from "./ProcessingProgress";
+import { isDatasetProcessingComplete } from "../utils/processingSteps";
 import { isGeonadirDataset } from "../utils/datasetUtils";
 import { fixAuthorNamesEncoding, sanitizeText } from "../utils/textUtils";
 import { IDataset } from "../types/dataset";
@@ -157,17 +158,7 @@ const DataTable: React.FC<DataTableProps> = ({
   console.debug("userData in DataTable", userData);
 
   const isDatasetComplete = (record: Dataset): boolean => {
-    return !!(
-      !record.has_error &&
-      record.is_upload_done &&
-      record.is_ortho_done &&
-      record.is_cog_done &&
-      record.is_thumbnail_done &&
-      record.is_metadata_done &&
-      record.is_deadwood_done &&
-      record.is_forest_cover_done &&
-      record.is_combined_model_done
-    );
+    return !!(record.is_thumbnail_done && isDatasetProcessingComplete(record));
   };
 
   // Dataset is viewable on the map - use centralized utility

--- a/frontend/src/hooks/useDatasetSubscription.ts
+++ b/frontend/src/hooks/useDatasetSubscription.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "./useSupabase";
 import { useAuth } from "./useAuthProvider";
 import { useProcessingNotification } from "./useProcessingNotification";
+import { isDatasetProcessingComplete } from "../utils/processingSteps";
 
 interface StatusPayloadData {
   dataset_id: number;
@@ -68,21 +69,7 @@ export function useDatasetSubscription() {
             // Helper function to check if processing is complete
             const isProcessingComplete = (data: StatusPayloadData | null): boolean => {
               if (!data) return false;
-
-              // Check if ODM step is required (presence of is_odm_done field)
-              const odmComplete = data.is_odm_done === undefined || data.is_odm_done;
-
-              return (
-                data.is_upload_done &&
-                odmComplete &&
-                data.is_ortho_done &&
-                data.is_cog_done &&
-                data.is_thumbnail_done &&
-                data.is_metadata_done &&
-                data.is_deadwood_done &&
-                data.is_forest_cover_done &&
-                data.is_combined_model_done
-              );
+              return data.is_thumbnail_done && isDatasetProcessingComplete({ ...data, file_name: datasetInfo.file_name });
             };
 
             // Check if processing just completed (was incomplete before, now complete)

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -45,6 +45,7 @@ import { useDatasetLogs, useProcessingOverview, ProcessingOverviewRow, Processin
 import { getAcquisitionPeriod } from "../utils/phenologyUtils";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useAnalytics } from "../hooks/useAnalytics";
+import { isDatasetProcessingComplete } from "../utils/processingSteps";
 
 const { Title, Text } = Typography;
 
@@ -86,14 +87,7 @@ const formatHours = (value: number | null | undefined): string => {
 
 // Helper function to check if dataset processing is complete
 const isProcessingComplete = (dataset: IDataset) => {
-	return (
-		dataset.is_upload_done &&
-		dataset.is_ortho_done &&
-		dataset.is_cog_done &&
-		dataset.is_thumbnail_done &&
-		dataset.is_deadwood_done &&
-		dataset.is_metadata_done
-	);
+	return dataset.is_thumbnail_done && isDatasetProcessingComplete(dataset);
 };
 
 // Helper to format location
@@ -501,6 +495,7 @@ function DatasetAuditInner() {
 		hasProcessingStates,
 		inSeasonOnly,
 		auditMap,
+		correctionsMap,
 		contributorMap,
 		flaggedAgg,
 		hasAboveMinId,

--- a/frontend/src/utils/processingSteps.test.ts
+++ b/frontend/src/utils/processingSteps.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateProcessingProgress,
+  isDatasetProcessingComplete,
+  type DatasetProgress,
+} from "./processingSteps";
+
+const completeCore: DatasetProgress = {
+  file_name: "legacy.tif",
+  current_status: "idle",
+  has_error: false,
+  is_upload_done: true,
+  is_ortho_done: true,
+  is_metadata_done: true,
+  is_cog_done: true,
+  is_odm_done: false,
+};
+
+describe("processing step completion", () => {
+  it("treats legacy deadwood and tree-cover outputs as complete without combined model output", () => {
+    const dataset: DatasetProgress = {
+      ...completeCore,
+      is_deadwood_done: true,
+      is_forest_cover_done: true,
+      is_combined_model_done: false,
+    };
+
+    expect(isDatasetProcessingComplete(dataset)).toBe(true);
+    expect(calculateProcessingProgress(dataset)).toMatchObject({
+      isComplete: true,
+      percentage: 100,
+      totalSteps: 6,
+    });
+  });
+
+  it("keeps the combined model step visible while it is actively running after legacy outputs", () => {
+    const dataset: DatasetProgress = {
+      ...completeCore,
+      current_status: "deadwood_treecover_combined_segmentation",
+      is_deadwood_done: true,
+      is_forest_cover_done: true,
+      is_combined_model_done: false,
+    };
+
+    const progress = calculateProcessingProgress(dataset);
+
+    expect(isDatasetProcessingComplete(dataset)).toBe(false);
+    expect(progress.isComplete).toBe(false);
+    expect(progress.currentStepInfo.key).toBe("combined_model");
+    expect(progress.totalSteps).toBe(7);
+  });
+
+  it("treats combined-model-only outputs as complete", () => {
+    const dataset: DatasetProgress = {
+      ...completeCore,
+      is_deadwood_done: false,
+      is_forest_cover_done: false,
+      is_combined_model_done: true,
+    };
+
+    expect(isDatasetProcessingComplete(dataset)).toBe(true);
+    expect(calculateProcessingProgress(dataset)).toMatchObject({
+      isComplete: true,
+      percentage: 100,
+      totalSteps: 5,
+    });
+  });
+
+  it("does not complete predictions without a legacy or combined prediction signal", () => {
+    const dataset: DatasetProgress = {
+      ...completeCore,
+      is_deadwood_done: false,
+      is_forest_cover_done: false,
+      is_combined_model_done: false,
+    };
+
+    const progress = calculateProcessingProgress(dataset);
+
+    expect(isDatasetProcessingComplete(dataset)).toBe(false);
+    expect(progress.isComplete).toBe(false);
+    expect(progress.currentStepInfo.key).toBe("deadwood");
+  });
+
+  it("requires ODM completion only for raw image ZIP workflows", () => {
+    const dataset: DatasetProgress = {
+      ...completeCore,
+      file_name: "raw-images.zip",
+      is_deadwood_done: true,
+      is_forest_cover_done: true,
+      is_odm_done: false,
+    };
+
+    expect(isDatasetProcessingComplete(dataset)).toBe(false);
+    expect(isDatasetProcessingComplete({ ...dataset, is_odm_done: true })).toBe(true);
+  });
+});

--- a/frontend/src/utils/processingSteps.ts
+++ b/frontend/src/utils/processingSteps.ts
@@ -12,7 +12,6 @@ export const GEOTIFF_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
   { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
   { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
-  { key: "combined_model", label: "Combined AI Analysis", description: "Running combined deadwood and tree cover model" },
 ];
 
 export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
@@ -24,8 +23,19 @@ export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
   { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
   { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
-  { key: "combined_model", label: "Combined AI Analysis", description: "Running combined deadwood and tree cover model" },
 ];
+
+const COMBINED_MODEL_STEP: ProcessingStep = {
+  key: "combined_model",
+  label: "Combined AI Analysis",
+  description: "Running combined deadwood and tree cover model",
+};
+
+const COMBINED_MODEL_STATUS = "deadwood_treecover_combined_segmentation";
+
+function isOdmWorkflow(dataset: DatasetProgress): boolean {
+  return dataset.file_name?.toLowerCase().endsWith(".zip") || false;
+}
 
 export interface DatasetProgress {
   file_name?: string;
@@ -47,50 +57,46 @@ export interface DatasetProgress {
   has_valid_acquisition_date?: boolean | null;
 }
 
-/**
- * Smart detection for when deadwood processing is actually complete
- * even when is_deadwood_done = false (no deadwood found case)
- */
 function isDeadwoodProcessingComplete(dataset: DatasetProgress): boolean {
-  // If is_deadwood_done is already true, processing is definitely complete
-  if (dataset.is_deadwood_done) {
-    return true;
-  }
+  return !!dataset.is_deadwood_done;
+}
 
-  // If all previous steps are done, status is idle, and no errors,
-  // assume deadwood processing completed (just found no results)
-  const odmComplete = dataset.is_odm_done === undefined || dataset.is_odm_done;
+function isTreecoverProcessingComplete(dataset: DatasetProgress): boolean {
+  return !!dataset.is_forest_cover_done;
+}
+
+export function isLegacyPredictionProcessingComplete(
+  dataset: DatasetProgress,
+): boolean {
+  return (
+    isDeadwoodProcessingComplete(dataset) &&
+    isTreecoverProcessingComplete(dataset)
+  );
+}
+
+export function isPredictionProcessingComplete(
+  dataset: DatasetProgress,
+): boolean {
+  return (
+    isLegacyPredictionProcessingComplete(dataset) ||
+    !!dataset.is_combined_model_done
+  );
+}
+
+export function isDatasetProcessingComplete(dataset: DatasetProgress): boolean {
+  const odmComplete = !isOdmWorkflow(dataset) || dataset.is_odm_done;
+  const hasActiveProcessingStatus =
+    !!dataset.current_status && dataset.current_status !== "idle";
+
   return !!(
+    !dataset.has_error &&
+    !hasActiveProcessingStatus &&
     dataset.is_upload_done &&
     odmComplete &&
     dataset.is_ortho_done &&
     dataset.is_metadata_done &&
     dataset.is_cog_done &&
-    !dataset.has_error &&
-    dataset.current_status === "idle"
-  );
-}
-
-/**
- * Smart detection for when treecover processing is actually complete
- * even when is_forest_cover_done = false (no tree cover found case)
- */
-function isTreecoverProcessingComplete(dataset: DatasetProgress): boolean {
-  // If is_forest_cover_done is already true, processing is definitely complete
-  if (dataset.is_forest_cover_done) {
-    return true;
-  }
-
-  // If all previous steps are done, status is idle, and no errors,
-  // assume treecover processing completed (just found no results)
-  return !!(
-    dataset.is_upload_done &&
-    dataset.is_ortho_done &&
-    dataset.is_metadata_done &&
-    dataset.is_cog_done &&
-    isDeadwoodProcessingComplete(dataset) &&
-    !dataset.has_error &&
-    dataset.current_status === "idle"
+    isPredictionProcessingComplete(dataset)
   );
 }
 
@@ -102,8 +108,32 @@ export function calculateProcessingProgress(dataset: DatasetProgress): {
   isComplete: boolean;
 } {
   // Determine if this is an ODM workflow (raw images) based on file extension
-  const isOdmWorkflow = dataset.file_name?.toLowerCase().endsWith(".zip") || false;
-  const steps = isOdmWorkflow ? RAW_IMAGES_PROCESSING_STEPS : GEOTIFF_PROCESSING_STEPS;
+  const isOdmDataset = isOdmWorkflow(dataset);
+  const hasExplicitLegacyPredictionOutput =
+    !!dataset.is_deadwood_done || !!dataset.is_forest_cover_done;
+  const includeCombinedModelStep =
+    dataset.is_combined_model_done ||
+    dataset.current_status === COMBINED_MODEL_STATUS;
+  const useCombinedModelOnly =
+    includeCombinedModelStep && !hasExplicitLegacyPredictionOutput;
+  const steps = useCombinedModelOnly
+    ? [
+        ...(isOdmDataset
+          ? RAW_IMAGES_PROCESSING_STEPS
+          : GEOTIFF_PROCESSING_STEPS
+        ).slice(0, -2),
+        COMBINED_MODEL_STEP,
+      ]
+    : includeCombinedModelStep
+      ? [
+          ...(isOdmDataset
+            ? RAW_IMAGES_PROCESSING_STEPS
+            : GEOTIFF_PROCESSING_STEPS),
+          COMBINED_MODEL_STEP,
+        ]
+      : isOdmDataset
+        ? RAW_IMAGES_PROCESSING_STEPS
+        : GEOTIFF_PROCESSING_STEPS;
   const totalSteps = steps.length;
 
   // If there's an error, return error state
@@ -117,17 +147,29 @@ export function calculateProcessingProgress(dataset: DatasetProgress): {
     };
   }
 
-  // Check completion status for each step with smart detection
-  const stepCompletions = [
+  const baseStepCompletions = [
     dataset.is_upload_done || false,
-    ...(isOdmWorkflow ? [dataset.is_odm_done || false] : []), // ODM step only for raw images
+    ...(isOdmDataset ? [dataset.is_odm_done || false] : []), // ODM step only for raw images
     dataset.is_ortho_done || false,
     dataset.is_metadata_done || false,
     dataset.is_cog_done || false,
-    isDeadwoodProcessingComplete(dataset), // Smart deadwood completion check
-    isTreecoverProcessingComplete(dataset), // Smart treecover completion check
-    dataset.is_combined_model_done || false,
   ];
+
+  // Check completion status for each step.
+  const stepCompletions = useCombinedModelOnly
+    ? [...baseStepCompletions, dataset.is_combined_model_done || false]
+    : includeCombinedModelStep
+      ? [
+          ...baseStepCompletions,
+          isDeadwoodProcessingComplete(dataset),
+          isTreecoverProcessingComplete(dataset),
+          dataset.is_combined_model_done || false,
+        ]
+      : [
+          ...baseStepCompletions,
+          isDeadwoodProcessingComplete(dataset),
+          isTreecoverProcessingComplete(dataset),
+        ];
 
   // Find the current step (first incomplete step)
   const currentStep = stepCompletions.findIndex((completed) => !completed);


### PR DESCRIPTION
## Summary
- Treat legacy deadwood + forest-cover predictions as complete without requiring the new combined-model flag
- Keep the combined-model progress step visible when that model is actively running or has produced outputs
- Reuse the shared completion helper in profile status, audit pending filtering, and realtime completion notifications
- Add focused processing progress tests for legacy, active combined, and combined-only cases

## Validation
- npm test -- processingSteps.test.ts
- npx eslint src/utils/processingSteps.ts src/utils/processingSteps.test.ts src/components/DataTable.tsx src/pages/DatasetAudit.tsx src/hooks/useDatasetSubscription.ts --ext ts,tsx --max-warnings 0
- npm run build

Fixes DT-425

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes completion/progress logic that drives UI gating (profile status, audit eligibility, realtime notifications); mistakes could incorrectly mark datasets complete/incomplete across workflows.
> 
> **Overview**
> Fixes processing completion detection so **legacy datasets with separate deadwood + forest-cover outputs are considered complete** without requiring `is_combined_model_done`, while still keeping the `combined_model` progress step visible when that model is actively running or has produced outputs.
> 
> Replaces scattered “all flags done” checks in `DataTable`, `DatasetAudit`, and `useDatasetSubscription` with the shared `isDatasetProcessingComplete` helper, and adds focused `processingSteps.test.ts` coverage for legacy-complete, active combined-model, and combined-model-only scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8aa062a9b17b9748da7d525090be47d8f22504. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->