### PR TITLE
fix(frontend): show combined forest cover layer

### DIFF
--- a/.cursor/rules/github.mdc
+++ b/.cursor/rules/github.mdc
@@ -90,6 +90,13 @@ gh pr list --repo Deadwood-ai/deadtrees
 gh pr view PR_NUMBER --repo Deadwood-ai/deadtrees
 ```
 
+### Pull Request Titles
+- PR titles must pass `.github/workflows/pr-title-check.yml`.
+- Use Conventional Commit style: `type(scope): short summary`.
+- Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`.
+- Do not prefix titles with agent markers such as `[codex]`; those fail the title check.
+- Good example: `fix(frontend): show combined forest cover layer`.
+
 ## 🏗️ **DEADWOOD PROJECT STRUCTURE**
 
 ### Main Repository
@@ -206,4 +213,4 @@ gh auth refresh -s repo,project,read:project,workflow
 - **Project board visibility**: Use the project board for sprint planning
 - **CLI automation**: Leverage GitHub CLI for repetitive tasks
 - **Cross-reference**: Link issues to commits, PRs, and other issues
-- **Milestone tracking**: Use milestones for release planning 
+- **Milestone tracking**: Use milestones for release planning

--- a/frontend/src/components/Corrections/CorrectionEditorView.tsx
+++ b/frontend/src/components/Corrections/CorrectionEditorView.tsx
@@ -27,6 +27,7 @@ import { createDeadwoodVectorLayer, createForestCoverVectorLayer } from "../Data
 import { useDatasetLabelTypes } from "../../hooks/useDatasetLabelTypes";
 import { useDatasetDetailsMap } from "../../hooks/useDatasetDetailsMapProvider";
 import { createOpenFreeMapLibertyLayerGroup, createStandardMapControls } from "../../utils/basemaps";
+import { hasForestCoverPredictionOutput } from "../../utils/predictionAvailability";
 
 interface Props {
   dataset: IDataset;
@@ -72,6 +73,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
     predictionLabel?.id,
     editingLayerType
   );
+  const hasDisplayableForestCover = hasForestCoverPredictionOutput(dataset);
 
   // Save mutations
   const saveCorrections = useSaveCorrections();
@@ -115,7 +117,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
       ? createDeadwoodVectorLayer(deadwood.data.id, { showCorrectionStyling: true })
       : undefined;
     const forestCoverVectorLayer =
-      dataset.is_forest_cover_done && forestCover.data?.id
+      hasDisplayableForestCover && forestCover.data?.id
         ? createForestCoverVectorLayer(forestCover.data.id, { showCorrectionStyling: true })
         : undefined;
 
@@ -187,7 +189,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
       deadwoodLayerRef.current = null;
       forestCoverLayerRef.current = null;
     };
-  }, [dataset.cog_path, dataset.is_forest_cover_done, deadwood.data?.id, forestCover.data?.id]);
+  }, [dataset.cog_path, hasDisplayableForestCover, deadwood.data?.id, forestCover.data?.id]);
 
   // Start editing
   const handleStartEditing = useCallback(async () => {

--- a/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
+++ b/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
@@ -19,6 +19,7 @@ import { useDatasetEditing } from "../../hooks/useDatasetEditing";
 import { mapColors } from "../../theme/mapColors";
 import { MAP_FLOATING_TOP_CLASS } from "../../theme/mapLayout";
 import { trackAppEvent } from "../../utils/analytics";
+import { hasForestCoverPredictionOutput } from "../../utils/predictionAvailability";
 
 interface AuditMapWithControlsProps {
 	dataset: IDataset;
@@ -74,7 +75,7 @@ const AuditMapWithControls = forwardRef<AuditMapWithControlsHandle, AuditMapWith
 		});
 
 		const hasDeadwood = !!deadwood.data?.id;
-		const hasForestCover = !!forestCover.data?.id && !!dataset.is_forest_cover_done;
+		const hasForestCover = !!forestCover.data?.id && hasForestCoverPredictionOutput(dataset);
 
 		// Editing hook for polygon corrections
 		const editing = useDatasetEditing({ datasetId: dataset?.id, user });

--- a/frontend/src/components/DatasetAudit/DatasetAuditMap.tsx
+++ b/frontend/src/components/DatasetAudit/DatasetAuditMap.tsx
@@ -6,6 +6,7 @@ import { IDataset } from "../../types/dataset";
 import { useDatasetLabelTypes } from "../../hooks/useDatasetLabelTypes";
 import { useDatasetDetailsMap } from "../../hooks/useDatasetDetailsMapProvider";
 import { useDatasetAOI } from "../../hooks/useDatasetAudit";
+import { hasForestCoverPredictionOutput } from "../../utils/predictionAvailability";
 import { FeatureTooltip, FeaturePopover, ClickedPolygonInfo } from "../DatasetDetailsMap/overlays";
 import {
 	useMapCore,
@@ -160,7 +161,7 @@ const DatasetAuditMap = forwardRef<DatasetAuditMapHandle, DatasetAuditMapProps>(
 		map: mapRef.current,
 		deadwoodLabelId: deadwood.data?.id,
 		forestCoverLabelId: forestCover.data?.id,
-		isForestCoverDone: data?.is_forest_cover_done,
+		isForestCoverDone: hasForestCoverPredictionOutput(data),
 		showCorrectionStyling: true,
 		filterCorrectionStatus: 'all', // Show all polygons including pending deletions
 		getDeadwoodVisible,

--- a/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
+++ b/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
@@ -6,6 +6,7 @@ import { useDatasetLabelTypes } from "../../hooks/useDatasetLabelTypes";
 import { useDatasetDetailsMap } from "../../hooks/useDatasetDetailsMapProvider";
 import { useDatasetAOI } from "../../hooks/useDatasetAudit";
 import { useIsMobile } from "../../hooks/useIsMobile";
+import { hasForestCoverPredictionOutput } from "../../utils/predictionAvailability";
 import { FeatureTooltip, FeaturePopover, ClickedPolygonInfo } from "./overlays";
 import {
 	useMapInstance,
@@ -146,7 +147,7 @@ export default function BaseMap({
 		map: mapRef.current,
 		deadwoodLabelId: deadwoodLabelIdOverride !== undefined ? deadwoodLabelIdOverride : deadwood.data?.id,
 		forestCoverLabelId: forestCoverLabelIdOverride !== undefined ? forestCoverLabelIdOverride : forestCover.data?.id,
-		isForestCoverDone: data?.is_forest_cover_done,
+		isForestCoverDone: hasForestCoverPredictionOutput(data),
 		showCorrectionStyling: true,
 		getDeadwoodVisible,
 		getForestCoverVisible,

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -17,6 +17,7 @@ import { useDatasetEditing } from "../hooks/useDatasetEditing";
 import { useCanAudit } from "../hooks/useUserPrivileges";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useAnalytics } from "../hooks/useAnalytics";
+import { hasForestCoverPredictionOutput } from "../utils/predictionAvailability";
 
 import DatasetLayerControlPanel from "../components/DatasetDetailsMap/DatasetLayerControlPanel";
 import EditingSidebar from "../components/DatasetDetailsMap/EditingSidebar";
@@ -178,6 +179,7 @@ export default function DatasetDetails() {
   }
 
   const { isEditing, editingLayerType, editor, ai, hasDeadwood, hasForestCover, refreshKey } = editing;
+  const hasDisplayableForestCover = hasForestCover && hasForestCoverPredictionOutput(dataset);
   const SIDEBAR_LEFT_PX = 16;
   const SIDEBAR_WIDTH_PX = 384;
   const SIDEBAR_BUTTON_TOP_PX = 112;
@@ -302,7 +304,7 @@ export default function DatasetDetails() {
               setShowDroneImagery={setShowDroneImagery}
               showAOI={layerControl.showAOI}
               setShowAOI={setShowAOI}
-              hasForestCover={hasForestCover && !!dataset.is_forest_cover_done}
+              hasForestCover={hasDisplayableForestCover}
               hasDeadwood={hasDeadwood}
               hasAOI={true}
               forestCoverQuality={auditInfo?.forest_cover_quality as "great" | "sentinel_ok" | "bad" | undefined}
@@ -418,7 +420,7 @@ export default function DatasetDetails() {
             setShowDroneImagery={setShowDroneImagery}
             showAOI={layerControl.showAOI}
             setShowAOI={setShowAOI}
-            hasForestCover={hasForestCover && !!dataset.is_forest_cover_done}
+            hasForestCover={hasDisplayableForestCover}
             hasDeadwood={hasDeadwood}
             hasAOI={true}
             forestCoverQuality={auditInfo?.forest_cover_quality as "great" | "sentinel_ok" | "bad" | undefined}

--- a/frontend/src/utils/predictionAvailability.test.ts
+++ b/frontend/src/utils/predictionAvailability.test.ts
@@ -1,35 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  hasDeadwoodPredictionOutput,
-  hasForestCoverPredictionOutput,
-} from "./predictionAvailability";
+import { hasForestCoverPredictionOutput } from "./predictionAvailability";
 
 describe("prediction availability", () => {
-  it("accepts legacy per-layer completion flags", () => {
-    expect(hasDeadwoodPredictionOutput({ is_deadwood_done: true })).toBe(true);
+  it("accepts the legacy forest-cover completion flag", () => {
     expect(hasForestCoverPredictionOutput({ is_forest_cover_done: true })).toBe(true);
   });
 
-  it("accepts combined-model completion for both prediction layers", () => {
+  it("accepts combined-model completion for forest-cover prediction output", () => {
     const dataset = {
-      is_deadwood_done: false,
       is_forest_cover_done: false,
       is_combined_model_done: true,
     };
 
-    expect(hasDeadwoodPredictionOutput(dataset)).toBe(true);
     expect(hasForestCoverPredictionOutput(dataset)).toBe(true);
   });
 
-  it("requires at least one completion signal", () => {
+  it("requires a forest-cover or combined-model completion signal", () => {
     const dataset = {
-      is_deadwood_done: false,
       is_forest_cover_done: false,
       is_combined_model_done: false,
     };
 
-    expect(hasDeadwoodPredictionOutput(dataset)).toBe(false);
     expect(hasForestCoverPredictionOutput(dataset)).toBe(false);
   });
 });

--- a/frontend/src/utils/predictionAvailability.test.ts
+++ b/frontend/src/utils/predictionAvailability.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasDeadwoodPredictionOutput,
+  hasForestCoverPredictionOutput,
+} from "./predictionAvailability";
+
+describe("prediction availability", () => {
+  it("accepts legacy per-layer completion flags", () => {
+    expect(hasDeadwoodPredictionOutput({ is_deadwood_done: true })).toBe(true);
+    expect(hasForestCoverPredictionOutput({ is_forest_cover_done: true })).toBe(true);
+  });
+
+  it("accepts combined-model completion for both prediction layers", () => {
+    const dataset = {
+      is_deadwood_done: false,
+      is_forest_cover_done: false,
+      is_combined_model_done: true,
+    };
+
+    expect(hasDeadwoodPredictionOutput(dataset)).toBe(true);
+    expect(hasForestCoverPredictionOutput(dataset)).toBe(true);
+  });
+
+  it("requires at least one completion signal", () => {
+    const dataset = {
+      is_deadwood_done: false,
+      is_forest_cover_done: false,
+      is_combined_model_done: false,
+    };
+
+    expect(hasDeadwoodPredictionOutput(dataset)).toBe(false);
+    expect(hasForestCoverPredictionOutput(dataset)).toBe(false);
+  });
+});

--- a/frontend/src/utils/predictionAvailability.ts
+++ b/frontend/src/utils/predictionAvailability.ts
@@ -4,10 +4,6 @@ type PredictionCompletionState = Partial<
   Pick<IDataset, "is_deadwood_done" | "is_forest_cover_done" | "is_combined_model_done">
 >;
 
-export function hasDeadwoodPredictionOutput(dataset: PredictionCompletionState | null | undefined): boolean {
-  return !!(dataset?.is_deadwood_done || dataset?.is_combined_model_done);
-}
-
 export function hasForestCoverPredictionOutput(dataset: PredictionCompletionState | null | undefined): boolean {
   return !!(dataset?.is_forest_cover_done || dataset?.is_combined_model_done);
 }

--- a/frontend/src/utils/predictionAvailability.ts
+++ b/frontend/src/utils/predictionAvailability.ts
@@ -1,0 +1,13 @@
+import { IDataset } from "../types/dataset";
+
+type PredictionCompletionState = Partial<
+  Pick<IDataset, "is_deadwood_done" | "is_forest_cover_done" | "is_combined_model_done">
+>;
+
+export function hasDeadwoodPredictionOutput(dataset: PredictionCompletionState | null | undefined): boolean {
+  return !!(dataset?.is_deadwood_done || dataset?.is_combined_model_done);
+}
+
+export function hasForestCoverPredictionOutput(dataset: PredictionCompletionState | null | undefined): boolean {
+  return !!(dataset?.is_forest_cover_done || dataset?.is_combined_model_done);
+}


### PR DESCRIPTION
## Summary
- Treat combined-model completion as valid prediction output for forest-cover layer availability.
- Keep the existing requirement that a forest-cover label exists before showing or creating the layer.
- Apply the same availability rule on dataset details, audit maps, and correction editor views.
- Add a focused utility test for legacy and combined-model prediction signals.

## Root Cause
Dataset 8839 has combined-model labels and forest-cover geometries, but the legacy `is_forest_cover_done` flag remains false by design. The frontend still gated Forest Cover UI and MVT layer creation only on that legacy flag, so the data existed in prod but did not appear in the layer controls.

## Validation
- `npm test -- src/utils/predictionAvailability.test.ts src/utils/processingSteps.test.ts`
- `npm run build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI gating change that only affects when the Forest Cover vector layer and controls are enabled, plus a small new utility with unit tests.
> 
> **Overview**
> **Fixes Forest Cover layer visibility for combined-model datasets.** Forest cover map layers/controls and correction editor visualization are now gated by a new `hasForestCoverPredictionOutput()` helper that treats `is_combined_model_done` as a valid completion signal (while still requiring a forest-cover label ID).
> 
> This updates the dataset details page, audit map flow, and correction editor to consistently use the new availability check, and adds a focused `predictionAvailability` utility (with tests) to cover legacy per-layer flags vs combined-model completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab87b052f1b14f0b7ee776b5648b2ed8fa9e2616. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->