### PR TITLE
fix(frontend): improve audit flag status actions

### DIFF
--- a/frontend/src/components/DatasetAudit/AuditStepCards.tsx
+++ b/frontend/src/components/DatasetAudit/AuditStepCards.tsx
@@ -24,6 +24,7 @@ interface UserFlagsCardProps {
 
 export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId, onUpdateFlag }: UserFlagsCardProps) {
 	const latestFlagStatusesRef = useRef(new Map<number, FlagStatus>());
+	const undoVersionsRef = useRef(new Map<number, number>());
 
 	const formatStatus = (status: FlagStatus) => status.charAt(0).toUpperCase() + status.slice(1);
 
@@ -36,6 +37,8 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 			const previousStatus = flag.status;
 			await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: newStatus });
 			latestFlagStatusesRef.current.set(flag.id, newStatus);
+			const undoVersion = (undoVersionsRef.current.get(flag.id) ?? 0) + 1;
+			undoVersionsRef.current.set(flag.id, undoVersion);
 
 			const key = `flag-status-${flag.id}-${Date.now()}`;
 			notification.success({
@@ -46,13 +49,17 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 						size="small"
 						onClick={async () => {
 							try {
-								if (latestFlagStatusesRef.current.get(flag.id) !== newStatus) {
+								if (
+									undoVersionsRef.current.get(flag.id) !== undoVersion ||
+									latestFlagStatusesRef.current.get(flag.id) !== newStatus
+								) {
 									notification.destroy(key);
 									message.warning("Undo skipped because this issue changed again.");
 									return;
 								}
 								await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: previousStatus });
 								latestFlagStatusesRef.current.set(flag.id, previousStatus);
+								undoVersionsRef.current.set(flag.id, undoVersion + 1);
 								notification.destroy(key);
 								message.success(`Issue moved back to ${previousStatus}`);
 							} catch {

--- a/frontend/src/components/DatasetAudit/AuditStepCards.tsx
+++ b/frontend/src/components/DatasetAudit/AuditStepCards.tsx
@@ -1,4 +1,4 @@
-import { Card, Typography, Form, Radio, Input, Space, Tooltip, Tag, Button, Image, Collapse, message } from "antd";
+import { Card, Typography, Form, Radio, Input, Space, Tooltip, Tag, Button, Image, Collapse, message, notification, Popconfirm } from "antd";
 import { CopyOutlined, DownloadOutlined, EditOutlined, DeleteOutlined, CloseOutlined, PlusOutlined, SaveOutlined } from "@ant-design/icons";
 import { createConditionalRule, formatAcquisitionDate } from "./auditConstants";
 import { IDataset } from "../../types/dataset";
@@ -22,22 +22,101 @@ interface UserFlagsCardProps {
 }
 
 export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId, onUpdateFlag }: UserFlagsCardProps) {
-	const handleAcknowledge = async (flagId: number) => {
+	const formatStatus = (status: FlagStatus) => status.charAt(0).toUpperCase() + status.slice(1);
+
+	const handleStatusChange = async (flag: DatasetFlag, newStatus: FlagStatus, successMessage: string) => {
 		try {
-			await onUpdateFlag({ flag_id: flagId, dataset_id: datasetId, new_status: "acknowledged" });
-			message.success("Flag acknowledged");
+			const previousStatus = flag.status;
+			await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: newStatus });
+
+			const key = `flag-status-${flag.id}-${Date.now()}`;
+			notification.success({
+				key,
+				message: successMessage,
+				description: (
+					<Button
+						size="small"
+						onClick={async () => {
+							try {
+								await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: previousStatus });
+								notification.destroy(key);
+								message.success(`Issue moved back to ${formatStatus(previousStatus).toLowerCase()}`);
+							} catch {
+								message.error("Failed to undo status change");
+							}
+						}}
+					>
+						Undo
+					</Button>
+				),
+				duration: 8,
+				placement: "topRight",
+			});
 		} catch {
 			message.error("Failed to update flag");
 		}
 	};
 
-	const handleResolve = async (flagId: number) => {
-		try {
-			await onUpdateFlag({ flag_id: flagId, dataset_id: datasetId, new_status: "resolved" });
-			message.success("Flag resolved");
-		} catch {
-			message.error("Failed to update flag");
+	const renderFlagActions = (flag: DatasetFlag) => {
+		if (flag.status === "open") {
+			return (
+				<Button
+					size="small"
+					type="primary"
+					onClick={() => handleStatusChange(flag, "acknowledged", "Issue acknowledged")}
+					disabled={isUpdatingFlag}
+				>
+					Acknowledge
+				</Button>
+			);
 		}
+
+		if (flag.status === "acknowledged") {
+			return (
+				<>
+					<Popconfirm
+						title="Mark this issue resolved?"
+						description="Use this when the report has been handled and should leave the audit queue."
+						okText="Mark resolved"
+						cancelText="Cancel"
+						onConfirm={() => handleStatusChange(flag, "resolved", "Issue resolved")}
+					>
+						<Button size="small" type="default" disabled={isUpdatingFlag}>
+							Mark resolved
+						</Button>
+					</Popconfirm>
+					<Button
+						size="small"
+						type="text"
+						onClick={() => handleStatusChange(flag, "open", "Issue reopened")}
+						disabled={isUpdatingFlag}
+					>
+						Reopen
+					</Button>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<Button
+					size="small"
+					type="primary"
+					onClick={() => handleStatusChange(flag, "acknowledged", "Issue moved back to acknowledged")}
+					disabled={isUpdatingFlag}
+				>
+					Move to acknowledged
+				</Button>
+				<Button
+					size="small"
+					type="text"
+					onClick={() => handleStatusChange(flag, "open", "Issue reopened")}
+					disabled={isUpdatingFlag}
+				>
+					Reopen
+				</Button>
+			</>
+		);
 	};
 
 	return (
@@ -60,7 +139,7 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 									{f.is_prediction_issue && <Tag color="default">Segmentation</Tag>}
 								</div>
 								<Tag color={f.status === "open" ? "red" : f.status === "acknowledged" ? "gold" : "green"}>
-									{f.status.charAt(0).toUpperCase() + f.status.slice(1)}
+									{formatStatus(f.status)}
 								</Tag>
 							</div>
 							{f.reporter_email && (
@@ -68,22 +147,7 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 							)}
 							<div className="whitespace-pre-wrap text-xs text-gray-700">{f.description}</div>
 							<div className="mt-3 flex items-center gap-3">
-								<Button
-									size="small"
-									type="primary"
-									onClick={() => handleAcknowledge(f.id)}
-									disabled={f.status !== "open" || isUpdatingFlag}
-								>
-									Acknowledge
-								</Button>
-								<Button
-									size="small"
-									type="default"
-									onClick={() => handleResolve(f.id)}
-									disabled={isUpdatingFlag}
-								>
-									Resolve
-								</Button>
+								{renderFlagActions(f)}
 							</div>
 						</Card>
 					))}

--- a/frontend/src/components/DatasetAudit/AuditStepCards.tsx
+++ b/frontend/src/components/DatasetAudit/AuditStepCards.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Card, Typography, Form, Radio, Input, Space, Tooltip, Tag, Button, Image, Collapse, message, notification, Popconfirm } from "antd";
 import { CopyOutlined, DownloadOutlined, EditOutlined, DeleteOutlined, CloseOutlined, PlusOutlined, SaveOutlined } from "@ant-design/icons";
 import { createConditionalRule, formatAcquisitionDate } from "./auditConstants";
@@ -22,12 +23,19 @@ interface UserFlagsCardProps {
 }
 
 export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId, onUpdateFlag }: UserFlagsCardProps) {
+	const latestFlagStatusesRef = useRef(new Map<number, FlagStatus>());
+
 	const formatStatus = (status: FlagStatus) => status.charAt(0).toUpperCase() + status.slice(1);
+
+	useEffect(() => {
+		latestFlagStatusesRef.current = new Map(flags.map((flag) => [flag.id, flag.status]));
+	}, [flags]);
 
 	const handleStatusChange = async (flag: DatasetFlag, newStatus: FlagStatus, successMessage: string) => {
 		try {
 			const previousStatus = flag.status;
 			await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: newStatus });
+			latestFlagStatusesRef.current.set(flag.id, newStatus);
 
 			const key = `flag-status-${flag.id}-${Date.now()}`;
 			notification.success({
@@ -38,9 +46,15 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 						size="small"
 						onClick={async () => {
 							try {
+								if (latestFlagStatusesRef.current.get(flag.id) !== newStatus) {
+									notification.destroy(key);
+									message.warning("Undo skipped because this issue changed again.");
+									return;
+								}
 								await onUpdateFlag({ flag_id: flag.id, dataset_id: datasetId, new_status: previousStatus });
+								latestFlagStatusesRef.current.set(flag.id, previousStatus);
 								notification.destroy(key);
-								message.success(`Issue moved back to ${formatStatus(previousStatus).toLowerCase()}`);
+								message.success(`Issue moved back to ${previousStatus}`);
 							} catch {
 								message.error("Failed to undo status change");
 							}
@@ -79,6 +93,7 @@ export function UserFlagsCard({ flags, isFlagsLoading, isUpdatingFlag, datasetId
 						description="Use this when the report has been handled and should leave the audit queue."
 						okText="Mark resolved"
 						cancelText="Cancel"
+						disabled={isUpdatingFlag}
 						onConfirm={() => handleStatusChange(flag, "resolved", "Issue resolved")}
 					>
 						<Button size="small" type="default" disabled={isUpdatingFlag}>


### PR DESCRIPTION
## Summary
- make audit flag actions status-aware so Acknowledge is the primary action for open reports
- add explicit recovery actions for acknowledged and resolved flags
- add an undo notification after each flag status change
- require confirmation before marking an acknowledged report resolved

## Why
Aaron reported that pressing Resolve felt irreversible and that the expected action was to acknowledge the report instead. The backend already supports `open`, `acknowledged`, and `resolved`, so this PR fixes the frontend workflow around those existing states.

## Validation
- `npm run build`
- `npx eslint src/components/DatasetAudit/AuditStepCards.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `git diff --check`
- Browser Use smoke test on local prod-profile frontend for dataset audit 8035: verified `Resolved -> Move to acknowledged -> Undo -> Resolved`, and verified the Mark resolved confirmation popover

Note: full `npm run lint` still fails on pre-existing unrelated repo-wide lint issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only workflow change to audit flag status actions; main risk is confusing auditors if status transitions/undo don’t match backend expectations.
> 
> **Overview**
> Updates `UserFlagsCard` to make flag actions *status-aware*: `open` flags only show a primary **Acknowledge** action, `acknowledged` flags can **Mark resolved** (with confirmation) or **Reopen**, and `resolved` flags can be moved back to **acknowledged** or **Reopen**.
> 
> Adds an undoable status-change flow via an AntD `notification` that includes an **Undo** button to revert to the previous status after any update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85dbcbdf5b07155c6a4f8624f620fdf6eceee91d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->