### PR TITLE
fix(frontend): align tree and deadwood cover labels

### DIFF
--- a/frontend/src/components/AuditBadge.tsx
+++ b/frontend/src/components/AuditBadge.tsx
@@ -55,8 +55,8 @@ function buildTooltip(audit: DatasetAuditUserInfo) {
     { label: "Georeferenced", value: renderBool(audit.is_georeferenced) },
     { label: "Valid acquisition date", value: renderBool(audit.has_valid_acquisition_date) },
     { label: "Phenology", value: `${renderBool(audit.has_valid_phenology)}`, hint: acquisitionHint },
-    { label: "Deadwood quality", value: renderQuality(audit.deadwood_quality || null) },
-    { label: "Forest cover quality", value: renderQuality(audit.forest_cover_quality || null) },
+    { label: "Deadwood cover quality", value: renderQuality(audit.deadwood_quality || null) },
+    { label: "Tree cover quality", value: renderQuality(audit.forest_cover_quality || null) },
   ];
 
   return (

--- a/frontend/src/components/Corrections/CorrectionEditorView.tsx
+++ b/frontend/src/components/Corrections/CorrectionEditorView.tsx
@@ -229,7 +229,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
     }
 
     message.info(
-      `Editing ${editingLayerType === "deadwood" ? "Deadwood" : "Forest Cover"} - ${loadedGeometries.length} polygons loaded`
+      `Editing ${editingLayerType === "deadwood" ? "deadwood cover" : "tree cover"} - ${loadedGeometries.length} polygons loaded`
     );
   }, [predictionLabel?.id, loadedGeometries, editingLayerType, editor]);
 
@@ -504,7 +504,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
             loading={isLoading}
           >
             Start Editing{" "}
-            {editingLayerType === "deadwood" ? "Deadwood" : "Forest Cover"}
+            {editingLayerType === "deadwood" ? "Deadwood cover" : "Tree cover"}
           </Button>
         )}
       </div>

--- a/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
+++ b/frontend/src/components/DatasetAudit/AuditMapWithControls.tsx
@@ -219,24 +219,24 @@ const AuditMapWithControls = forwardRef<AuditMapWithControlsHandle, AuditMapWith
 									</Tooltip>
 									<div className="flex flex-col gap-1 ml-2">
 										{pendingDeadwood > 0 && (
-											<Tooltip title="Click to show pending deadwood edits">
+												<Tooltip title="Click to show pending deadwood cover edits">
 												<div
 													className="flex items-center gap-1.5 text-[10px] text-gray-600 cursor-pointer hover:text-orange-600"
 													onClick={() => handleFlashPending("deadwood")}
 												>
 													<span className="h-2 w-2 rounded-sm" style={{ backgroundColor: mapColors.deadwood.fill }} />
-													<span>{pendingDeadwood} deadwood</span>
+														<span>{pendingDeadwood} deadwood cover</span>
 												</div>
 											</Tooltip>
 										)}
 										{pendingForestCover > 0 && (
-											<Tooltip title="Click to show pending forest cover edits">
+												<Tooltip title="Click to show pending tree cover edits">
 												<div
 													className="flex items-center gap-1.5 text-[10px] text-gray-600 cursor-pointer hover:text-green-600"
 													onClick={() => handleFlashPending("forest_cover")}
 												>
 													<span className="h-2 w-2 rounded-sm bg-green-500" />
-													<span>{pendingForestCover} forest cover</span>
+														<span>{pendingForestCover} tree cover</span>
 												</div>
 											</Tooltip>
 										)}
@@ -329,7 +329,7 @@ const AuditMapWithControls = forwardRef<AuditMapWithControlsHandle, AuditMapWith
 						onSave={editing.handleSaveEdits}
 						onCancel={editing.handleCancelEditing}
 						position="top-right"
-						title={`Editing ${editingLayerType === "deadwood" ? "Deadwood" : "Forest Cover"}`}
+							title={`Editing ${editingLayerType === "deadwood" ? "deadwood cover" : "tree cover"}`}
 					/>
 				)}
 

--- a/frontend/src/components/DatasetAudit/AuditStepCards.tsx
+++ b/frontend/src/components/DatasetAudit/AuditStepCards.tsx
@@ -311,10 +311,10 @@ export function PredictionQualityCard() {
 				<Text strong className="text-xs">4. Prediction Quality</Text>
 			</div>
 
-			{/* Deadwood */}
+				{/* Deadwood cover */}
 			<div className="mb-3">
 				<div className="mb-1 flex items-center">
-					<Text className="text-xs font-medium">Deadwood Segmentation</Text>
+					<Text className="text-xs font-medium">Deadwood cover segmentation</Text>
 				</div>
 				<Form.Item
 					name="deadwood_quality"
@@ -330,19 +330,19 @@ export function PredictionQualityCard() {
 					</Radio.Group>
 				</Form.Item>
 				<Form.Item name="deadwood_notes" className="mb-0">
-					<TextArea rows={1} placeholder="Deadwood notes..." className="text-xs" />
+					<TextArea rows={1} placeholder="Deadwood cover notes..." className="text-xs" />
 				</Form.Item>
 			</div>
 
-			{/* Forest Cover */}
+			{/* Tree cover */}
 			<div>
 				<div className="mb-1 flex items-center">
-					<Text className="text-xs font-medium">Forest Cover Segmentation</Text>
+					<Text className="text-xs font-medium">Tree cover segmentation</Text>
 				</div>
 				<Form.Item
 					name="forest_cover_quality"
 					className="mb-1"
-					rules={[{ required: false, message: "Please rate forest cover quality" }]}
+					rules={[{ required: false, message: "Please rate tree cover quality" }]}
 				>
 					<Radio.Group>
 						<Space size="large">

--- a/frontend/src/components/DatasetAudit/auditConstants.ts
+++ b/frontend/src/components/DatasetAudit/auditConstants.ts
@@ -8,9 +8,9 @@ export const AUDIT_INFO = {
 	phenology:
 		"Assess seasonal appropriateness: In Season means appropriate for the region and time. Out of Season (especially in non-tropical regions) should be excluded from Sentinel training.",
 	deadwoodQuality:
-		"Rate deadwood segmentation prediction quality: Great = highly accurate, OK = acceptable for Sentinel training, Bad = poor quality predictions.",
+			"Rate deadwood cover segmentation prediction quality: Great = highly accurate, OK = acceptable for Sentinel training, Bad = poor quality predictions.",
 	forestCoverQuality:
-		"Evaluate forest cover segmentation quality: Great = precise boundaries and classification, OK = acceptable accuracy, Bad = poor segmentation results.",
+			"Evaluate tree cover segmentation quality: Great = precise boundaries and classification, OK = acceptable accuracy, Bad = poor segmentation results.",
 	cogIssues:
 		"Assess Cloud-Optimized GeoTIFF quality: Check transparency, black/white areas, color band consistency, and artifacts. Good = no issues, Issues = problems detected.",
 	thumbnailIssues:

--- a/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
@@ -90,8 +90,8 @@ const assessmentConfig = {
 };
 
 const tooltips = {
-  forestCover: "Quality of the AI forest cover segmentation. Great = highly accurate boundaries.",
-  deadwood: "Quality of the AI deadwood detection. Great = dead trees accurately identified.",
+  forestCover: "Quality of the AI tree cover segmentation. Great = highly accurate boundaries.",
+  deadwood: "Quality of the AI deadwood cover detection. Great = dead trees accurately identified.",
   finalAssessment: "Overall quality assessment. Ready = suitable for analysis, Fixable = has correctable issues, Excluded = not suitable.",
 };
 
@@ -145,10 +145,10 @@ const AuditSection = ({ audit }: AuditSectionProps) => {
 
       {/* Content rows */}
       <div className="p-5 space-y-3">
-        <InfoRow label="Forest Cover Prediction" tooltip={tooltips.forestCover}>
+        <InfoRow label="Tree cover prediction" tooltip={tooltips.forestCover}>
           <QualityValue quality={audit.forest_cover_quality} />
         </InfoRow>
-        <InfoRow label="Deadwood Prediction" tooltip={tooltips.deadwood}>
+        <InfoRow label="Deadwood cover prediction" tooltip={tooltips.deadwood}>
           <QualityValue quality={audit.deadwood_quality} />
         </InfoRow>
         <InfoRow label="Final Assessment" tooltip={tooltips.finalAssessment}>

--- a/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
@@ -145,7 +145,7 @@ const DatasetLayerControlPanel = ({
               >
                 <span className={`flex items-center gap-2 ${forestCoverQuality === "bad" && !canBypassQualityRestriction ? "opacity-50" : ""}`}>
                   <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.forest.fill }} />
-                  <span className="text-xs text-gray-600">Forest Cover</span>
+                  <span className="text-xs text-gray-600">Tree cover</span>
                 </span>
               </Checkbox>
               <QualityIcon quality={forestCoverQuality} />
@@ -175,7 +175,7 @@ const DatasetLayerControlPanel = ({
               >
                 <span className={`flex items-center gap-2 ${deadwoodQuality === "bad" && !canBypassQualityRestriction ? "opacity-50" : ""}`}>
                   <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.deadwood.fill }} />
-                  <span className="text-xs text-gray-600">Standing Deadwood</span>
+                  <span className="text-xs text-gray-600">Deadwood cover</span>
                 </span>
               </Checkbox>
               <div className="flex items-center gap-1">
@@ -265,7 +265,7 @@ const DatasetLayerControlPanel = ({
             <div className="mt-2 space-y-2 rounded bg-gray-50 p-2 text-xs">
               {hasDeadwood && (
                 <div>
-                  <div className="font-semibold text-gray-800">Deadwood Detection:</div>
+                  <div className="font-semibold text-gray-800">Deadwood cover:</div>
                   <a
                     href="https://www.sciencedirect.com/science/article/pii/S2667393225000237"
                     className="text-blue-600 underline"
@@ -278,7 +278,7 @@ const DatasetLayerControlPanel = ({
               )}
               {hasForestCover && (
                 <div>
-                  <div className="font-semibold text-gray-800">Forest Cover:</div>
+                  <div className="font-semibold text-gray-800">Tree cover:</div>
                   <a
                     href="https://proceedings.neurips.cc/paper_files/paper/2024/file/58efdd77196fa8159062afa0408245da-Paper-Datasets_and_Benchmarks_Track.pdf"
                     className="text-blue-600 underline"
@@ -321,7 +321,7 @@ const DatasetLayerControlPanel = ({
               onClick={onEditForestCover}
               block
             >
-              Edit Forest Cover
+              Edit tree cover
             </Button>
           )}
 
@@ -332,7 +332,7 @@ const DatasetLayerControlPanel = ({
               onClick={onEditDeadwood}
               block
             >
-              Edit Deadwood
+              Edit deadwood cover
             </Button>
           )}
 

--- a/frontend/src/components/DatasetDetailsMap/DeadwoodCardDetails.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DeadwoodCardDetails.tsx
@@ -47,10 +47,10 @@ export function DeadwoodCardDetails({
 
         {!isCollapsed && (
           <>
-            {/* Deadwood Layer Controls - Only show if data exists */}
+            {/* Deadwood cover controls - only show if data exists */}
             {showLegend && (
               <div className="mb-2 flex w-full items-center">
-                <p className="m-0 w-2/3 text-xs text-gray-600">Deadwood Segmentation</p>
+                <p className="m-0 w-2/3 text-xs text-gray-600">Deadwood cover segmentation</p>
                 <div className="w-1/3 pl-3">
                   <Slider
                     className="m-0 w-full"
@@ -65,10 +65,10 @@ export function DeadwoodCardDetails({
               </div>
             )}
 
-            {/* Forest Cover Layer Controls - Only show if data exists */}
+            {/* Tree cover controls - only show if data exists */}
             {showForestCoverLegend && forestCoverOpacity !== undefined && setForestCoverOpacity && (
               <div className="mb-2 flex w-full items-center">
-                <p className="m-0 w-2/3 text-xs text-gray-600">Forest Cover Segmentation</p>
+                <p className="m-0 w-2/3 text-xs text-gray-600">Tree cover segmentation</p>
                 <div className="w-1/3 pl-3">
                   <Slider
                     className="m-0 w-full"
@@ -148,7 +148,7 @@ export function DeadwoodCardDetails({
                     )}
                     {showLegend && (
                       <div>
-                        <div className="font-semibold text-gray-800">Deadwood Detection:</div>
+                        <div className="font-semibold text-gray-800">Deadwood cover:</div>
                         <a
                           href="https://www.sciencedirect.com/science/article/pii/S2667393225000237"
                           className="text-blue-600 underline"
@@ -161,7 +161,7 @@ export function DeadwoodCardDetails({
                     )}
                     {showForestCoverLegend && (
                       <div>
-                        <div className="font-semibold text-gray-800">Forest Cover:</div>
+                        <div className="font-semibold text-gray-800">Tree cover:</div>
                         <a
                           href="https://proceedings.neurips.cc/paper_files/paper/2024/file/58efdd77196fa8159062afa0408245da-Paper-Datasets_and_Benchmarks_Track.pdf"
                           className="text-blue-600 underline"

--- a/frontend/src/components/DatasetDetailsMap/EditingSidebar.tsx
+++ b/frontend/src/components/DatasetDetailsMap/EditingSidebar.tsx
@@ -16,7 +16,7 @@ interface EditingSidebarProps {
 }
 
 export default function EditingSidebar({ layerType }: EditingSidebarProps) {
-  const layerName = layerType === "deadwood" ? "Deadwood" : "Forest Cover";
+  const layerName = layerType === "deadwood" ? "Deadwood cover" : "Tree cover";
 
   return (
     <div className="p-2">

--- a/frontend/src/components/DatasetDetailsMap/hooks/useMapInteractions.ts
+++ b/frontend/src/components/DatasetDetailsMap/hooks/useMapInteractions.ts
@@ -89,10 +89,10 @@ export function useMapInteractions({
 		// Check deadwood layer first (higher priority)
 		if (deadwoodLayer?.getVisible() && map.hasFeatureAtPixel(pixel, { layerFilter: (l) => l === deadwoodLayer })) {
 			hitLayer = deadwoodLayer;
-			layerType = "Deadwood";
+			layerType = "Deadwood cover";
 		} else if (forestCoverLayer?.getVisible() && map.hasFeatureAtPixel(pixel, { layerFilter: (l) => l === forestCoverLayer })) {
 			hitLayer = forestCoverLayer;
-			layerType = "Forest Cover";
+			layerType = "Tree cover";
 		}
 
 		// Update cursor
@@ -140,11 +140,11 @@ export function useMapInteractions({
 		if (deadwoodLayer?.getVisible() && map.hasFeatureAtPixel(pixel, { layerFilter: (l) => l === deadwoodLayer })) {
 			hitLayer = deadwoodLayer;
 			layerType = "deadwood";
-			displayType = "Deadwood";
+			displayType = "Deadwood cover";
 		} else if (forestCoverLayer?.getVisible() && map.hasFeatureAtPixel(pixel, { layerFilter: (l) => l === forestCoverLayer })) {
 			hitLayer = forestCoverLayer;
 			layerType = "forest_cover";
-			displayType = "Forest Cover";
+			displayType = "Tree cover";
 		}
 
 		if (hitLayer) {

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -478,14 +478,14 @@ const DeadtreesMap = () => {
           if (showForest) {
             layerParts.push(`<span style="display: flex; align-items: center; gap: 4px;">
                 <span style="width: 8px; height: 8px; border-radius: 2px; background: ${mapColors.forest.fill};"></span>
-                <span style="color: ${palette.neutral[700]};">Tree</span>
+                <span style="color: ${palette.neutral[700]};">Tree cover [%]</span>
                 <span style="font-weight: 600;">${forestPct}%</span>
               </span>`);
           }
           if (showDeadwood) {
             layerParts.push(`<span style="display: flex; align-items: center; gap: 4px;">
                 <span style="width: 8px; height: 8px; border-radius: 2px; background: ${mapColors.deadwood.fill};"></span>
-                <span style="color: ${palette.neutral[700]};">Deadwood</span>
+                <span style="color: ${palette.neutral[700]};">Deadwood cover [%]</span>
                 <span style="font-weight: 600;">${deadwoodPct}%</span>
               </span>`);
           }
@@ -1380,7 +1380,7 @@ const DeadtreesMap = () => {
         </div>
 
         {/* Top Right - Layer Controls (desktop) */}
-        <div className="absolute right-4 top-24 z-50 hidden md:block">
+        <div className="fixed right-40 top-24 z-50 hidden md:block">
           <LayerControlPanel
             mapStyle={DeadwoodMapStyle}
             onMapStyleChange={handleMapStyleChange}

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -1380,7 +1380,7 @@ const DeadtreesMap = () => {
         </div>
 
         {/* Top Right - Layer Controls (desktop) */}
-        <div className="fixed right-40 top-24 z-50 hidden md:block">
+        <div className="absolute right-4 top-24 z-50 hidden md:block">
           <LayerControlPanel
             mapStyle={DeadwoodMapStyle}
             onMapStyleChange={handleMapStyleChange}

--- a/frontend/src/components/DeadwoodMap/DeadwoodCard.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadwoodCard.tsx
@@ -47,18 +47,18 @@ const DeadwoodCard = ({
     <div className="flex w-[300px] flex-col rounded-lg bg-white px-4 py-4 shadow-lg">
       {/* Header */}
       <div className="mb-4">
-        <h3 className="m-0 text-base font-semibold text-gray-700">Tree & Standing Deadwood Cover</h3>
+        <h3 className="m-0 text-base font-semibold text-gray-700">Tree and deadwood cover [%]</h3>
         <span className="text-[10px] text-gray-400">Fractional cover maps • Sentinel-2</span>
       </div>
 
       {/* Legend Section */}
       <div className="mb-1 flex flex-col gap-2">
         <LegendItem
-          label="Tree Cover"
+          label="Tree cover [%]"
           gradientClass="bg-gradient-to-r from-green-100/50 via-green-400/60 to-green-600/80"
         />
         <LegendItem
-          label="Deadwood Cover"
+          label="Deadwood cover [%]"
           gradientClass="bg-gradient-to-r from-red-100/50 via-red-400/60 to-red-500/80"
         />
       </div>
@@ -93,11 +93,11 @@ const DeadwoodCard = ({
         {/* Layer Toggles */}
         <div className="border-t border-gray-100" />
         <div className="flex items-center justify-between">
-          <span className="text-[11px] text-gray-500">Tree Cover</span>
+          <span className="text-[11px] text-gray-500">Tree cover [%]</span>
           <Switch size="small" checked={showForest} onChange={(checked) => setShowForest(checked)} />
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-[11px] text-gray-500">Deadwood Cover</span>
+          <span className="text-[11px] text-gray-500">Deadwood cover [%]</span>
           <Switch size="small" checked={showDeadwood} onChange={(checked) => setShowDeadwood(checked)} />
         </div>
 

--- a/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
+++ b/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
@@ -74,7 +74,7 @@ const LayerControlPanel = ({
 
   return (
     <div
-      className={`map-control-panel box-border min-w-0 pointer-events-auto flex flex-col overflow-x-hidden p-3 ${isDrawerSheet ? "map-control-panel--drawer w-full" : "w-52 overflow-hidden rounded-2xl border border-gray-200/60 bg-white/95 shadow-xl backdrop-blur-sm"}`}
+      className={`map-control-panel box-border min-w-0 pointer-events-auto flex flex-col overflow-x-hidden p-3 ${isDrawerSheet ? "map-control-panel--drawer w-full" : "w-60 max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-gray-200/60 bg-white/95 shadow-xl backdrop-blur-sm"}`}
     >
       {/* Basemap Selection */}
       <div className="mb-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500">Basemap</div>
@@ -94,14 +94,14 @@ const LayerControlPanel = ({
         <Checkbox checked={showForest} onChange={(e) => setShowForest(e.target.checked)}>
           <span className="flex items-center gap-2">
             <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.forest.fill }} />
-            <span className="text-xs text-gray-600">Tree</span>
+            <span className="text-xs text-gray-600">Tree cover [%]</span>
           </span>
         </Checkbox>
         <div className="flex items-center justify-between">
           <Checkbox checked={showDeadwood} onChange={(e) => setShowDeadwood(e.target.checked)}>
             <span className="flex items-center gap-2">
               <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.deadwood.fill }} />
-              <span className="text-xs text-gray-600">Standing Deadwood</span>
+              <span className="text-xs text-gray-600">Deadwood cover [%]</span>
             </span>
           </Checkbox>
           <Tooltip title={<div className="max-w-xs text-xs leading-relaxed">{standingDeadwoodLayerExplanation}</div>} placement="left">

--- a/frontend/src/components/DeadwoodMap/Legend.tsx
+++ b/frontend/src/components/DeadwoodMap/Legend.tsx
@@ -1,7 +1,7 @@
 const Legend = () => {
   return (
     <div className="flex min-w-fit flex-col items-end space-x-2 rounded-md bg-white p-4">
-      <p className="m-0 max-w-24 pb-2 text-center text-xs text-gray-500">Share of standing deadwood (%)</p>
+      <p className="m-0 max-w-24 pb-2 text-center text-xs text-gray-500">Deadwood cover [%]</p>
       <div className="flex h-32 space-x-2">
         <div className="flex flex-col items-end justify-between">
           <p className="m-0 text-xs text-gray-600">100% - </p>

--- a/frontend/src/components/DeadwoodMap/MapLegend.tsx
+++ b/frontend/src/components/DeadwoodMap/MapLegend.tsx
@@ -50,17 +50,17 @@ const MapLegend = ({ clickedValues, showForest, showDeadwood, embedded = false }
     >
       {/* Header */}
       <div className="mb-2">
-        <div className="text-sm font-medium text-gray-700">Fractional Cover</div>
+        <div className="text-sm font-medium text-gray-700">Fractional cover [%]</div>
         <div className="text-xs text-gray-400">Sentinel-2 based</div>
       </div>
 
-      {/* Tree - only show when active */}
+      {/* Tree cover - only show when active */}
       {showForest && (
         <div>
           <div className="mb-1 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <div className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.forest.fill }} />
-              <span className="text-xs text-gray-600">Tree</span>
+              <span className="text-xs text-gray-600">Tree cover [%]</span>
             </div>
             <span className="text-xs text-gray-400">0–100%</span>
           </div>
@@ -72,14 +72,14 @@ const MapLegend = ({ clickedValues, showForest, showDeadwood, embedded = false }
         </div>
       )}
 
-      {/* Standing Deadwood - only show when active */}
+      {/* Deadwood cover - only show when active */}
       {showDeadwood && showForest && <div className="mt-2" />}
       {showDeadwood && (
         <div>
           <div className="mb-1 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <div className="h-3 w-3 rounded-sm" style={{ backgroundColor: mapColors.deadwood.fill }} />
-              <span className="text-xs text-gray-600">Standing Deadwood</span>
+              <span className="text-xs text-gray-600">Deadwood cover [%]</span>
             </div>
             <span className="text-xs text-gray-400">0–100%</span>
           </div>
@@ -99,10 +99,10 @@ const MapLegend = ({ clickedValues, showForest, showDeadwood, embedded = false }
         </div>
 
         {clickedValues ? (
-          <div className="flex text-xs">
+          <div className="flex flex-col gap-1 text-xs">
             {showForest && (
               <div className="flex items-center gap-1">
-                <span className="text-gray-500">Tree:</span>
+                <span className="text-gray-500">Tree cover [%]:</span>
                 <span className="font-semibold" style={{ color: mapColors.forest.text }}>
                   {clickedValues.forestPct}%
                 </span>
@@ -110,7 +110,7 @@ const MapLegend = ({ clickedValues, showForest, showDeadwood, embedded = false }
             )}
             {showDeadwood && (
               <div className="flex items-center gap-1">
-                <span className="text-gray-500">Standing Deadwood:</span>
+                <span className="text-gray-500">Deadwood cover [%]:</span>
                 <span className="font-semibold" style={{ color: mapColors.deadwood.text }}>
                   {clickedValues.deadwoodPct}%
                 </span>

--- a/frontend/src/components/DeadwoodMap/PolygonStatsModal.tsx
+++ b/frontend/src/components/DeadwoodMap/PolygonStatsModal.tsx
@@ -82,7 +82,7 @@ const VIEW_DESCRIPTIONS: Record<
   (treeThreshold: number, deadwoodThreshold: number) => string
 > = {
   threshold: (tree, dead) =>
-    `Pixels above a cover threshold are counted as fully covered (tree cover >${tree}%, deadwood >${dead}%). Best for detecting clearings and mortality patches.`,
+    `Pixels above a cover threshold are counted as fully covered (tree cover >${tree}%, deadwood cover >${dead}%). Best for detecting clearings and mortality patches.`,
   continuous: () =>
     "Each pixel contributes proportionally to its cover value. Captures gradual canopy changes but is sensitive to prediction variability.",
 };
@@ -114,14 +114,14 @@ const PolygonStatsModal = ({
           items.push({
             year: String(s.year),
             value: treeHa,
-            category: "Tree Cover",
+            category: "Tree cover",
           });
         }
         if (deadHa !== null) {
           items.push({
             year: String(s.year),
             value: deadHa,
-            category: "Standing Deadwood",
+            category: "Deadwood cover",
           });
         }
         return items;
@@ -270,10 +270,10 @@ const PolygonStatsModal = ({
                 </span>
               )}
             </div>
-            {/* Tree Cover */}
+            {/* Tree cover */}
             <div>
               <div className="text-xs" style={{ color: palette.forest[600] }}>
-                Tree Cover
+                Tree cover
               </div>
               <div
                 className={isMobile ? "text-base font-semibold" : "text-lg font-semibold"}
@@ -283,10 +283,10 @@ const PolygonStatsModal = ({
               </div>
               {treeCoverChange && <ChangeIndicator change={treeCoverChange} />}
             </div>
-            {/* Standing Deadwood */}
+            {/* Deadwood cover */}
             <div>
               <div className="text-xs" style={{ color: palette.deadwood[500] }}>
-                Standing Deadwood
+                Deadwood cover
               </div>
               <div
                 className={isMobile ? "text-base font-semibold" : "text-lg font-semibold"}
@@ -303,7 +303,7 @@ const PolygonStatsModal = ({
             <Alert
               type="info"
               message="No coverage data available"
-              description="The drawn polygon does not overlap with any coverage data. Try drawing in an area where the tree cover / deadwood layers are visible on the map."
+              description="The drawn polygon does not overlap with any coverage data. Try drawing in an area where the tree cover / deadwood cover layers are visible on the map."
               showIcon
             />
           )}

--- a/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
+++ b/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
@@ -118,11 +118,11 @@ const YearImagerySelector = ({
   // Determine the active product name based on which layers are shown
   const activeProductName =
     showForest && showDeadwood
-      ? "Fractional Cover"
+      ? "Fractional cover [%]"
       : showForest
-        ? "Fractional Tree Cover"
+        ? "Tree cover [%]"
         : showDeadwood
-          ? "Fractional Standing Deadwood"
+          ? "Deadwood cover [%]"
           : "Predictions";
 
   // Items are already sorted by acquisition date (oldest first) from the hook

--- a/frontend/src/components/FilterModal.tsx
+++ b/frontend/src/components/FilterModal.tsx
@@ -94,7 +94,7 @@ const FilterModal: React.FC<FilterModalProps> = ({ isVisible, onClose, onApplyFi
         }}
       >
         <Form.Item className="mb-2" name="hasDeadwoodPrediction" valuePropName="checked">
-          <Checkbox>Has Deadwood Prediction</Checkbox>
+          <Checkbox>Has deadwood cover prediction</Checkbox>
         </Form.Item>
 
         {/* <Form.Item className="mb-2" name="hasLabels" valuePropName="checked">

--- a/frontend/src/components/Home/Features.tsx
+++ b/frontend/src/components/Home/Features.tsx
@@ -31,8 +31,7 @@ const Features = () => {
       <div className="pt-12 md:flex md:pt-24">
         <Feature
           title="Open access community effort"
-          description="Upload and download your aerial imagery with optional delineations of standing deadwood. 
-          Every contributor will be credited and invited to collaborate."
+          description="Upload and download your aerial imagery with optional deadwood cover annotations. Every contributor will be credited and invited to collaborate."
           iconPath="assets/open-access-icon.svg"
         />
         <Feature
@@ -50,7 +49,7 @@ const Features = () => {
         />
         <Feature
           title="Analysis ready training data"
-          description="High-resolution aerial imagery of forests worldwide together with delineated standing deadwood which can be used for training your own AI models."
+          description="High-resolution aerial imagery of forests worldwide together with deadwood cover annotations which can be used for training your own AI models."
           iconPath="assets/database-icon.svg"
           accent="amber"
         />

--- a/frontend/src/components/Home/GetInContact.tsx
+++ b/frontend/src/components/Home/GetInContact.tsx
@@ -173,7 +173,7 @@ const GetInContact = () => {
 							Contribute aerial imagery
 						</p>
 						<p className="m-0 mt-4 max-w-lg text-base leading-relaxed text-gray-500">
-							{`Upload high-resolution (<10cm) orthophotos and get automatic deadwood detection, proper attribution, and full database access. `}
+								{`Upload high-resolution (<10cm) orthophotos and get automatic deadwood cover detection, proper attribution, and full database access. `}
 							<em>Labels are optional</em> — our AI handles the rest.
 						</p>
 						<div className="mt-8 flex flex-wrap items-center gap-4">

--- a/frontend/src/components/Home/HowItWorks.tsx
+++ b/frontend/src/components/Home/HowItWorks.tsx
@@ -119,7 +119,7 @@ const HowItWorks = () => {
               AI Processing & Open Archive
             </h3>
             <p className="text-lg text-gray-600">
-              Our models automatically detect deadwood and forest cover in your uploaded imagery through semantic segmentation. The results are aggregated into an analysis-ready training database, freely accessible for researchers worldwide.
+              Our models automatically detect deadwood cover and tree cover in your uploaded imagery through semantic segmentation. The results are aggregated into an analysis-ready training database, freely accessible for researchers worldwide.
             </p>
           </div>
           <div className="-mx-4 md:mx-0 relative z-10">

--- a/frontend/src/components/Home/PlatformFeatures.tsx
+++ b/frontend/src/components/Home/PlatformFeatures.tsx
@@ -29,7 +29,7 @@ const PlatformFeatures = () => {
             </div>
             <h3 className="mb-3 text-2xl font-bold tracking-tight text-gray-900 md:text-3xl">Community labeling</h3>
             <p className="text-base leading-relaxed text-gray-600">
-              Review predictions, add missing polygons, and correct deadwood labels directly in the browser to improve training data quality.
+	              Review predictions, add missing polygons, and correct deadwood cover labels directly in the browser to improve training data quality.
             </p>
           </div>
           <div className="relative w-full px-8 pb-8 md:w-1/2 md:p-10 md:pl-0">

--- a/frontend/src/components/MLTiles/MLTileMap.tsx
+++ b/frontend/src/components/MLTiles/MLTileMap.tsx
@@ -638,12 +638,12 @@ export default function MLTileMap({
           )}
           {deadwood.data?.id && (
             <Checkbox checked={showDeadwood} onChange={(e) => setShowDeadwood(e.target.checked)}>
-              Deadwood <span className="text-xs text-gray-500">(K)</span>
+              Deadwood cover <span className="text-xs text-gray-500">(K)</span>
             </Checkbox>
           )}
           {forestCover.data?.id && (
             <Checkbox checked={showForestCover} onChange={(e) => setShowForestCover(e.target.checked)}>
-              Forest Cover <span className="text-xs text-gray-500">(L)</span>
+              Tree cover <span className="text-xs text-gray-500">(L)</span>
             </Checkbox>
           )}
         </Space>

--- a/frontend/src/components/MLTiles/validation/MLTileValidationPhase.tsx
+++ b/frontend/src/components/MLTiles/validation/MLTileValidationPhase.tsx
@@ -85,13 +85,13 @@ export default function MLTileValidationPhase({ dataset }: Props) {
       render: (value: number | null) => (value != null ? `${value}%` : "—"),
     },
     {
-      title: "Deadwood %",
+      title: "Deadwood cover [%]",
       dataIndex: "deadwood_prediction_coverage_percent",
       key: "deadwood",
       render: (value: number | null) => (value != null ? `${value}%` : "—"),
     },
     {
-      title: "Forest %",
+      title: "Tree cover [%]",
       dataIndex: "forest_cover_prediction_coverage_percent",
       key: "forest",
       render: (value: number | null) => (value != null ? `${value}%` : "—"),

--- a/frontend/src/components/PolygonEditor/EditorToolbar.tsx
+++ b/frontend/src/components/PolygonEditor/EditorToolbar.tsx
@@ -53,7 +53,7 @@ export default function EditorToolbar({
   title,
   className,
 }: Props) {
-  const displayTitle = title || `Editing ${type === "deadwood" ? "Deadwood" : "Forest Cover"}`;
+  const displayTitle = title || `Editing ${type === "deadwood" ? "deadwood cover" : "tree cover"}`;
 
   return (
     <div className={`absolute ${position === "top-right" ? "right-4" : "left-4"} ${className || "top-32"} z-20`}>

--- a/frontend/src/components/PolygonEditor/LayerRadioButtons.tsx
+++ b/frontend/src/components/PolygonEditor/LayerRadioButtons.tsx
@@ -24,7 +24,7 @@ export default function LayerRadioButtons({
 
   return (
     <div className={`absolute ${position === "bottom-left" ? "left-2" : "right-2"} bottom-2 z-10`}>
-      <Card size="small" className="shadow-lg" bodyStyle={{ padding: "12px", width: 180 }}>
+      <Card size="small" className="shadow-lg" bodyStyle={{ padding: "12px", width: 200 }}>
         <Radio.Group value={value} onChange={(e) => onChange(e.target.value)}>
           <Space direction="vertical" size="small" className="w-full">
             {showOrthoOnly && (
@@ -38,7 +38,7 @@ export default function LayerRadioButtons({
             {showDeadwood && (
               <Radio value="deadwood">
                 <span className="flex items-center justify-between">
-                  Deadwood
+                  Deadwood cover
                   <span className="ml-2 text-xs text-gray-400">(2)</span>
                 </span>
               </Radio>
@@ -46,7 +46,7 @@ export default function LayerRadioButtons({
             {showForestCover && (
               <Radio value="forest_cover">
                 <span className="flex items-center justify-between">
-                  Forest Cover
+                  Tree cover
                   <span className="ml-2 text-xs text-gray-400">(3)</span>
                 </span>
               </Radio>

--- a/frontend/src/components/ReferencePatches/BatchProgressIndicator.tsx
+++ b/frontend/src/components/ReferencePatches/BatchProgressIndicator.tsx
@@ -9,7 +9,7 @@ interface BatchProgressProps {
 }
 
 export default function BatchProgressIndicator({ layer, current, total, percentage }: BatchProgressProps) {
-  const layerLabel = layer === "deadwood" ? "Deadwood" : "Forest Cover";
+  const layerLabel = layer === "deadwood" ? "Deadwood cover" : "Tree cover";
 
   return (
     <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">

--- a/frontend/src/components/ReferencePatches/PatchDetailSidebar.tsx
+++ b/frontend/src/components/ReferencePatches/PatchDetailSidebar.tsx
@@ -511,7 +511,7 @@ export default function PatchDetailSidebar({
             {/* Layer-specific progress bars */}
             <div>
               <div className="mb-1 flex items-center justify-between">
-                <span className="text-xs text-gray-500">Deadwood Validation</span>
+                <span className="text-xs text-gray-500">Deadwood cover validation</span>
                 <span className="text-xs font-medium">
                   {basePatchProgress.deadwoodValidated} / {basePatchProgress.total5}
                 </span>
@@ -525,7 +525,7 @@ export default function PatchDetailSidebar({
             </div>
             <div>
               <div className="mb-1 flex items-center justify-between">
-                <span className="text-xs text-gray-500">Forest Cover Validation</span>
+                <span className="text-xs text-gray-500">Tree cover validation</span>
                 <span className="text-xs font-medium">
                   {basePatchProgress.forestCoverValidated} / {basePatchProgress.total5}
                 </span>
@@ -639,11 +639,11 @@ export default function PatchDetailSidebar({
               size="large"
               title={editButtonEnabled ? "Edit current layer (E)" : "Select a layer to edit"}
             >
-              Edit {currentLayer === "deadwood" ? "Deadwood" : "Forest Cover"} (E)
+              Edit {currentLayer === "deadwood" ? "deadwood cover" : "tree cover"} (E)
             </Button>
             {!editButtonEnabled && (
               <Typography.Text type="secondary" className="mt-2 block text-center text-xs">
-                Select a layer to edit (Deadwood or Forest Cover)
+                Select a layer to edit (deadwood cover or tree cover)
               </Typography.Text>
             )}
           </div>

--- a/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
@@ -382,7 +382,7 @@ export default function ReferencePatchEditorView({
       console.debug("Overlay layer z-index:", overlayLayer.getZIndex());
 
       message.info(
-        `Editing ${layerType === "deadwood" ? "Deadwood" : "Forest Cover"} - ${features.length} polygons loaded`,
+        `Editing ${layerType === "deadwood" ? "deadwood cover" : "tree cover"} - ${features.length} polygons loaded`,
       );
     } catch (error) {
       console.error("Failed to load geometries for editing:", error);
@@ -439,7 +439,7 @@ export default function ReferencePatchEditorView({
       editor.getOverlayLayer()?.getSource()?.clear();
       setEditingMode(null);
 
-      message.success(`${editingMode === "deadwood" ? "Deadwood" : "Forest Cover"} reference updated!`);
+      message.success(`${editingMode === "deadwood" ? "Deadwood cover" : "Tree cover"} reference updated!`);
       onUnsavedChanges(true);
     } catch (error) {
       console.error("Failed to save edits:", error);

--- a/frontend/src/components/ReferencePatches/validation/PatchValidationPhase.tsx
+++ b/frontend/src/components/ReferencePatches/validation/PatchValidationPhase.tsx
@@ -85,13 +85,13 @@ export default function PatchValidationPhase({ dataset }: Props) {
       render: (value: number | null) => (value != null ? `${value}%` : "—"),
     },
     {
-      title: "Deadwood %",
+      title: "Deadwood cover [%]",
       dataIndex: "deadwood_prediction_coverage_percent",
       key: "deadwood",
       render: (value: number | null) => (value != null ? `${value}%` : "—"),
     },
     {
-      title: "Forest %",
+      title: "Tree cover [%]",
       dataIndex: "forest_cover_prediction_coverage_percent",
       key: "forest",
       render: (value: number | null) => (value != null ? `${value}%` : "—"),

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -524,7 +524,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
                             <div className="text-start">
                               <p className="ant-upload-text mb-0">Click or drag labels file to this area</p>
                               <p className="ant-upload-hint mb-0 text-xs">
-                                Upload standing deadwood labels as GeoJSON, Shapefile (zip) or GeoPackage
+	                                Upload deadwood cover labels as GeoJSON, Shapefile (zip) or GeoPackage
                               </p>
                             </div>
                           </div>

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -62,8 +62,8 @@ const PROCESSING_STATE_OPTIONS: Array<{ label: string; value: ProcessingStateFil
 	{ label: "Ortho", value: "ortho" },
 	{ label: "COG", value: "cog" },
 	{ label: "Thumb", value: "thumbnail" },
-	{ label: "Deadwood", value: "deadwood" },
-	{ label: "Forest", value: "forestCover" },
+	{ label: "Deadwood cover", value: "deadwood" },
+	{ label: "Tree cover", value: "forestCover" },
 	{ label: "Metadata", value: "metadata" },
 ];
 

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -345,7 +345,7 @@ export default function DatasetDetails() {
             onSave={editing.handleSaveEdits}
             onCancel={editing.handleCancelEditing}
             position="top-right"
-            title={`Editing ${editingLayerType === "deadwood" ? "Deadwood" : "Forest Cover"}`}
+            title={`Editing ${editingLayerType === "deadwood" ? "deadwood cover" : "tree cover"}`}
           />
         )}
 

--- a/frontend/src/pages/DatasetLabelEditor.tsx
+++ b/frontend/src/pages/DatasetLabelEditor.tsx
@@ -410,8 +410,8 @@ export default function DatasetLabelEditor() {
             onChange={(e) => setActiveLayer(e.target.value as "deadwood" | "forest_cover")}
             size="small"
           >
-            <Radio.Button value="deadwood">Deadwood</Radio.Button>
-            <Radio.Button value="forest_cover">Forest cover</Radio.Button>
+            <Radio.Button value="deadwood">Deadwood cover</Radio.Button>
+            <Radio.Button value="forest_cover">Tree cover</Radio.Button>
           </Radio.Group>
         </div>
       </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -58,7 +58,7 @@ const FAQ = () => {
       children: (
         <div>
               <p className="text-md">
-                The data is processed to detect forest cover and tree mortality to train our machine learning models. By default,
+	                The data is processed to detect tree cover and deadwood cover to train our machine learning models. By default,
                 all uploaded data is made publicly available under the Creative Commons Attribution (CC BY) license, though
                 you can request private usage for model training only if needed.
               </p>
@@ -112,7 +112,7 @@ const FAQ = () => {
         <div>
           <p className="text-md">
             Individual datasets are available for immediate download, including both orthophotos and machine-generated
-            deadwood labels in GeoPackage format. However, our complete database currently exceeds several terabytes in
+	            deadwood cover labels in GeoPackage format. However, our complete database currently exceeds several terabytes in
             size, making bulk downloads challenging.
           </p>
           <p className="text-md mt-2">We're actively developing improved infrastructure to enable:</p>
@@ -147,7 +147,7 @@ const FAQ = () => {
             </li>
 
             <li>
-              <strong>Optional:</strong> Vector data (GeoJSON, Shapefile, GeoPackage) with deadwood labels or other
+	              <strong>Optional:</strong> Vector data (GeoJSON, Shapefile, GeoPackage) with deadwood cover labels or other
               reference data
             </li>
           </ul>

--- a/frontend/src/utils/fileValidation.ts
+++ b/frontend/src/utils/fileValidation.ts
@@ -125,7 +125,7 @@ export const validateGeoTiffAiEligibility = async (file: Blob): Promise<GeoTiffA
 
   if (!inspection.supportsAiSegmentation) {
     throw new Error(
-      `We cannot process this dataset yet. Deadwood and tree cover currently require an RGB orthomosaic, but this file looks like ${inspection.colorModel}.`,
+      `We cannot process this dataset yet. Deadwood cover and tree cover currently require an RGB orthomosaic, but this file looks like ${inspection.colorModel}.`,
     );
   }
 

--- a/frontend/src/utils/processingSteps.ts
+++ b/frontend/src/utils/processingSteps.ts
@@ -10,8 +10,8 @@ export const GEOTIFF_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "ortho", label: "Processing Image", description: "Processing and validating your orthophoto" },
   { key: "metadata", label: "Extracting Information", description: "Extracting geographic and technical metadata" },
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
-  { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
-  { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
+  { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood cover detection" },
+  { key: "treecover", label: "Tree cover analysis", description: "Running AI analysis for tree cover segmentation" },
 ];
 
 export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
@@ -21,14 +21,14 @@ export const RAW_IMAGES_PROCESSING_STEPS: ProcessingStep[] = [
   { key: "ortho", label: "Processing Image", description: "Processing and validating your orthophoto" },
   { key: "metadata", label: "Extracting Information", description: "Extracting geographic and technical metadata" },
   { key: "cog", label: "Optimizing Data", description: "Converting to optimized format for visualization" },
-  { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood detection" },
-  { key: "treecover", label: "Tree Cover Analysis", description: "Running AI analysis for tree cover segmentation" },
+  { key: "deadwood", label: "AI Analysis", description: "Running AI analysis for deadwood cover detection" },
+  { key: "treecover", label: "Tree cover analysis", description: "Running AI analysis for tree cover segmentation" },
 ];
 
 const COMBINED_MODEL_STEP: ProcessingStep = {
   key: "combined_model",
   label: "Combined AI Analysis",
-  description: "Running combined deadwood and tree cover model",
+  description: "Running combined deadwood cover and tree cover model",
 };
 
 const COMBINED_MODEL_STATUS = "deadwood_treecover_combined_segmentation";


### PR DESCRIPTION
## Release context
Clarifies prediction-layer language for people reading the map, dataset detail vector layers, audit/editor tools, and upload/help copy. Percentage raster layers now say `Tree cover [%]` and `Deadwood cover [%]`; vector and editing surfaces use `Tree cover` and `Deadwood cover` without units. This is for data contributors, auditors, and researchers interpreting tree and deadwood predictions.

## What changed
- Standardized visible frontend labels across dataset details, audit/editor tools, ML tile controls, correction/review UIs, upload/help text, and public copy.
- Kept internal DB/model identifiers unchanged.
- Adjusted the global satellite map controls and legend so the longer labels do not clip.

## Validation
- `npm run build`
- `git diff --check`
- Browser Use check on `http://127.0.0.1:5173/deadtrees` verified the map control panel and legend render without clipping after the layout fix.

Note: Browser checks of `/dataset` and `/dataset/9821` were attempted, but the local/prod-profile app stayed in the data-loading state in this environment, so rendered dataset-detail verification was limited to build/static checks.
