### PR TITLE
fix(frontend): override vulnerable object-path dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8226,11 +8226,12 @@
       }
     },
     "node_modules/object-path": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
-      "integrity": "sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">= 10.12.0"
       }
     },
     "node_modules/ol": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,5 +71,8 @@
     "typescript": "^5.7.3",
     "vite": "^5.4.21",
     "vitest": "^3.1.2"
+  },
+  "overrides": {
+    "object-path": "0.11.8"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm override so the frontend resolves transitive object-path to 0.11.8
- refresh the frontend lockfile for the overridden dependency

## Why
Dependabot security updates cannot resolve object-path because sort-by@1.2.0 pins object-path@0.6.0. This keeps the existing direct dependency graph while moving the vulnerable transitive package to the fixed version.

## Validation
- npm ci
- npm test
- npm run build
- npm audit --json no longer reports object-path; unrelated existing advisories remain

## Risk
Low. sort-by keeps the same direct version, but its object-path implementation is overridden to a newer compatible release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/lockfile-only change; main risk is unexpected runtime incompatibility if any transitive consumer relied on `object-path@0.6.0` behavior or Node version constraints.
> 
> **Overview**
> Updates the frontend dependency resolution to **override transitive `object-path` to `0.11.8`** (via `package.json` `overrides`) to address a vulnerability.
> 
> Refreshes `package-lock.json` so `object-path` is locked to `0.11.8` (including updated metadata such as engine requirements), without changing the direct dependency list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97b58594ea8a38fd1127f2c4f429ee3f28b7274. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->