### PR TITLE
fix(frontend): prefer combined model labels for public users

### DIFF
--- a/frontend/src/hooks/useDatasetLabels.ts
+++ b/frontend/src/hooks/useDatasetLabels.ts
@@ -2,6 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "../hooks/useSupabase";
 import { ILabel, ILabelData } from "../types/labels";
 import { Settings } from "../config";
+import {
+  ModelConfig,
+  selectPreferredModelLabel,
+} from "../utils/modelPreferences";
 
 interface UseDatasetLabelsProps {
   datasetId: number;
@@ -11,7 +15,7 @@ interface UseDatasetLabelsProps {
 
 interface ModelPreference {
   label_data: string;
-  model_config: Record<string, unknown>;
+  model_config: ModelConfig;
 }
 
 function useModelPreferences() {
@@ -25,18 +29,15 @@ function useModelPreferences() {
         console.error("Error fetching model preferences:", error);
         return new Map();
       }
-      return new Map((data as ModelPreference[]).map((row) => [row.label_data, row.model_config]));
+      return new Map(
+        (data as ModelPreference[]).map((row) => [
+          row.label_data,
+          row.model_config,
+        ]),
+      );
     },
     staleTime: 5 * 60 * 1000,
   });
-}
-
-function configMatches(
-  labelConfig: Record<string, unknown> | undefined,
-  preferredConfig: Record<string, unknown>,
-): boolean {
-  if (!labelConfig) return false;
-  return Object.entries(preferredConfig).every(([k, v]) => labelConfig[k] === v);
 }
 
 export function useDatasetLabels({
@@ -47,11 +48,19 @@ export function useDatasetLabels({
   const { data: preferences } = useModelPreferences();
 
   return useQuery({
-    queryKey: ["labels", datasetId, labelType, preferences ? "prefs-loaded" : "prefs-pending"],
+    queryKey: [
+      "labels",
+      datasetId,
+      labelType,
+      preferences ? "prefs-loaded" : "prefs-pending",
+    ],
     queryFn: async (): Promise<ILabel | null> => {
       if (!datasetId) return null;
 
-      const query = supabase.from(Settings.LABELS_TABLE).select("*").eq("dataset_id", datasetId);
+      const query = supabase
+        .from(Settings.LABELS_TABLE)
+        .select("*")
+        .eq("dataset_id", datasetId);
 
       if (labelType) {
         query.eq("label_data", labelType);
@@ -68,23 +77,11 @@ export function useDatasetLabels({
         return null;
       }
 
-      if (data.length === 1) {
-        return data[0];
-      }
-
-      // Prefer the model_prediction label whose model_config matches v2_model_preferences.
-      const preferredConfig = labelType ? preferences?.get(labelType) : undefined;
-      if (preferredConfig) {
-        const preferred = data.find(
-          (label) =>
-            label.label_source === "model_prediction" &&
-            configMatches(label.model_config, preferredConfig),
-        );
-        if (preferred) return preferred;
-      }
-
-      // Fall back to any model_prediction, then first label.
-      return data.find((label) => label.label_source === "model_prediction") ?? data[0];
+      return selectPreferredModelLabel(
+        data as ILabel[],
+        labelType,
+        preferences,
+      );
     },
     enabled,
   });

--- a/frontend/src/utils/modelPreferences.test.ts
+++ b/frontend/src/utils/modelPreferences.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { ILabel, ILabelData, ILabelSource, ILabelType } from "../types/labels";
+import { selectPreferredModelLabel } from "./modelPreferences";
+
+function modelLabel(id: number, module: string | null): ILabel {
+  return {
+    id,
+    dataset_id: 9739,
+    user_id: "test-user",
+    label_source: ILabelSource.MODEL_PREDICTION,
+    label_type: ILabelType.SEMANTIC_SEGMENTATION,
+    label_data: ILabelData.FOREST_COVER,
+    model_config: module
+      ? {
+          module,
+          checkpoint_name:
+            module === "deadwood_treecover_combined_v2"
+              ? "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors"
+              : "legacy.safetensors",
+        }
+      : undefined,
+    created_at: "2026-04-29T09:51:38.523681+00:00",
+    updated_at: "2026-04-29T09:51:38.523681+00:00",
+  };
+}
+
+describe("model preference label selection", () => {
+  it("defaults to the combined model when preferences are unavailable", () => {
+    const labels = [
+      modelLabel(20762, "treecover_segmentation_oam_tcd"),
+      modelLabel(20764, "deadwood_treecover_combined_v2"),
+    ];
+
+    expect(
+      selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, new Map())?.id,
+    ).toBe(20764);
+    expect(
+      selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, undefined)?.id,
+    ).toBe(20764);
+  });
+
+  it("uses configured model preferences when they are available", () => {
+    const labels = [
+      modelLabel(20762, "treecover_segmentation_oam_tcd"),
+      modelLabel(20764, "deadwood_treecover_combined_v2"),
+    ];
+
+    const preferences = new Map([
+      [
+        ILabelData.FOREST_COVER,
+        {
+          module: "treecover_segmentation_oam_tcd",
+          checkpoint_name: "legacy.safetensors",
+        },
+      ],
+    ]);
+
+    expect(
+      selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, preferences)
+        ?.id,
+    ).toBe(20762);
+  });
+});

--- a/frontend/src/utils/modelPreferences.ts
+++ b/frontend/src/utils/modelPreferences.ts
@@ -1,0 +1,50 @@
+import { ILabel, ILabelData, ILabelSource } from "../types/labels";
+
+export type ModelConfig = Record<string, unknown>;
+
+export const COMBINED_MODEL_CONFIG: ModelConfig = {
+  module: "deadwood_treecover_combined_v2",
+  checkpoint_name: "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors",
+};
+
+export const DEFAULT_MODEL_PREFERENCES: Record<ILabelData, ModelConfig> = {
+  [ILabelData.DEADWOOD]: COMBINED_MODEL_CONFIG,
+  [ILabelData.FOREST_COVER]: COMBINED_MODEL_CONFIG,
+};
+
+function configMatches(
+  labelConfig: ModelConfig | undefined,
+  preferredConfig: ModelConfig,
+): boolean {
+  if (!labelConfig) return false;
+  return Object.entries(preferredConfig).every(
+    ([key, value]) => labelConfig[key] === value,
+  );
+}
+
+export function selectPreferredModelLabel<
+  T extends Pick<ILabel, "label_source" | "model_config">,
+>(
+  labels: T[],
+  labelType: ILabelData,
+  preferences?: ReadonlyMap<string, ModelConfig>,
+): T | null {
+  if (labels.length === 0) return null;
+  if (labels.length === 1) return labels[0];
+
+  const preferredConfig =
+    preferences?.get(labelType) ?? DEFAULT_MODEL_PREFERENCES[labelType];
+  const preferred = labels.find(
+    (label) =>
+      label.label_source === ILabelSource.MODEL_PREDICTION &&
+      configMatches(label.model_config, preferredConfig),
+  );
+
+  if (preferred) return preferred;
+
+  return (
+    labels.find(
+      (label) => label.label_source === ILabelSource.MODEL_PREDICTION,
+    ) ?? labels[0]
+  );
+}

--- a/supabase/migrations/20260430110000_allow_anon_read_model_preferences.sql
+++ b/supabase/migrations/20260430110000_allow_anon_read_model_preferences.sql
@@ -1,0 +1,18 @@
+grant select on table public.v2_model_preferences to anon;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'v2_model_preferences'
+      and policyname = 'Public users can read model preferences'
+  ) then
+    create policy "Public users can read model preferences"
+      on public.v2_model_preferences
+      for select
+      to anon
+      using (true);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- allow anonymous clients to read `v2_model_preferences` so public dataset views can resolve the preferred model labels
- add frontend default model preferences that point both deadwood and forest cover to `deadwood_treecover_combined_v2`
- move preferred-label selection into a tested helper and cover the empty-preferences fallback

## Root cause
Public users could not read `v2_model_preferences`, so the frontend preference query returned no rows for anonymous visitors. The label hook then fell back to the first `model_prediction`, which can be the older V1 deadwood/treecover labels on datasets that also have combined-model labels.

## Validation
- `npm test` in `frontend` passed: 34 tests
- targeted ESLint on touched frontend files passed
- `npm run build` in `frontend` passed

Note: repo-wide `npm run lint` still fails on pre-existing unrelated lint issues outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes label-selection behavior for public dataset views and modifies Supabase grants/RLS on `v2_model_preferences`, which could affect what anonymous users can read.
> 
> **Overview**
> **Fixes preferred model-label selection for public dataset views.** Anonymous clients can now `SELECT` from `v2_model_preferences` via a new Supabase migration granting access and adding an anon read policy.
> 
> On the frontend, preferred-label selection is refactored into a new tested helper (`selectPreferredModelLabel`) that applies **default preferences** (deadwood/forest cover -> `deadwood_treecover_combined_v2`) when DB preferences are missing, instead of falling back to an arbitrary first `model_prediction` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c5ed28db8c38e1d5fa19b333dc084ffdd2b71c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->