### PR TITLE
fix(processing): version combined model labels

### DIFF
--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -512,6 +512,8 @@ def filter_exportable_dataset_labels(
 	"""Keep only exportable label sources, and for model predictions only the preferred model version."""
 	result = []
 	for label in labels:
+		if not label.is_active:
+			continue
 		if label.label_source not in EXPORTABLE_LABEL_SOURCES:
 			continue
 		if label.label_source == LabelSourceEnum.model_prediction:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -251,7 +251,8 @@ Dead Trees worktrees bootstrap themselves automatically.
 
 The setup script auto-detects the primary checkout from `git worktree list`,
 so a Codex-created worktree will reuse the main checkout for shared `assets`,
-`data`, and `.local/ssh` without hardcoding a machine-specific path.
+`data`, `.local/ssh`, local `.codex` project config, and ignored local
+`docs/ops` playbooks without hardcoding a machine-specific path.
 
 ## Project structure
 

--- a/frontend/src/components/DatasetDetailsMap/fetchLabels.ts
+++ b/frontend/src/components/DatasetDetailsMap/fetchLabels.ts
@@ -4,7 +4,11 @@ import { supabase } from "../../hooks/useSupabase";
 
 const fetchLabels = async ({ dataset_id }: { dataset_id: number }): Promise<ILabels | null> => {
   console.debug("dataset_id", dataset_id);
-  const { data, error } = await supabase.from(Settings.LABELS_TABLE).select("*").eq("dataset_id", dataset_id);
+  const { data, error } = await supabase
+    .from(Settings.LABELS_TABLE)
+    .select("*")
+    .eq("dataset_id", dataset_id)
+    .eq("is_active", true);
 
   if (error) {
     // console.error("Error fetching data:", error);

--- a/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { IDataset } from "../../types/dataset";
 import { IReferencePatch, PatchResolution } from "../../types/referencePatches";
-import { ILabelData } from "../../types/labels";
+import { ILabel, ILabelData, ILabelSource } from "../../types/labels";
 import {
   useReferencePatches,
   useCreateReferencePatch,
@@ -28,6 +28,7 @@ import { LayerRadioButtons, EditorToolbar, type LayerSelection } from "../Polygo
 import { findBasePatchForPatch, getPreferredDefaultPatch } from "./utils/patchSelection";
 import { MAP_FLOATING_CHILD_TOP_CLASS, MAP_REFERENCE_SIDEBAR_WIDTH_CLASS } from "../../theme/mapLayout";
 import { useReferenceEditorKeyboardShortcuts } from "./hooks/useReferenceEditorKeyboardShortcuts";
+import { selectPreferredModelLabel } from "../../utils/modelPreferences";
 
 interface Props {
   dataset: IDataset;
@@ -517,22 +518,23 @@ export default function ReferencePatchEditorView({
       try {
         console.debug("[Auto-copy] Starting batch processing for patch:", basePatch.id);
 
-        // Fetch model prediction labels for deadwood and forest_cover
-        const { data: deadwoodLabel } = await supabase
-          .from("v2_labels")
-          .select("id")
-          .eq("dataset_id", dataset.id)
-          .eq("label_data", ILabelData.DEADWOOD)
-          .eq("label_source", "model_prediction")
-          .maybeSingle();
+        const fetchPreferredPredictionLabel = async (labelData: ILabelData) => {
+          const { data, error } = await supabase
+            .from("v2_labels")
+            .select("id,label_source,label_data,model_config,is_active")
+            .eq("dataset_id", dataset.id)
+            .eq("label_data", labelData)
+            .eq("label_source", ILabelSource.MODEL_PREDICTION)
+            .eq("is_active", true);
 
-        const { data: forestCoverLabel } = await supabase
-          .from("v2_labels")
-          .select("id")
-          .eq("dataset_id", dataset.id)
-          .eq("label_data", ILabelData.FOREST_COVER)
-          .eq("label_source", "model_prediction")
-          .maybeSingle();
+          if (error) throw error;
+
+          const preferredLabel = selectPreferredModelLabel((data ?? []) as ILabel[], labelData);
+          return preferredLabel ? { id: preferredLabel.id } : null;
+        };
+
+        const deadwoodLabel = await fetchPreferredPredictionLabel(ILabelData.DEADWOOD);
+        const forestCoverLabel = await fetchPreferredPredictionLabel(ILabelData.FOREST_COVER);
 
         const bbox = {
           minx: basePatch.bbox_minx,

--- a/frontend/src/hooks/useDatasetLabels.ts
+++ b/frontend/src/hooks/useDatasetLabels.ts
@@ -60,7 +60,8 @@ export function useDatasetLabels({
       const query = supabase
         .from(Settings.LABELS_TABLE)
         .select("*")
-        .eq("dataset_id", datasetId);
+        .eq("dataset_id", datasetId)
+        .eq("is_active", true);
 
       if (labelType) {
         query.eq("label_data", labelType);

--- a/frontend/src/hooks/useModelVariantLabels.ts
+++ b/frontend/src/hooks/useModelVariantLabels.ts
@@ -14,6 +14,7 @@ export function useModelVariantLabels(datasetId: number | undefined, labelData: 
         .eq("dataset_id", datasetId)
         .eq("label_data", labelData)
         .eq("label_source", ILabelSource.MODEL_PREDICTION)
+        .eq("is_active", true)
         .order("created_at", { ascending: false });
       if (error) throw error;
       return (data ?? []) as ILabel[];

--- a/frontend/src/hooks/useSaveCorrections.ts
+++ b/frontend/src/hooks/useSaveCorrections.ts
@@ -7,6 +7,8 @@ import type Feature from "ol/Feature";
 import type { Geometry } from "ol/geom";
 import MultiPolygon from "ol/geom/MultiPolygon";
 import GeoJSON from "ol/format/GeoJSON";
+import { ILabel, ILabelData, ILabelSource } from "../types/labels";
+import { selectPreferredModelLabel } from "../utils/modelPreferences";
 
 export type LayerType = "deadwood" | "forest_cover";
 
@@ -52,15 +54,18 @@ export function usePredictionLabel(datasetId: number | undefined, layerType: Lay
 
       const { data, error } = await supabase
         .from("v2_labels")
-        .select("id")
+        .select("id,label_source,label_data,model_config,is_active")
         .eq("dataset_id", datasetId)
         .eq("label_data", layerType)
-        .eq("label_source", "model_prediction")
-        .eq("is_active", true)
-        .maybeSingle();
+        .eq("label_source", ILabelSource.MODEL_PREDICTION)
+        .eq("is_active", true);
 
       if (error) throw error;
-      return data;
+      const preferredLabel = selectPreferredModelLabel(
+        (data ?? []) as ILabel[],
+        layerType as ILabelData
+      );
+      return preferredLabel ? { id: preferredLabel.id } : null;
     },
     enabled: !!datasetId && !!layerType,
   });

--- a/frontend/src/utils/modelPreferences.test.ts
+++ b/frontend/src/utils/modelPreferences.test.ts
@@ -60,4 +60,22 @@ describe("model preference label selection", () => {
         ?.id,
     ).toBe(20762);
   });
+
+  it("ignores inactive model label versions", () => {
+    const inactiveCombined = modelLabel(
+      20764,
+      "deadwood_treecover_combined_v2",
+    );
+    inactiveCombined.is_active = false;
+
+    const activeLegacy = modelLabel(20762, "treecover_segmentation_oam_tcd");
+
+    expect(
+      selectPreferredModelLabel(
+        [inactiveCombined, activeLegacy],
+        ILabelData.FOREST_COVER,
+        new Map(),
+      )?.id,
+    ).toBe(20762);
+  });
 });

--- a/frontend/src/utils/modelPreferences.ts
+++ b/frontend/src/utils/modelPreferences.ts
@@ -23,18 +23,19 @@ function configMatches(
 }
 
 export function selectPreferredModelLabel<
-  T extends Pick<ILabel, "label_source" | "model_config">,
+  T extends Pick<ILabel, "label_source" | "model_config" | "is_active">,
 >(
   labels: T[],
   labelType: ILabelData,
   preferences?: ReadonlyMap<string, ModelConfig>,
 ): T | null {
-  if (labels.length === 0) return null;
-  if (labels.length === 1) return labels[0];
+  const activeLabels = labels.filter((label) => label.is_active !== false);
+  if (activeLabels.length === 0) return null;
+  if (activeLabels.length === 1) return activeLabels[0];
 
   const preferredConfig =
     preferences?.get(labelType) ?? DEFAULT_MODEL_PREFERENCES[labelType];
-  const preferred = labels.find(
+  const preferred = activeLabels.find(
     (label) =>
       label.label_source === ILabelSource.MODEL_PREDICTION &&
       configMatches(label.model_config, preferredConfig),
@@ -43,8 +44,8 @@ export function selectPreferredModelLabel<
   if (preferred) return preferred;
 
   return (
-    labels.find(
+    activeLabels.find(
       (label) => label.label_source === ILabelSource.MODEL_PREDICTION,
-    ) ?? labels[0]
+    ) ?? activeLabels[0]
   );
 }

--- a/processor/src/deadwood_treecover_combined_v2/predict_combined.py
+++ b/processor/src/deadwood_treecover_combined_v2/predict_combined.py
@@ -5,10 +5,9 @@ import rasterio
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
 from shared.models import COMBINED_MODEL_CHECKPOINT_NAME, COMBINED_MODEL_CONFIG, COMBINED_MODEL_MODULE, LabelDataEnum
-from shared.labels import delete_model_prediction_labels
 
 from ..exceptions import ProcessingError
-from ..utils.prediction_labels import replace_model_prediction_label
+from ..utils.prediction_labels import create_versioned_model_prediction_label
 from ..utils.segmentation import polygons_to_multipolygon_geojson, reproject_polygons
 from ..utils.geometry_validation import validate_and_fix_polygons
 from .inference import CombinedInference
@@ -74,12 +73,6 @@ def _save_label(polygons, label_data, src_crs, dataset_id, user_id, token, model
 
     if len(polygons) == 0:
         logger.warning(f'No {label_type} polygons detected', log_ctx)
-        delete_model_prediction_labels(
-            dataset_id=dataset_id,
-            label_data=label_data,
-            token=token,
-            model_config=model_config,
-        )
         return
 
     polygons = reproject_polygons(polygons, src_crs, 'EPSG:4326')
@@ -87,16 +80,10 @@ def _save_label(polygons, label_data, src_crs, dataset_id, user_id, token, model
 
     if len(polygons) == 0:
         logger.warning(f'No valid {label_type} polygons after geometry validation', log_ctx)
-        delete_model_prediction_labels(
-            dataset_id=dataset_id,
-            label_data=label_data,
-            token=token,
-            model_config=model_config,
-        )
         return
 
     geojson = polygons_to_multipolygon_geojson(polygons)
-    label = replace_model_prediction_label(
+    label = create_versioned_model_prediction_label(
         dataset_id=dataset_id,
         user_id=user_id,
         label_data=label_data,

--- a/processor/src/utils/prediction_labels.py
+++ b/processor/src/utils/prediction_labels.py
@@ -1,4 +1,6 @@
-from shared.db import login
+from typing import Any
+
+from shared.db import login, use_client
 from shared.labels import create_label_with_geometries, delete_model_prediction_labels
 from shared.logging import LogCategory, LogContext
 from shared.logger import logger
@@ -36,3 +38,74 @@ def replace_model_prediction_label(
 		geometry=geometry,
 	)
 	return create_label_with_geometries(payload, user_id, token)
+
+
+def create_versioned_model_prediction_label(
+	dataset_id: int,
+	user_id: str,
+	label_data: LabelDataEnum,
+	geometry: dict,
+	token: str,
+	model_config: dict[str, Any],
+):
+	"""Create a new model-prediction label and deactivate older labels for the same model.
+
+	This preserves legacy/other-model prediction labels and avoids deleting labels that
+	may be referenced by geometry corrections.
+	"""
+	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
+
+	with use_client(token) as client:
+		response = (
+			client.table(settings.labels_table)
+			.select('id,model_config,is_active,version')
+			.eq('dataset_id', dataset_id)
+			.eq('label_source', LabelSourceEnum.model_prediction.value)
+			.eq('label_data', label_data.value)
+			.execute()
+		)
+
+	existing_matching = [
+		label for label in (response.data or []) if _model_config_matches(label.get('model_config'), model_config)
+	]
+	active_matching = [label for label in existing_matching if label.get('is_active', True)]
+	previous_active = max(active_matching, key=lambda label: label.get('version') or 1, default=None)
+	next_version = max((label.get('version') or 1 for label in existing_matching), default=0) + 1
+
+	payload = LabelPayloadData(
+		dataset_id=dataset_id,
+		label_source=LabelSourceEnum.model_prediction,
+		label_type=LabelTypeEnum.semantic_segmentation,
+		label_data=label_data,
+		label_quality=3,
+		model_metadata=model_config,
+		geometry=geometry,
+	)
+	label = create_label_with_geometries(payload, user_id, token)
+
+	previous_ids = [existing['id'] for existing in existing_matching if existing['id'] != label.id]
+	with use_client(token) as client:
+		client.table(settings.labels_table).update(
+			{
+				'is_active': True,
+				'version': next_version,
+				'parent_label_id': previous_active['id'] if previous_active else None,
+			}
+		).eq('id', label.id).execute()
+
+		if previous_ids:
+			client.table(settings.labels_table).update({'is_active': False}).in_('id', previous_ids).execute()
+
+	if previous_ids:
+		logger.info(
+			f'Deactivated {len(previous_ids)} older prediction labels',
+			LogContext(category=LogCategory.DEADWOOD, dataset_id=dataset_id, user_id=user_id, token=token),
+		)
+
+	return label
+
+
+def _model_config_matches(label_config: dict[str, Any] | None, model_config: dict[str, Any]) -> bool:
+	if not label_config:
+		return False
+	return all(label_config.get(key) == value for key, value in model_config.items())

--- a/processor/tests/test_prediction_labels.py
+++ b/processor/tests/test_prediction_labels.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+
+from shared.models import Label, LabelDataEnum, LabelSourceEnum, LabelTypeEnum
+from processor.src.utils import prediction_labels
+
+
+class FakeLabelsQuery:
+	def __init__(self, client, table_name):
+		self.client = client
+		self.table_name = table_name
+		self.update_payload = None
+		self.eq_filters = []
+		self.in_filter = None
+
+	def select(self, *_args):
+		return self
+
+	def eq(self, column, value):
+		self.eq_filters.append((column, value))
+		return self
+
+	def update(self, payload):
+		self.update_payload = payload
+		return self
+
+	def in_(self, column, values):
+		self.in_filter = (column, values)
+		return self
+
+	def execute(self):
+		if self.update_payload is not None:
+			self.client.updates.append(
+				{
+					'table': self.table_name,
+					'payload': self.update_payload,
+					'eq_filters': self.eq_filters,
+					'in_filter': self.in_filter,
+				}
+			)
+			return SimpleNamespace(data=[])
+
+		return SimpleNamespace(data=self.client.existing_labels)
+
+
+class FakeLabelsClient:
+	def __init__(self, existing_labels):
+		self.existing_labels = existing_labels
+		self.updates = []
+
+	def table(self, table_name):
+		return FakeLabelsQuery(self, table_name)
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, *_args):
+		return False
+
+
+def test_create_versioned_model_prediction_label_deactivates_only_matching_model_config(monkeypatch):
+	model_config = {
+		'module': 'deadwood_treecover_combined_v2',
+		'checkpoint_name': 'combined.safetensors',
+	}
+	legacy_config = {
+		'module': 'treecover_segmentation_oam_tcd',
+		'checkpoint_name': 'legacy.safetensors',
+	}
+	fake_client = FakeLabelsClient(
+		[
+			{'id': 10, 'model_config': model_config, 'is_active': True, 'version': 1},
+			{'id': 11, 'model_config': None, 'is_active': True, 'version': 1},
+			{'id': 12, 'model_config': legacy_config, 'is_active': True, 'version': 1},
+			{'id': 13, 'model_config': model_config, 'is_active': False, 'version': 2},
+		]
+	)
+
+	monkeypatch.setattr(prediction_labels, 'login', lambda *_args: 'processor-token')
+	monkeypatch.setattr(prediction_labels, 'use_client', lambda *_args, **_kwargs: fake_client)
+	monkeypatch.setattr(prediction_labels.logger, 'info', lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(
+		prediction_labels,
+		'create_label_with_geometries',
+		lambda *_args, **_kwargs: Label(
+			id=99,
+			dataset_id=123,
+			user_id='processor-user',
+			label_source=LabelSourceEnum.model_prediction,
+			label_type=LabelTypeEnum.semantic_segmentation,
+			label_data=LabelDataEnum.forest_cover,
+			label_quality=3,
+			model_metadata=model_config,
+		),
+	)
+
+	label = prediction_labels.create_versioned_model_prediction_label(
+		dataset_id=123,
+		user_id='processor-user',
+		label_data=LabelDataEnum.forest_cover,
+		geometry={'type': 'MultiPolygon', 'coordinates': []},
+		token='old-token',
+		model_config=model_config,
+	)
+
+	assert label.id == 99
+	assert fake_client.updates[0]['payload'] == {
+		'is_active': True,
+		'version': 3,
+		'parent_label_id': 10,
+	}
+	assert fake_client.updates[0]['eq_filters'] == [('id', 99)]
+	assert fake_client.updates[1]['payload'] == {'is_active': False}
+	assert fake_client.updates[1]['in_filter'] == ('id', [10, 13])

--- a/processor/tests/test_process_deadwood_treecover_combined_v2.py
+++ b/processor/tests/test_process_deadwood_treecover_combined_v2.py
@@ -127,8 +127,8 @@ def test_process_combined_segmentation_success(combined_task, auth_token):
 
 
 @pytest.mark.comprehensive
-def test_process_combined_replaces_existing_labels(combined_task, auth_token):
-	"""Re-running the combined model replaces previous prediction labels for both layer types."""
+def test_process_combined_versions_existing_combined_labels_without_deleting_legacy_labels(combined_task, auth_token):
+	"""Re-running the combined model preserves labels and only deactivates older combined versions."""
 	from shared.models import LabelPayloadData
 	from shared.labels import create_label_with_geometries
 	from shapely.geometry import Polygon
@@ -139,9 +139,10 @@ def test_process_combined_replaces_existing_labels(combined_task, auth_token):
 	}
 	model_config = {'module': 'deadwood_treecover_combined_v2', 'checkpoint_name': Path(MODEL_PATH).name}
 
-	existing_ids = []
+	existing_combined_ids = {}
+	legacy_ids = {}
 	for label_data in (LabelDataEnum.deadwood, LabelDataEnum.forest_cover):
-		payload = LabelPayloadData(
+		combined_payload = LabelPayloadData(
 			dataset_id=combined_task.dataset_id,
 			label_source=LabelSourceEnum.model_prediction,
 			label_type=LabelTypeEnum.semantic_segmentation,
@@ -150,16 +151,54 @@ def test_process_combined_replaces_existing_labels(combined_task, auth_token):
 			model_metadata=model_config,
 			geometry=test_geojson,
 		)
-		label = create_label_with_geometries(payload, combined_task.user_id, auth_token)
-		existing_ids.append(label.id)
+		combined_label = create_label_with_geometries(combined_payload, combined_task.user_id, auth_token)
+		existing_combined_ids[label_data.value] = combined_label.id
+
+		legacy_payload = LabelPayloadData(
+			dataset_id=combined_task.dataset_id,
+			label_source=LabelSourceEnum.model_prediction,
+			label_type=LabelTypeEnum.semantic_segmentation,
+			label_data=label_data,
+			label_quality=3,
+			model_metadata=None,
+			geometry=test_geojson,
+		)
+		legacy_label = create_label_with_geometries(legacy_payload, combined_task.user_id, auth_token)
+		legacy_ids[label_data.value] = legacy_label.id
 
 	process_deadwood_treecover_combined_v2(combined_task, auth_token, settings.processing_path)
 
 	with use_client(auth_token) as client:
 		response = (
-			client.table(settings.labels_table).select('id').eq('dataset_id', combined_task.dataset_id).execute()
+			client.table(settings.labels_table)
+			.select('id,label_data,model_config,is_active,version,parent_label_id')
+			.eq('dataset_id', combined_task.dataset_id)
+			.execute()
 		)
-	new_ids = {r['id'] for r in response.data}
 
-	# None of the original labels should survive
-	assert not new_ids & set(existing_ids)
+	labels_by_id = {label['id']: label for label in response.data}
+
+	for label_id in legacy_ids.values():
+		assert label_id in labels_by_id
+		assert labels_by_id[label_id]['is_active'] is True
+
+	for label_data, old_id in existing_combined_ids.items():
+		assert old_id in labels_by_id
+
+		new_combined_labels = [
+			label
+			for label in response.data
+			if label['label_data'] == label_data
+			and label['id'] != old_id
+			and (label.get('model_config') or {}).get('module') == 'deadwood_treecover_combined_v2'
+		]
+		if not new_combined_labels:
+			# Empty predictions leave the previous combined label untouched.
+			assert labels_by_id[old_id]['is_active'] is True
+			continue
+
+		assert labels_by_id[old_id]['is_active'] is False
+		for label in new_combined_labels:
+			assert label['is_active'] is True
+			assert label['version'] == 2
+			assert label['parent_label_id'] == old_id

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -129,6 +129,38 @@ ensure_file_from_shared() {
   log "Copied local file from shared root: $relative_path"
 }
 
+ensure_directory_from_shared() {
+  local relative_path="$1"
+  local target="$REPO_ROOT/$relative_path"
+  local source="$SHARED_ROOT/$relative_path"
+  local copied=false
+
+  if [[ "$SHARED_ROOT" == "$REPO_ROOT" || ! -d "$source" ]]; then
+    log "Shared local directory missing, skipping copy: $relative_path"
+    return
+  fi
+
+  while IFS= read -r -d '' relative_dir; do
+    mkdir -p "$target/$relative_dir"
+  done < <(cd "$source" && find . -type d -print0)
+
+  while IFS= read -r -d '' relative_file; do
+    if [[ -e "$target/$relative_file" ]]; then
+      continue
+    fi
+
+    mkdir -p "$(dirname "$target/$relative_file")"
+    cp "$source/$relative_file" "$target/$relative_file"
+    copied=true
+  done < <(cd "$source" && find . -type f -print0)
+
+  if [[ "$copied" == true ]]; then
+    log "Copied local directory from shared root: $relative_path"
+  else
+    log "Local directory already present: $relative_path"
+  fi
+}
+
 ensure_frontend_env_profiles() {
   ensure_file_from_shared "frontend/.env.dev.local"
   ensure_file_from_shared "frontend/.env.prod.local"
@@ -138,6 +170,12 @@ ensure_frontend_env_profiles() {
   fi
 
   ensure_file_from_example "$REPO_ROOT/frontend/.env.local" "$REPO_ROOT/frontend/.env.local.example"
+}
+
+ensure_codex_local_config() {
+  ensure_file_from_shared ".codex/config.toml"
+  ensure_file_from_shared ".codex/local-access.md"
+  ensure_directory_from_shared ".codex/environments"
 }
 
 ensure_env_line() {
@@ -266,6 +304,8 @@ git -C "$REPO_ROOT" submodule update --init --recursive
 
 ensure_file_from_example "$REPO_ROOT/.env" "$REPO_ROOT/.env.example"
 ensure_frontend_env_profiles
+ensure_codex_local_config
+ensure_directory_from_shared "docs/ops"
 ensure_env_line "$REPO_ROOT/.env" "COMPOSE_PROJECT_NAME" "$DEFAULT_COMPOSE_PROJECT_NAME"
 
 if [[ "$LINK_SHARED" == true ]]; then
@@ -293,6 +333,8 @@ Worktree setup complete.
 What this prepared:
   - repo env files
   - frontend local/prod env profiles where available
+  - local Codex config where available (.codex)
+  - local ops docs where available (docs/ops)
   - stable Docker compose project name (${DEFAULT_COMPOSE_PROJECT_NAME})
   - git submodules
   - per-worktree Python CLI environment

--- a/shared/models.py
+++ b/shared/models.py
@@ -516,6 +516,10 @@ class Label(BaseModel):
 		validation_alias=AliasChoices('model_config', 'model_metadata'),
 		serialization_alias='model_config',
 	)
+	is_active: bool = True
+	parent_label_id: Optional[int] = None
+	reference_patch_id: Optional[int] = None
+	version: int = 1
 	created_at: Optional[datetime] = None
 	updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
## Summary
- add versioned combined-model prediction label writes that deactivate only older labels with the same combined model config
- stop combined-model reruns from deleting legacy deadwood/treecover prediction labels, including empty-prediction cases
- update downloads and frontend label consumers to ignore inactive versions and choose the preferred active model label when multiple active prediction models exist

## Impact
This keeps old deadwood/treecover model labels available while adding combined-model labels. Older combined rerun outputs remain in history but are inactive, so exports and normal visualization use the current active version.

## Validation
- npm --prefix frontend test -- modelPreferences.test.ts
- npm --prefix frontend run build
- venv/bin/python -m py_compile processor/src/utils/prediction_labels.py processor/src/deadwood_treecover_combined_v2/predict_combined.py shared/models.py api/src/download/downloads.py processor/tests/test_prediction_labels.py
- venv/bin/python -m pytest processor/tests/test_prediction_labels.py shared/tests/test_odm_models.py -q
- processing-server: deadtrees dev test processor processor/tests/test_prediction_labels.py

## Notes
- npm --prefix frontend run lint still fails on existing repo-wide lint debt unrelated to this change.
- If a combined rerun produces no valid polygons for a layer, the previous active combined label is left untouched instead of deleting data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how model-prediction labels are written, deactivated, and selected across processor, API exports, and frontend queries; mistakes could hide labels or affect correction workflows. Scope spans multiple services but is constrained to model-prediction label lifecycle and selection logic.
> 
> **Overview**
> **Model prediction labels are now versioned instead of replaced/deleted.** The processor’s combined model write path now creates a new label version and *deactivates only prior labels with the same `model_config`*, linking versions via `parent_label_id` and incrementing `version`; empty/invalid predictions no longer trigger deletion of existing labels.
> 
> **Consumers now ignore inactive labels and prefer the correct active model output.** API download bundling filters out `is_active=false` labels, and frontend Supabase queries add `is_active=true` plus use `selectPreferredModelLabel` (updated to ignore inactive versions) when multiple model variants exist.
> 
> **Schema/model + tooling updates.** `shared.models.Label` gains `is_active`, `version`, and relationship fields, processor tests are updated/added to assert deactivation/versioning behavior, and the worktree bootstrap script/docs now copy local `.codex` config and `docs/ops` from the primary checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588f34edc93947b380ac6843a823d7e41ecbf946. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->