### PR TITLE
ci(deps): expand blocked major update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,20 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "antd"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@ant-design/icons"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@geoapify/geocoder-autocomplete"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "unzipit"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
 
       # Tooling majors should be reviewed as explicit maintenance work.
       - dependency-name: "vitest"


### PR DESCRIPTION
## Summary
- add major-version ignores for Ant Design, Geoapify autocomplete, unzipit, and related UI packages
- keep those migration-class updates out of the routine Dependabot queue

## Why
The new Dependabot policy immediately surfaced major UI/library jumps. Several are failing or dirty and should be planned as migrations rather than merged with security patch work.

## Validation
- parsed .github/dependabot.yml with Ruby YAML
- verified the corresponding major PRs appeared in the live queue

## Risk
Low. Patch and minor updates remain enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts Dependabot ignore rules and doesn’t affect runtime code; the main impact is delaying major-version upgrade PRs for the listed packages.
> 
> **Overview**
> Updates `.github/dependabot.yml` to **block Dependabot semver-major PRs** for additional frontend libraries: `antd`, `@ant-design/icons`, `@geoapify/geocoder-autocomplete`, and `unzipit`.
> 
> Patch/minor grouping and existing major ignores remain unchanged; the routine Dependabot queue will now exclude these major upgrade proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e306656d57910d65c59405ca18cf5ee4280b50. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->