### PR TITLE
ci(deps): add dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  # Frontend app dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-patch:
+        update-types: ["patch"]
+      npm-minor:
+        update-types: ["minor"]
+    ignore:
+      # React 19 and the Vite 8 toolchain need coordinated migrations.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+
+      # Tooling majors should be reviewed as explicit maintenance work.
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/parser"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-all:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- add a repo Dependabot policy for frontend npm and GitHub Actions updates
- group patch and minor frontend updates to reduce queue noise
- hold React, Vite/plugin-react, and major tooling jumps for planned maintenance PRs

## Why
The repo had open Dependabot security PRs but no checked-in .github/dependabot.yml, so Vite 8 was proposed as a standalone red PR.

## Validation
- parsed .github/dependabot.yml with Ruby YAML
- live Dependabot queue checked before opening

## Risk
Low. Security patch/minor updates remain enabled; incompatible majors are deferred intentionally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Dependabot configuration only, affecting how dependency update PRs are created rather than runtime behavior; the main risk is deferred major upgrades (React/Vite/tooling) requiring separate planned work.
> 
> **Overview**
> Adds a new `.github/dependabot.yml` configuring weekly Dependabot updates for the `frontend` npm workspace and for GitHub Actions.
> 
> Frontend updates are grouped by **patch** and **minor** versions with a PR limit, while **major** upgrades for React, Vite/plugin-react, and key tooling (Vitest, ESLint, TypeScript, `@typescript-eslint/*`) are explicitly ignored to force manual, coordinated migrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1dcdd507403774a7459d08ae835fce491d0a120. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->