### PR TITLE
fix(frontend): handle password reset errors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,7 +48,9 @@ function LayoutWrapper() {
     "/reset-password",
   ];
 
-  const shouldUseFullHeight = fullHeightPaths.some((path) => location.pathname.startsWith(path));
+  const shouldUseFullHeight = fullHeightPaths.some((path) =>
+    location.pathname.startsWith(path),
+  );
 
   return (
     <div>
@@ -81,9 +83,6 @@ function AppWithTracking() {
   useEffect(() => {
     // Initialize PostHog on app load
     initializePostHog();
-
-    // Track initial page view
-    trackPageView(window.location.href);
   }, []);
 
   useEffect(() => {
@@ -97,43 +96,52 @@ function AppWithTracking() {
         <Route path="/" element={<HomePage />} />
         <Route
           path="profile"
-          element={(
+          element={
             <RequireAuth>
               <ProfilePage />
             </RequireAuth>
-          )}
+          }
         />
         <Route path="dataset" element={<Dataset />} />
         <Route path="dataset/:id" element={<DatasetDetails />} />
         <Route path="dataset-audit" element={<DatasetAudit />} />
         <Route path="dataset-audit/:id" element={<DatasetAudit />} />
         {/* New route for Reference Patch Editor */}
-        <Route path="dataset-audit/:id/reference-patches" element={<DatasetReferencePatchEditor />} />
+        <Route
+          path="dataset-audit/:id/reference-patches"
+          element={<DatasetReferencePatchEditor />}
+        />
         {/* Old route kept for backward compatibility */}
         <Route path="dataset-audit/:id/ml-tiles" element={<DatasetMLTiles />} />
         <Route path="dataset-label/:id" element={<DatasetLabelEditor />} />
         {/* Public labelling / corrections editor */}
-        <Route path="dataset-corrections/:id" element={<DatasetCorrections />} />
+        <Route
+          path="dataset-corrections/:id"
+          element={<DatasetCorrections />}
+        />
         <Route path="deadtrees" element={<Deadtrees />} />
         <Route path="about" element={<About />} />
         <Route path="impressum" element={<Impressum />} />
-        <Route path="datenschutzerklaerung" element={<Datenschutzerklaerung />} />
+        <Route
+          path="datenschutzerklaerung"
+          element={<Datenschutzerklaerung />}
+        />
         <Route path="terms-of-service" element={<TermsOfService />} />
         <Route
           path="sign-up"
-          element={(
+          element={
             <PublicOnly>
               <SignUp />
             </PublicOnly>
-          )}
+          }
         />
         <Route
           path="sign-in"
-          element={(
+          element={
             <PublicOnly>
               <SignIn />
             </PublicOnly>
-          )}
+          }
         />
         <Route path="forgot-password" element={<Forgotpassword />} />
         <Route path="reset-password" element={<ResetPassword />} />

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -1,9 +1,10 @@
 import { Alert, Button, Form, Input, message, Spin } from "antd";
 import { Link, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useAuth } from "../../hooks/useAuthProvider";
 import { supabase } from "../../hooks/useSupabase";
+import { trackAppEvent } from "../../utils/analytics";
 
 type ResetPasswordFormValues = {
   confirmPassword: string;
@@ -20,15 +21,61 @@ function getPasswordResetErrorMessage(error: unknown) {
   const errorMessage = String((error as { message?: unknown }).message || "");
   const normalizedMessage = errorMessage.toLowerCase();
 
-  if (normalizedMessage.includes("auth session missing") || normalizedMessage.includes("session")) {
+  if (
+    normalizedMessage.includes("auth session missing") ||
+    normalizedMessage.includes("session")
+  ) {
     return "This reset link is missing or expired. Please request a new password reset email.";
   }
 
-  if (normalizedMessage.includes("weak") || normalizedMessage.includes("password")) {
+  if (
+    normalizedMessage.includes("weak") ||
+    normalizedMessage.includes("password")
+  ) {
     return errorMessage;
   }
 
-  return errorMessage || "We could not update your password. Please request a new reset link and try again.";
+  return (
+    errorMessage ||
+    "We could not update your password. Please request a new reset link and try again."
+  );
+}
+
+function getPasswordResetFailureReason(error: unknown) {
+  if (!error || typeof error !== "object" || !("message" in error)) {
+    return "unknown";
+  }
+
+  const normalizedMessage = String(
+    (error as { message?: unknown }).message || "",
+  ).toLowerCase();
+
+  if (
+    normalizedMessage.includes("auth session missing") ||
+    normalizedMessage.includes("session")
+  ) {
+    return "session_missing";
+  }
+
+  if (
+    normalizedMessage.includes("weak") ||
+    normalizedMessage.includes("password")
+  ) {
+    return "password_validation";
+  }
+
+  return "update_failed";
+}
+
+function getResetLinkErrorCode() {
+  const hashParams = new URLSearchParams(
+    window.location.hash.replace(/^#/, ""),
+  );
+  return (
+    hashParams.get("error_code") ||
+    hashParams.get("error") ||
+    "missing_recovery_session"
+  );
 }
 
 const ResetPassword = () => {
@@ -36,24 +83,66 @@ const ResetPassword = () => {
   const [form] = Form.useForm<ResetPasswordFormValues>();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasTrackedInvalidLink = useRef(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (status !== "anonymous" || hasTrackedInvalidLink.current) return;
+
+    hasTrackedInvalidLink.current = true;
+    trackAppEvent("password_reset_link_invalid", {
+      auth_path: `${window.location.pathname}${window.location.search}`,
+      error_code: getResetLinkErrorCode(),
+      is_logged_in: false,
+      source_surface: "auth",
+      status: "invalid_or_expired",
+      user_segment: "visitor",
+    });
+  }, [status]);
 
   const onFormSubmit = async ({ password }: ResetPasswordFormValues) => {
     setErrorMessage(null);
     setIsSubmitting(true);
+    const authPath = `${window.location.pathname}${window.location.search}`;
+    trackAppEvent("password_reset_submitted", {
+      auth_path: authPath,
+      is_logged_in: true,
+      source_surface: "auth",
+      user_segment: "contributor",
+    });
 
     try {
       const { error } = await supabase.auth.updateUser({ password });
       if (error) {
         setErrorMessage(getPasswordResetErrorMessage(error));
+        trackAppEvent("password_reset_failed", {
+          auth_path: authPath,
+          failure_reason: getPasswordResetFailureReason(error),
+          is_logged_in: true,
+          source_surface: "auth",
+          user_segment: "contributor",
+        });
         return;
       }
 
+      trackAppEvent("password_reset_completed", {
+        auth_path: authPath,
+        is_logged_in: true,
+        source_surface: "auth",
+        user_segment: "contributor",
+      });
       form.resetFields();
       navigate("/profile");
       message.success("Password updated successfully");
     } catch (error) {
       setErrorMessage(getPasswordResetErrorMessage(error));
+      trackAppEvent("password_reset_failed", {
+        auth_path: authPath,
+        failure_reason: getPasswordResetFailureReason(error),
+        is_logged_in: true,
+        source_surface: "auth",
+        user_segment: "contributor",
+      });
     } finally {
       setIsSubmitting(false);
     }
@@ -64,7 +153,9 @@ const ResetPassword = () => {
   return (
     <div className="m-auto flex h-full max-w-7xl items-center justify-center">
       <div className="w-96 rounded-md bg-white p-8">
-        <h1 className="mb-8 text-3xl font-semibold text-gray-600">Reset Password</h1>
+        <h1 className="mb-8 text-3xl font-semibold text-gray-600">
+          Reset Password
+        </h1>
         {status === "checking" ? (
           <div className="flex items-center justify-center gap-3 py-8 text-gray-600">
             <Spin />
@@ -77,18 +168,31 @@ const ResetPassword = () => {
             showIcon
             type="warning"
             message="Reset link expired"
-            description={(
+            description={
               <span>
-                Request a new password reset email, then open the latest link from your inbox.{" "}
+                Request a new password reset email, then open the latest link
+                from your inbox.{" "}
                 <Link to="/forgot-password" className="text-blue-500 underline">
                   Send a new reset link
                 </Link>
               </span>
-            )}
+            }
           />
         ) : null}
-        {errorMessage ? <Alert className="mb-4" showIcon type="error" message={errorMessage} /> : null}
-        <Form form={form} layout="vertical" onFinish={onFormSubmit} disabled={!hasRecoverySession || isSubmitting}>
+        {errorMessage ? (
+          <Alert
+            className="mb-4"
+            showIcon
+            type="error"
+            message={errorMessage}
+          />
+        ) : null}
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={onFormSubmit}
+          disabled={!hasRecoverySession || isSubmitting}
+        >
           <Form.Item
             label="New Password"
             name="password"
@@ -100,7 +204,11 @@ const ResetPassword = () => {
               },
             ]}
           >
-            <Input.Password className="w-full p-2" placeholder="New Password" autoComplete="new-password" />
+            <Input.Password
+              className="w-full p-2"
+              placeholder="New Password"
+              autoComplete="new-password"
+            />
           </Form.Item>
           <Form.Item
             label="Confirm New Password"
@@ -119,7 +227,11 @@ const ResetPassword = () => {
               }),
             ]}
           >
-            <Input.Password className="w-full p-2" placeholder="Confirm New Password" autoComplete="new-password" />
+            <Input.Password
+              className="w-full p-2"
+              placeholder="Confirm New Password"
+              autoComplete="new-password"
+            />
           </Form.Item>
           <Form.Item>
             <Button

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -1,39 +1,135 @@
-// import { UpdatePassword as UpdatePasswordAuthUI } from "@supabase/auth-ui-react";
-// import { ThemeSupa } from "@supabase/auth-ui-shared";
+import { Alert, Button, Form, Input, message, Spin } from "antd";
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+import { useAuth } from "../../hooks/useAuthProvider";
 import { supabase } from "../../hooks/useSupabase";
-import { useNavigate } from "react-router-dom";
-import { ChangeEvent, useState } from "react";
-import Input from "antd/es/input/Input";
-import { Button, Form, message } from "antd";
+
+type ResetPasswordFormValues = {
+  confirmPassword: string;
+  password: string;
+};
+
+const MIN_PASSWORD_LENGTH = 6;
+
+function getPasswordResetErrorMessage(error: unknown) {
+  if (!error || typeof error !== "object" || !("message" in error)) {
+    return "We could not update your password. Please request a new reset link and try again.";
+  }
+
+  const errorMessage = String((error as { message?: unknown }).message || "");
+  const normalizedMessage = errorMessage.toLowerCase();
+
+  if (normalizedMessage.includes("auth session missing") || normalizedMessage.includes("session")) {
+    return "This reset link is missing or expired. Please request a new password reset email.";
+  }
+
+  if (normalizedMessage.includes("weak") || normalizedMessage.includes("password")) {
+    return errorMessage;
+  }
+
+  return errorMessage || "We could not update your password. Please request a new reset link and try again.";
+}
 
 const ResetPassword = () => {
-  const [password, setPassword] = useState("");
+  const { status } = useAuth();
+  const [form] = Form.useForm<ResetPasswordFormValues>();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
+  const onFormSubmit = async ({ password }: ResetPasswordFormValues) => {
+    setErrorMessage(null);
+    setIsSubmitting(true);
 
-  const onFormSubmit = async () => {
-    const { error } = await supabase.auth.updateUser({ password });
-    if (error) {
-      console.debug(error);
-    } else {
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        setErrorMessage(getPasswordResetErrorMessage(error));
+        return;
+      }
+
+      form.resetFields();
       navigate("/profile");
       message.success("Password updated successfully");
+    } catch (error) {
+      setErrorMessage(getPasswordResetErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
     }
   };
+
+  const hasRecoverySession = status === "authenticated";
 
   return (
     <div className="m-auto flex h-full max-w-7xl items-center justify-center">
       <div className="w-96 rounded-md bg-white p-8">
         <h1 className="mb-8 text-3xl font-semibold text-gray-600">Reset Password</h1>
-        <Form layout="vertical" onFinish={onFormSubmit}>
-          <Form.Item required={true} label="New Password">
-            <Input className="w-full p-2" type="password" placeholder="New Password" onChange={handleChange} />
+        {status === "checking" ? (
+          <div className="flex items-center justify-center gap-3 py-8 text-gray-600">
+            <Spin />
+            <span>Checking reset link...</span>
+          </div>
+        ) : null}
+        {status === "anonymous" ? (
+          <Alert
+            className="mb-4"
+            showIcon
+            type="warning"
+            message="Reset link expired"
+            description={(
+              <span>
+                Request a new password reset email, then open the latest link from your inbox.{" "}
+                <Link to="/forgot-password" className="text-blue-500 underline">
+                  Send a new reset link
+                </Link>
+              </span>
+            )}
+          />
+        ) : null}
+        {errorMessage ? <Alert className="mb-4" showIcon type="error" message={errorMessage} /> : null}
+        <Form form={form} layout="vertical" onFinish={onFormSubmit} disabled={!hasRecoverySession || isSubmitting}>
+          <Form.Item
+            label="New Password"
+            name="password"
+            rules={[
+              { required: true, message: "Please enter a new password." },
+              {
+                min: MIN_PASSWORD_LENGTH,
+                message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+              },
+            ]}
+          >
+            <Input.Password className="w-full p-2" placeholder="New Password" autoComplete="new-password" />
+          </Form.Item>
+          <Form.Item
+            label="Confirm New Password"
+            name="confirmPassword"
+            dependencies={["password"]}
+            rules={[
+              { required: true, message: "Please confirm your new password." },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue("password") === value) {
+                    return Promise.resolve();
+                  }
+
+                  return Promise.reject(new Error("Passwords do not match."));
+                },
+              }),
+            ]}
+          >
+            <Input.Password className="w-full p-2" placeholder="Confirm New Password" autoComplete="new-password" />
           </Form.Item>
           <Form.Item>
-            <Button className="w-full" size="large" type="primary" htmlType="submit">
+            <Button
+              className="w-full"
+              disabled={!hasRecoverySession}
+              loading={isSubmitting}
+              size="large"
+              type="primary"
+              htmlType="submit"
+            >
               Reset Password
             </Button>
           </Form.Item>

--- a/frontend/src/utils/analytics.test.ts
+++ b/frontend/src/utils/analytics.test.ts
@@ -19,7 +19,10 @@ vi.mock("posthog-js", () => ({
 let createAnalyticsPayload: typeof import("./analytics").createAnalyticsPayload;
 let deriveUserSegment: typeof import("./analytics").deriveUserSegment;
 let initializePostHog: typeof import("./analytics").initializePostHog;
+let sanitizeAnalyticsUrl: typeof import("./analytics").sanitizeAnalyticsUrl;
 let sanitizeEventProperties: typeof import("./analytics").sanitizeEventProperties;
+let sanitizePostHogCapture: typeof import("./analytics").sanitizePostHogCapture;
+let trackPageView: typeof import("./analytics").trackPageView;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -56,7 +59,10 @@ beforeEach(async () => {
   createAnalyticsPayload = analytics.createAnalyticsPayload;
   deriveUserSegment = analytics.deriveUserSegment;
   initializePostHog = analytics.initializePostHog;
+  sanitizeAnalyticsUrl = analytics.sanitizeAnalyticsUrl;
   sanitizeEventProperties = analytics.sanitizeEventProperties;
+  sanitizePostHogCapture = analytics.sanitizePostHogCapture;
+  trackPageView = analytics.trackPageView;
 });
 
 describe("deriveUserSegment", () => {
@@ -98,6 +104,49 @@ describe("sanitizeEventProperties", () => {
       }),
     ).toEqual({
       dataset_id: 42,
+    });
+  });
+});
+
+describe("sanitizeAnalyticsUrl", () => {
+  it("strips Supabase recovery tokens from URL fragments", () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        "https://deadtrees.earth/reset-password#access_token=secret&refresh_token=also-secret&type=recovery",
+      ),
+    ).toBe("https://deadtrees.earth/reset-password");
+  });
+
+  it("redacts sensitive query parameter values but keeps route context", () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        "/reset-password?access_token=secret&utm_source=email",
+      ),
+    ).toBe("/reset-password?access_token=%5Bredacted%5D&utm_source=email");
+  });
+});
+
+describe("sanitizePostHogCapture", () => {
+  it("sanitizes PostHog SDK URL properties before send", () => {
+    expect(
+      sanitizePostHogCapture({
+        event: "$pageview",
+        properties: {
+          $current_url:
+            "https://deadtrees.earth/reset-password#access_token=secret",
+          $session_entry_url:
+            "https://deadtrees.earth/reset-password?refresh_token=secret",
+          url: "/reset-password#refresh_token=secret",
+        },
+      }),
+    ).toEqual({
+      event: "$pageview",
+      properties: {
+        $current_url: "https://deadtrees.earth/reset-password",
+        $session_entry_url:
+          "https://deadtrees.earth/reset-password?refresh_token=%5Bredacted%5D",
+        url: "/reset-password",
+      },
     });
   });
 });
@@ -166,7 +215,7 @@ describe("initializePostHog", () => {
       expect.objectContaining({
         persistence: "memory",
         autocapture: false,
-        capture_pageview: true,
+        capture_pageview: false,
       }),
     );
     expect(posthogMock.clear_opt_in_out_capturing).toHaveBeenCalledTimes(1);
@@ -191,7 +240,7 @@ describe("initializePostHog", () => {
       expect.objectContaining({
         persistence: "memory",
         autocapture: false,
-        capture_pageview: true,
+        capture_pageview: false,
         capture_pageleave: false,
       }),
     );
@@ -200,8 +249,8 @@ describe("initializePostHog", () => {
       expect.objectContaining({
         persistence: "cookie",
         autocapture: true,
-        capture_pageview: true,
-        capture_pageleave: true,
+        capture_pageview: false,
+        capture_pageleave: false,
       }),
     );
     expect(posthogMock.opt_in_capturing).toHaveBeenCalledTimes(1);
@@ -213,5 +262,27 @@ describe("initializePostHog", () => {
     initializePostHog("pending");
 
     expect(posthogMock.clear_opt_in_out_capturing).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("trackPageView", () => {
+  it("captures accepted pageviews with sanitized URL properties", () => {
+    posthogMock.has_opted_in_capturing.mockReturnValue(true);
+
+    trackPageView("https://deadtrees.earth/reset-password#access_token=secret");
+
+    expect(posthogMock.capture).toHaveBeenCalledWith("$pageview", {
+      $current_url: "https://deadtrees.earth/reset-password",
+      url: "https://deadtrees.earth/reset-password",
+      url_path: "/reset-password",
+    });
+  });
+
+  it("captures limited pageviews without URL fragments", () => {
+    trackPageView("/reset-password#refresh_token=secret");
+
+    expect(posthogMock.capture).toHaveBeenCalledWith("$pageview", {
+      url_path: "/reset-password",
+    });
   });
 });

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,7 +1,9 @@
 import { User } from "@supabase/supabase-js";
 import posthog from "posthog-js";
 
-const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_PROJECT_KEY as string | undefined;
+const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_PROJECT_KEY as
+  | string
+  | undefined;
 let hasInitializedPostHog = false;
 let initializedPostHogMode: "limited" | "accepted" | null = null;
 
@@ -68,6 +70,20 @@ export interface AnalyticsEventPropertiesMap {
   };
   sign_in_completed: AnalyticsBaseProperties & {
     auth_path: string;
+  };
+  password_reset_link_invalid: AnalyticsBaseProperties & {
+    auth_path: string;
+    error_code?: string;
+  };
+  password_reset_submitted: AnalyticsBaseProperties & {
+    auth_path: string;
+  };
+  password_reset_completed: AnalyticsBaseProperties & {
+    auth_path: string;
+  };
+  password_reset_failed: AnalyticsBaseProperties & {
+    auth_path: string;
+    failure_reason: string;
   };
   upload_started: AnalyticsBaseProperties & {
     upload_type: string;
@@ -186,7 +202,9 @@ type EssentialAnalyticsProperty =
   | "filter_type"
   | "filter_value"
   | "interaction_type"
-  | "search_length";
+  | "search_length"
+  | "error_code"
+  | "url_path";
 
 const ESSENTIAL_PROPERTY_KEYS: EssentialAnalyticsProperty[] = [
   "page",
@@ -217,11 +235,17 @@ const ESSENTIAL_PROPERTY_KEYS: EssentialAnalyticsProperty[] = [
   "filter_value",
   "interaction_type",
   "search_length",
+  "error_code",
+  "url_path",
 ];
 
 const ESSENTIAL_EVENTS = new Set<AnalyticsEventName>([
   "sign_up_completed",
   "sign_in_completed",
+  "password_reset_link_invalid",
+  "password_reset_submitted",
+  "password_reset_completed",
+  "password_reset_failed",
   "upload_started",
   "upload_completed",
   "upload_failed",
@@ -262,12 +286,130 @@ const getCurrentPath = (): string => {
   return `${window.location.pathname}${window.location.search}`;
 };
 
+const SENSITIVE_QUERY_PARAMS = new Set([
+  "access_token",
+  "api_key",
+  "auth_token",
+  "code",
+  "email",
+  "key",
+  "otp",
+  "password",
+  "refresh_token",
+  "secret",
+  "session",
+  "token",
+]);
+
+const URL_PROPERTY_KEYS = new Set([
+  "$current_url",
+  "$initial_current_url",
+  "$initial_referrer",
+  "$referrer",
+  "$session_entry_url",
+  "url",
+]);
+
+const getAnalyticsOrigin = (): string => {
+  if (typeof window === "undefined") return "https://deadtrees.earth";
+  return window.location.origin || "https://deadtrees.earth";
+};
+
+const hasUrlScheme = (url: string): boolean =>
+  /^[a-z][a-z0-9+.-]*:\/\//i.test(url);
+
+const isSensitiveQueryParam = (paramName: string): boolean => {
+  const normalizedName = paramName.toLowerCase();
+  return (
+    SENSITIVE_QUERY_PARAMS.has(normalizedName) ||
+    normalizedName.endsWith("_token")
+  );
+};
+
+export const sanitizeAnalyticsUrl = (url: string): string => {
+  const urlWithoutHash = url.split("#")[0] || "/";
+
+  try {
+    const isAbsoluteUrl = hasUrlScheme(urlWithoutHash);
+    const parsedUrl = new URL(urlWithoutHash, getAnalyticsOrigin());
+    parsedUrl.hash = "";
+
+    parsedUrl.searchParams.forEach((_value, key) => {
+      if (isSensitiveQueryParam(key)) {
+        parsedUrl.searchParams.set(key, "[redacted]");
+      }
+    });
+
+    const pathWithSearch = `${parsedUrl.pathname}${parsedUrl.search}`;
+    return isAbsoluteUrl
+      ? `${parsedUrl.origin}${pathWithSearch}`
+      : pathWithSearch;
+  } catch {
+    return urlWithoutHash;
+  }
+};
+
+const getAnalyticsPathname = (url: string): string => {
+  try {
+    return new URL(sanitizeAnalyticsUrl(url), getAnalyticsOrigin()).pathname;
+  } catch {
+    return "/";
+  }
+};
+
+const getAbsoluteAnalyticsUrl = (url: string): string => {
+  try {
+    return new URL(sanitizeAnalyticsUrl(url), getAnalyticsOrigin()).toString();
+  } catch {
+    return getAnalyticsOrigin();
+  }
+};
+
+type PostHogCapturePayload = {
+  event?: string;
+  properties?: Record<string, unknown>;
+  $set?: Record<string, unknown>;
+  $set_once?: Record<string, unknown>;
+};
+
+const sanitizeUrlProperties = (
+  properties: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  if (!properties) return properties;
+
+  return Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => {
+      if (URL_PROPERTY_KEYS.has(key) && typeof value === "string") {
+        return [key, sanitizeAnalyticsUrl(value)];
+      }
+
+      return [key, value];
+    }),
+  );
+};
+
+export const sanitizePostHogCapture = <T extends PostHogCapturePayload | null>(
+  capture: T,
+): T => {
+  if (!capture) return capture;
+
+  return {
+    ...capture,
+    properties: sanitizeUrlProperties(capture.properties),
+    $set: sanitizeUrlProperties(capture.$set),
+    $set_once: sanitizeUrlProperties(capture.$set_once),
+  };
+};
+
 const getCurrentPage = (): string => {
   if (typeof window === "undefined") return "/";
   return window.location.pathname;
 };
 
-export const deriveUserSegment = (isLoggedIn: boolean, isCoreTeam: boolean): UserSegment => {
+export const deriveUserSegment = (
+  isLoggedIn: boolean,
+  isCoreTeam: boolean,
+): UserSegment => {
   if (!isLoggedIn) return "visitor";
   return isCoreTeam ? "core_team" : "contributor";
 };
@@ -287,7 +429,10 @@ export const isConsentNeeded = (): boolean => {
   if (!storage) return true;
 
   const storedVersion = storage.getItem(COOKIE_CONSENT_VERSION_KEY);
-  return !storage.getItem(COOKIE_CONSENT_KEY) || storedVersion !== COOKIE_CONSENT_VERSION;
+  return (
+    !storage.getItem(COOKIE_CONSENT_KEY) ||
+    storedVersion !== COOKIE_CONSENT_VERSION
+  );
 };
 
 export const canCaptureEvents = (): boolean => {
@@ -330,8 +475,9 @@ export const initializePostHog = (consent: string | null = null): void => {
     api_host: "https://eu.i.posthog.com",
     persistence: mode === "accepted" ? "cookie" : "memory",
     autocapture: mode === "accepted",
-    capture_pageview: true,
-    capture_pageleave: mode === "accepted",
+    capture_pageview: false,
+    capture_pageleave: false,
+    before_send: sanitizePostHogCapture,
   } as const;
 
   // Persisted opt-in/out flags survive reloads, so they are not a safe proxy for whether
@@ -351,7 +497,10 @@ export const initializePostHog = (consent: string | null = null): void => {
     posthog.opt_in_capturing();
   } else if (consent === "rejected" && !posthog.has_opted_out_capturing()) {
     posthog.opt_out_capturing();
-  } else if (consent !== "accepted" && (posthog.has_opted_in_capturing() || posthog.has_opted_out_capturing())) {
+  } else if (
+    consent !== "accepted" &&
+    (posthog.has_opted_in_capturing() || posthog.has_opted_out_capturing())
+  ) {
     posthog.clear_opt_in_out_capturing();
   }
 };
@@ -359,17 +508,25 @@ export const initializePostHog = (consent: string | null = null): void => {
 export const trackPageView = (url: string): void => {
   if (!isPostHogAvailable()) return;
 
+  const safeUrl = sanitizeAnalyticsUrl(url);
+  const pageviewProperties = {
+    $current_url: getAbsoluteAnalyticsUrl(safeUrl),
+    url: safeUrl,
+    url_path: getAnalyticsPathname(safeUrl),
+  };
+
   if (canCaptureEvents()) {
-    posthog.capture("$pageview", { url });
+    posthog.capture("$pageview", pageviewProperties);
     return;
   }
 
-  posthog.capture("$pageview", {
-    url_path: new URL(url, typeof window !== "undefined" ? window.location.origin : "https://deadtrees.earth").pathname,
-  });
+  posthog.capture("$pageview", sanitizeEventProperties(pageviewProperties));
 };
 
-export const identifyUser = (user: User | null, options?: { isCoreTeam?: boolean }): void => {
+export const identifyUser = (
+  user: User | null,
+  options?: { isCoreTeam?: boolean },
+): void => {
   if (!isPostHogAvailable() || !user) return;
 
   const userSegment = deriveUserSegment(true, options?.isCoreTeam === true);
@@ -396,13 +553,16 @@ export const identifyUser = (user: User | null, options?: { isCoreTeam?: boolean
 export const sanitizeEventProperties = (
   properties: Record<string, unknown>,
 ): Record<string, unknown> => {
-  return ESSENTIAL_PROPERTY_KEYS.reduce<Record<string, unknown>>((safeProps, key) => {
-    const value = properties[key];
-    if (value !== undefined && value !== null && value !== "") {
-      safeProps[key] = value;
-    }
-    return safeProps;
-  }, {});
+  return ESSENTIAL_PROPERTY_KEYS.reduce<Record<string, unknown>>(
+    (safeProps, key) => {
+      const value = properties[key];
+      if (value !== undefined && value !== null && value !== "") {
+        safeProps[key] = value;
+      }
+      return safeProps;
+    },
+    {},
+  );
 };
 
 type EventContext = {
@@ -436,7 +596,10 @@ export const trackEvent = (
   if (!isPostHogAvailable()) return;
   if (!isEssential && !canCaptureEvents()) return;
 
-  const payload = isEssential && !hasAcceptedCookies() ? sanitizeEventProperties(properties) : properties;
+  const payload =
+    isEssential && !hasAcceptedCookies()
+      ? sanitizeEventProperties(properties)
+      : properties;
   posthog.capture(eventName, payload);
 };
 
@@ -456,30 +619,37 @@ export const trackAuthCompletion = (
     authPath?: string;
   } = {},
 ): void => {
-  trackAppEvent(
-    authEvent,
-    {
-      auth_path: options.authPath ?? getCurrentPath(),
-      source_surface: "auth",
-      user_segment: deriveUserSegment(true, options.isCoreTeam === true),
-      is_logged_in: true,
-    } as AnalyticsEventPropertiesMap[typeof authEvent],
-  );
+  trackAppEvent(authEvent, {
+    auth_path: options.authPath ?? getCurrentPath(),
+    source_surface: "auth",
+    user_segment: deriveUserSegment(true, options.isCoreTeam === true),
+    is_logged_in: true,
+  } as AnalyticsEventPropertiesMap[typeof authEvent]);
 };
 
-export const trackEmailLinkClick = (campaign: string, linkType: string): void => {
+export const trackEmailLinkClick = (
+  campaign: string,
+  linkType: string,
+): void => {
   trackEvent(
     "email_link_clicked",
     {
       campaign,
       linkType,
       page: getCurrentPage(),
-      ...(hasAcceptedCookies() && typeof window !== "undefined" && {
-        referrer: document.referrer,
-        utm_source: new URLSearchParams(window.location.search).get("utm_source"),
-        utm_medium: new URLSearchParams(window.location.search).get("utm_medium"),
-        utm_campaign: new URLSearchParams(window.location.search).get("utm_campaign"),
-      }),
+      ...(hasAcceptedCookies() &&
+        typeof window !== "undefined" && {
+          referrer: document.referrer,
+          utm_source: new URLSearchParams(window.location.search).get(
+            "utm_source",
+          ),
+          utm_medium: new URLSearchParams(window.location.search).get(
+            "utm_medium",
+          ),
+          utm_campaign: new URLSearchParams(window.location.search).get(
+            "utm_campaign",
+          ),
+        }),
     },
     true,
   );


### PR DESCRIPTION
## Summary

- Show actionable reset-password errors instead of only logging Supabase failures to the console.
- Add required, minimum-length, and confirm-password validation before submitting the new password.
- Handle missing or expired recovery sessions with a visible warning and a link back to the reset-request page.
- Sanitize PostHog pageview URLs so Supabase recovery fragments (`access_token`, `refresh_token`) are never sent.
- Disable automatic PostHog pageviews and send controlled, path-only pageviews plus reset-flow telemetry (`password_reset_*`).

## Root Cause

A user report from Axel Weinreich said the password reset dialog did not accept the new password or close. Production auth audit logs showed recovery links were requested and login events followed, but Axel did not get a recent `user_updated_password` audit event. The reset page called `supabase.auth.updateUser({ password })`, but errors were only written to `console.debug`, leaving the user with a stuck form and no explanation.

Follow-up PostHog investigation showed this affected more than one user: in the last 90 days there were 78 `/reset-password` pageviews from 20 distinct IDs, with 39 expired-link pageviews from 9 distinct IDs. The Apr 29 report matched a session that repeatedly bounced through `/forgot-password`, expired `/reset-password` links, and `/sign-in`.

The same PostHog check found an adjacent privacy issue: full recovery URLs containing Supabase `access_token` and `refresh_token` fragments were captured in 27 reset-page events affecting 9 distinct IDs. This PR now strips URL fragments, redacts sensitive query params, disables automatic SDK pageviews, and sanitizes PostHog `before_send` URL properties.

Fixes DT-431.

## Validation

- `npm run test -- --run src/utils/analytics.test.ts`
- `npx eslint src/utils/analytics.ts src/utils/analytics.test.ts src/pages/auth/ResetPassword.tsx src/App.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `npx prettier --check src/utils/analytics.ts src/utils/analytics.test.ts src/pages/auth/ResetPassword.tsx src/App.tsx`
- `npm run build`

Note: full `npm run lint` is still blocked by existing unrelated lint errors elsewhere in the frontend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to the reset-password page; main risk is regressions in form validation or handling of Supabase session edge-cases (expired/missing recovery links).
>
> **Overview**
> Improves the reset-password flow to show actionable, in-page errors instead of only logging Supabase failures, including friendlier messaging for missing/expired recovery sessions.
>
> Adds client-side form validation (required fields, minimum length, and confirm-password match), a submitting/loading state, and disables the form when there is no valid recovery session; also shows a brief "checking reset link" spinner and a warning with a link back to `forgot-password` when the link is expired.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750ed674b6309be7a26914426a8c179b3a331fdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
