### PR TITLE
docs: note corrected label rerun safety

### DIFF
--- a/.cursor/rules/processing-patterns.mdc
+++ b/.cursor/rules/processing-patterns.mdc
@@ -113,6 +113,11 @@ task_types = ['geotiff', 'treecover_v1']
 task_types = ['geotiff', 'cog', 'thumbnail']
 ```
 
+**CRITICAL: corrected model labels**
+Do not rerun legacy replacement stages (`deadwood_v1`, `treecover_v1`) on datasets that may already have geometry corrections or audit edits. Those stages replace existing model-prediction labels by deleting old `v2_labels` rows first. If a label is referenced by `v2_geometry_corrections`, Postgres correctly rejects the delete via `v2_geometry_corrections_label_id_fkey` to preserve correction history.
+
+For combined-model backfill or comparison on corrected datasets, enqueue stages that do not replace corrected legacy labels, typically `geotiff` plus `deadwood_treecover_combined_v2`. Treat legacy-label replacement on corrected datasets as a future label-versioning or superseding design problem, not an ad-hoc rerun.
+
 ---
 
 ## Metadata Sources


### PR DESCRIPTION
## Summary
- document why legacy model replacement stages should not be rerun on datasets with correction history
- point combined-model backfill/comparison reruns to geotiff + deadwood_treecover_combined_v2 instead

## Validation
- doc/rules-only change; no tests run
- checked with git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior is modified.
> 
> **Overview**
> Adds a **critical documentation note** explaining that rerunning legacy replacement stages (`deadwood_v1`, `treecover_v1`) can fail or be unsafe on datasets with geometry corrections/audit edits because those stages delete existing `v2_labels` rows that may be FK-referenced.
> 
> Documents a recommended rerun/backfill approach for corrected datasets: enqueue `geotiff` plus `deadwood_treecover_combined_v2` instead of legacy replacement stages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f605be3d200c925991a891f9537c1f209640b9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->