### PR TITLE
ci(deps): hold react refresh eslint peer update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-react-refresh"
+        update-types: ["version-update:semver-minor"]
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- add a Dependabot hold for eslint-plugin-react-refresh semver-minor updates

## Why
The generated npm-minor group failed at npm ci because eslint-plugin-react-refresh 0.5.x requires ESLint 9 or 10, while deadtrees is still on ESLint 8. This should wait for a coordinated ESLint/tooling migration.

## Validation
- parsed .github/dependabot.yml with Ruby YAML
- inspected the failed #296 frontend-ci log

## Risk
Low. Patch updates remain allowed; the incompatible minor line is deferred intentionally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only adjusts Dependabot’s update policy to avoid pulling an incompatible `eslint-plugin-react-refresh` minor release; no runtime code is affected.
> 
> **Overview**
> Prevents Dependabot’s `npm-minor` group from proposing `eslint-plugin-react-refresh` *semver-minor* updates by adding it to `.github/dependabot.yml` `ignore`, avoiding CI breakage until the ESLint/tooling upgrade is coordinated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2cd2f2c20273515ec1df6ccc37e9ff0cfaac86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->