### PR TITLE
ci(deps): hold additional frontend majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "geotiff"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "match-sorter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-player"
+        update-types: ["version-update:semver-major"]
 
       # Tooling majors should be reviewed as explicit maintenance work.
       - dependency-name: "vitest"
@@ -50,6 +56,8 @@ updates:
       - dependency-name: "@typescript-eslint/parser"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-react-hooks"
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-react-refresh"
         update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
## Summary
- add semver-major Dependabot ignores for geotiff, match-sorter, react-player, and eslint-plugin-react-hooks

## Why
A fresh Dependabot wave opened these as routine updates after the queue cleanup. One already failed frontend-ci, and the rest are major frontend/runtime or tooling migrations that should be planned and smoke-tested separately.

## Validation
- ruby YAML parse for .github/dependabot.yml

## Risk
Low. This only changes Dependabot scheduling policy; it does not change runtime dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes Dependabot ignore rules and does not affect application runtime or build output. The only impact is on automated dependency PR generation cadence.
> 
> **Overview**
> Dependabot’s `/frontend` npm policy is updated to **ignore additional semver-major bumps** for `geotiff`, `match-sorter`, and `react-player`, preventing routine major-upgrade PRs.
> 
> It also adds a semver-major ignore for the tooling package `eslint-plugin-react-hooks`, keeping major lint/toolchain migrations as explicitly planned work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7681e81a3ca16e8fc1083d51640da842c75de22d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->