### PR TITLE
feat(frontend): add reference dataset gallery

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Route, Routes, useLocation } from "react-router-dom";
+import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { ConfigProvider, Layout } from "antd";
 import { useEffect } from "react";
 import { trackPageView, initializePostHog } from "./utils/analytics";
@@ -17,6 +17,8 @@ import DatasetReferencePatchEditor from "./pages/DatasetReferencePatchEditor";
 import DatasetLabelEditor from "./pages/DatasetLabelEditor";
 import DatasetCorrections from "./pages/DatasetCorrections";
 import Deadtrees from "./pages/Deadtrees";
+import ReferenceDatasets from "./pages/ReferenceDatasets";
+import DteAerialReferenceDataset from "./pages/DteAerialReferenceDataset";
 import SignUp from "./pages/auth/SignUp";
 import SignIn from "./pages/auth/SignIn";
 import Forgotpassword from "./pages/auth/ForgotPassword";
@@ -120,6 +122,15 @@ function AppWithTracking() {
           element={<DatasetCorrections />}
         />
         <Route path="deadtrees" element={<Deadtrees />} />
+        <Route path="reference-datasets" element={<ReferenceDatasets />} />
+        <Route
+          path="reference-datasets/dte-aerial"
+          element={<DteAerialReferenceDataset />}
+        />
+        <Route
+          path="DTE-aerial"
+          element={<Navigate to="/reference-datasets/dte-aerial" replace />}
+        />
         <Route path="about" element={<About />} />
         <Route path="impressum" element={<Impressum />} />
         <Route

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,12 +124,20 @@ function AppWithTracking() {
         <Route path="deadtrees" element={<Deadtrees />} />
         <Route path="reference-datasets" element={<ReferenceDatasets />} />
         <Route
-          path="reference-datasets/dte-aerial"
+          path="reference-datasets/dte-aerial-bench"
           element={<DteAerialReferenceDataset />}
         />
         <Route
+          path="reference-datasets/dte-aerial"
+          element={<Navigate to="/reference-datasets/dte-aerial-bench" replace />}
+        />
+        <Route
           path="DTE-aerial"
-          element={<Navigate to="/reference-datasets/dte-aerial" replace />}
+          element={<Navigate to="/reference-datasets/dte-aerial-bench" replace />}
+        />
+        <Route
+          path="DTE-aerial-bench"
+          element={<Navigate to="/reference-datasets/dte-aerial-bench" replace />}
         />
         <Route path="about" element={<About />} />
         <Route path="impressum" element={<Impressum />} />

--- a/frontend/src/components/Home/ReferenceDatasets.tsx
+++ b/frontend/src/components/Home/ReferenceDatasets.tsx
@@ -1,0 +1,168 @@
+import { Button, Tag } from "antd";
+import { DatabaseOutlined, ArrowRightOutlined } from "@ant-design/icons";
+import { Link } from "react-router-dom";
+
+import {
+	dteAerialReferenceDataset,
+	getReferencePatchImages,
+	type ReferenceDatasetSite,
+} from "../../data/referenceDatasets";
+import { GroundTruthMask } from "../ReferenceDatasets/GroundTruthMask";
+import { useAnalytics } from "../../hooks/useAnalytics";
+
+const FEATURED_PREVIEW_SITE_IDS = [375, 435, 1396, 4087, 5584, 6445];
+const PREVIEW_MODES: Array<"rgb" | "mask"> = [
+	"rgb",
+	"mask",
+	"rgb",
+	"mask",
+	"rgb",
+	"mask",
+];
+
+const pickPreviewSites = (
+	sites: ReferenceDatasetSite[],
+	preferredIds: number[],
+	count: number,
+): ReferenceDatasetSite[] => {
+	const byId = new Map(sites.map((site) => [site.id, site]));
+	const preferred = preferredIds
+		.map((id) => byId.get(id))
+		.filter((site): site is ReferenceDatasetSite => Boolean(site));
+	if (preferred.length >= count) return preferred.slice(0, count);
+	const rest = sites.filter((site) => !preferredIds.includes(site.id));
+	return [...preferred, ...rest].slice(0, count);
+};
+
+const ReferenceDatasetsSection = () => {
+	const { track } = useAnalytics("home");
+	const previewSites = pickPreviewSites(
+		dteAerialReferenceDataset.sites,
+		FEATURED_PREVIEW_SITE_IDS,
+		6,
+	);
+
+	const trackCta = (cta: string, target: string) => () =>
+		track("landing_cta_clicked", {
+			cta_name: cta,
+			action_target: target,
+		});
+
+	return (
+		<section className="w-full bg-white py-24 md:py-32">
+			<div className="m-auto max-w-6xl px-4 md:px-8">
+				<div className="mb-12 text-center md:mb-16">
+					<p className="mb-2 text-lg font-semibold uppercase tracking-wider text-[#1B5E35]">
+						Reference Datasets
+					</p>
+					<h2 className="m-0 text-4xl font-semibold text-gray-800 md:text-5xl">
+						Curated benchmarks for forest AI
+					</h2>
+					<p className="mx-auto mt-6 max-w-3xl text-lg text-gray-600">
+						Stable, citable releases with expert reference masks, multi-resolution patches,
+						and benchmark splits - built for reproducible machine learning research on
+						tree cover and deadwood.
+					</p>
+				</div>
+
+				<div className="mx-auto max-w-5xl">
+					<Link
+						to={`/reference-datasets/${dteAerialReferenceDataset.slug}`}
+						onClick={trackCta(
+							"home_reference_preview_strip",
+							`/reference-datasets/${dteAerialReferenceDataset.slug}`,
+						)}
+						className="group block overflow-hidden rounded-2xl shadow-xl ring-1 ring-black/5 transition-all hover:shadow-2xl"
+						aria-label="Open the deadtrees.earth-aerial reference gallery"
+					>
+						<div className="grid grid-cols-3 gap-px bg-gray-200 sm:grid-cols-6">
+							{previewSites.map((site, index) => {
+								const previewPatch = getReferencePatchImages(site, 20, 0);
+								const mode = PREVIEW_MODES[index % PREVIEW_MODES.length];
+								if (mode === "mask") {
+									return (
+										<GroundTruthMask
+											key={site.id}
+											forestCoverSrc={previewPatch.treeCoverMask}
+											deadwoodSrc={previewPatch.mortalityMask}
+											alt={`Reference mask from site ${site.id}`}
+											size={256}
+											className="transition-transform duration-300 group-hover:scale-[1.02]"
+										/>
+									);
+								}
+								return (
+									<div
+										key={site.id}
+										className="aspect-square overflow-hidden bg-gray-100"
+									>
+										<img
+											src={previewPatch.rgb}
+											alt={`Benchmark patch from site ${site.id}`}
+											loading="lazy"
+											className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+										/>
+									</div>
+								);
+							})}
+						</div>
+					</Link>
+
+					<div className="mt-8 flex flex-col items-start justify-between gap-6 md:flex-row md:items-center">
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								<Tag color="green" className="m-0">
+									Available
+								</Tag>
+								<span className="text-sm font-semibold text-gray-700">
+									{dteAerialReferenceDataset.shortName}
+								</span>
+								<span aria-hidden className="text-gray-300">
+									-
+								</span>
+								<span className="text-sm text-gray-500">
+									25 sites - 525 patches - 5, 10, 20 cm resolutions
+								</span>
+							</div>
+							<p className="mt-2 text-base text-gray-600">
+								A multi-resolution aerial benchmark for tree cover and mortality
+								detection - alternating RGB patches with paired forest cover and
+								deadwood reference masks.
+							</p>
+						</div>
+
+						<div className="flex flex-shrink-0 flex-wrap items-center gap-3">
+							<Link to="/reference-datasets">
+								<Button
+									type="primary"
+									size="large"
+									icon={<DatabaseOutlined />}
+									className="min-h-11 px-6"
+									onClick={trackCta(
+										"home_browse_reference_data",
+										"/reference-datasets",
+									)}
+								>
+									Browse Reference Data
+								</Button>
+							</Link>
+							<Link
+								to={`/reference-datasets/${dteAerialReferenceDataset.slug}`}
+								onClick={trackCta(
+									"home_open_dte_aerial_gallery",
+									`/reference-datasets/${dteAerialReferenceDataset.slug}`,
+								)}
+								className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#1B5E35] hover:underline"
+							>
+								Open DTE-aerial gallery
+								<ArrowRightOutlined />
+							</Link>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+};
+
+export default ReferenceDatasetsSection;

--- a/frontend/src/components/Home/ReferenceDatasets.tsx
+++ b/frontend/src/components/Home/ReferenceDatasets.tsx
@@ -73,7 +73,7 @@ const ReferenceDatasetsSection = () => {
 							`/reference-datasets/${dteAerialReferenceDataset.slug}`,
 						)}
 						className="group block overflow-hidden rounded-2xl shadow-xl ring-1 ring-black/5 transition-all hover:shadow-2xl"
-						aria-label="Open the deadtrees.earth-aerial reference gallery"
+						aria-label="Open the DTE-aerial-bench reference gallery"
 					>
 						<div className="grid grid-cols-3 gap-px bg-gray-200 sm:grid-cols-6">
 							{previewSites.map((site, index) => {
@@ -149,12 +149,12 @@ const ReferenceDatasetsSection = () => {
 							<Link
 								to={`/reference-datasets/${dteAerialReferenceDataset.slug}`}
 								onClick={trackCta(
-									"home_open_dte_aerial_gallery",
+									"home_open_dte_aerial_bench_gallery",
 									`/reference-datasets/${dteAerialReferenceDataset.slug}`,
 								)}
 								className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#1B5E35] hover:underline"
 							>
-								Open DTE-aerial gallery
+								Open DTE-aerial-bench gallery
 								<ArrowRightOutlined />
 							</Link>
 						</div>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -23,6 +23,10 @@ const defaultNavigation = [
     label: "Drone Archive",
   },
   {
+    key: "/reference-datasets",
+    label: "Reference Data",
+  },
+  {
     key: "/about",
     label: "About",
   },

--- a/frontend/src/components/ReferenceDatasets/GroundTruthMask.tsx
+++ b/frontend/src/components/ReferenceDatasets/GroundTruthMask.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from "react";
+
+export const GROUND_TRUTH_COLORS = {
+  background: "#BDBDBD",
+  forestCover: "#087C69",
+  deadwood: "#FF9800",
+} as const;
+
+const parseHexColor = (hex: string): [number, number, number] => {
+  const normalized = hex.replace("#", "");
+  return [
+    Number.parseInt(normalized.slice(0, 2), 16),
+    Number.parseInt(normalized.slice(2, 4), 16),
+    Number.parseInt(normalized.slice(4, 6), 16),
+  ];
+};
+
+const imageLoadCache = new Map<string, Promise<HTMLImageElement>>();
+const composedMaskCache = new Map<string, Promise<string>>();
+
+const loadImage = (src: string) => {
+  const cached = imageLoadCache.get(src);
+  if (cached) return cached;
+
+  const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+
+  imageLoadCache.set(src, promise);
+  return promise;
+};
+
+export const composeMaskDataUrl = ({
+  forestCoverSrc,
+  deadwoodSrc,
+  mode,
+  opacity,
+  size,
+}: {
+  forestCoverSrc: string;
+  deadwoodSrc: string;
+  mode: "opaque" | "transparent";
+  opacity: number;
+  size: number;
+}) => {
+  const cacheKey = `${forestCoverSrc}|${deadwoodSrc}|${mode}|${opacity}|${size}`;
+  const cached = composedMaskCache.get(cacheKey);
+  if (cached) return cached;
+
+  const promise = Promise.all([
+    loadImage(forestCoverSrc),
+    loadImage(deadwoodSrc),
+  ]).then(([forestImage, deadwoodImage]) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) throw new Error("Could not create mask canvas context");
+
+    const background = parseHexColor(GROUND_TRUTH_COLORS.background);
+    const forestCover = parseHexColor(GROUND_TRUTH_COLORS.forestCover);
+    const deadwood = parseHexColor(GROUND_TRUTH_COLORS.deadwood);
+
+    const maskCanvas = document.createElement("canvas");
+    maskCanvas.width = size;
+    maskCanvas.height = size;
+    const maskCtx = maskCanvas.getContext("2d", { willReadFrequently: true });
+    if (!maskCtx) throw new Error("Could not create source mask canvas context");
+
+    maskCtx.drawImage(forestImage, 0, 0, size, size);
+    const forestData = maskCtx.getImageData(0, 0, size, size).data;
+
+    maskCtx.clearRect(0, 0, size, size);
+    maskCtx.drawImage(deadwoodImage, 0, 0, size, size);
+    const deadwoodData = maskCtx.getImageData(0, 0, size, size).data;
+
+    const output = ctx.createImageData(size, size);
+
+    for (let i = 0; i < output.data.length; i += 4) {
+      const forestPositive = forestData[i] > 127;
+      const deadwoodPositive = deadwoodData[i] > 127;
+      const color = deadwoodPositive
+        ? deadwood
+        : forestPositive
+          ? forestCover
+          : background;
+      const alpha =
+        mode === "transparent"
+          ? deadwoodPositive || forestPositive
+            ? Math.round(opacity * 255)
+            : 0
+          : 255;
+
+      output.data[i] = color[0];
+      output.data[i + 1] = color[1];
+      output.data[i + 2] = color[2];
+      output.data[i + 3] = alpha;
+    }
+
+    ctx.putImageData(output, 0, 0);
+    return canvas.toDataURL("image/png");
+  });
+
+  const cachedPromise = promise.catch((error) => {
+    composedMaskCache.delete(cacheKey);
+    throw error;
+  });
+
+  composedMaskCache.set(cacheKey, cachedPromise);
+  return cachedPromise;
+};
+
+interface GroundTruthMaskProps {
+  forestCoverSrc: string;
+  deadwoodSrc: string;
+  alt: string;
+  mode?: "opaque" | "transparent";
+  opacity?: number;
+  size?: number;
+  className?: string;
+}
+
+export function GroundTruthMask({
+  forestCoverSrc,
+  deadwoodSrc,
+  alt,
+  mode = "opaque",
+  opacity = 1,
+  size = 256,
+  className = "",
+}: GroundTruthMaskProps) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [shouldRender, setShouldRender] = useState(false);
+  const [maskDataUrl, setMaskDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    if (!("IntersectionObserver" in window)) {
+      setShouldRender(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "180px" },
+    );
+
+    observer.observe(wrapper);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+
+    let cancelled = false;
+    setMaskDataUrl(null);
+
+    composeMaskDataUrl({ forestCoverSrc, deadwoodSrc, mode, opacity, size })
+      .then((dataUrl) => {
+        if (!cancelled) setMaskDataUrl(dataUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setMaskDataUrl(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [deadwoodSrc, forestCoverSrc, mode, opacity, shouldRender, size]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`aspect-square overflow-hidden ${
+        mode === "opaque" ? "bg-[#BDBDBD]" : "bg-transparent"
+      } ${className}`}
+    >
+      {maskDataUrl && (
+        <img
+          src={maskDataUrl}
+          alt={alt}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/data/referenceDatasets.ts
+++ b/frontend/src/data/referenceDatasets.ts
@@ -383,10 +383,10 @@ export const getReferencePatchGridImages = (
 };
 
 export const dteAerialReferenceDataset: ReferenceDatasetCollection = {
-  slug: "dte-aerial",
-  name: "deadtrees.earth-aerial",
-  shortName: "DTE-aerial",
-  title: "deadtrees.earth-aerial: A Multi-Resolution Aerial Image Dataset for Tree Cover and Mortality Detection",
+  slug: "dte-aerial-bench",
+  name: "DTE-aerial-bench",
+  shortName: "DTE-aerial-bench",
+  title: "DTE-aerial-bench: A Multi-Resolution Aerial Image Benchmark for Tree Cover and Mortality Detection",
   status: "available",
   summary:
     "A curated aerial benchmark for tree cover and mortality detection, built from high-resolution drone and aircraft orthophotos with expert reference masks.",

--- a/frontend/src/data/referenceDatasets.ts
+++ b/frontend/src/data/referenceDatasets.ts
@@ -1,0 +1,685 @@
+export type ReferencePatchResolution = 5 | 10 | 20;
+
+export interface ReferenceDatasetSite {
+  id: number;
+  fileName: string;
+  biome: string;
+  license: string;
+  citationUrl: string | null;
+  thumbnailPath: string;
+  exportSeed: string;
+  center: {
+    lon: number;
+    lat: number;
+  };
+  patchCount: number;
+}
+
+export interface ReferenceDatasetAdminInfo {
+  id: number | string;
+  admin_level_1: string | null;
+  admin_level_2: string | null;
+  admin_level_3: string | null;
+  aquisition_year: number | string | null;
+  aquisition_month: number | string | null;
+  aquisition_day: number | string | null;
+  platform: string | null;
+  authors: string[] | null;
+}
+
+export interface ReferencePatchImageSet {
+  resolutionCm: ReferencePatchResolution;
+  patchIndex: number;
+  label: string;
+  rgb: string;
+  treeCoverMask: string;
+  mortalityMask: string;
+}
+
+export interface ReferenceDatasetCollection {
+  slug: string;
+  name: string;
+  shortName: string;
+  title: string;
+  status: "available" | "coming-soon";
+  summary: string;
+  stats: Array<{ label: string; value: string }>;
+  links: {
+    dataset: string;
+    citation: string;
+    croissant: string;
+  };
+  sites: ReferenceDatasetSite[];
+}
+
+export const REFERENCE_EXPORT_BASE_URL =
+  "https://data2.deadtrees.earth/reference/69e57f93-d003-4b64-9108-fe3dfa654918";
+
+export const dteAerialReferenceDatasetAdminInfoById: Record<number, ReferenceDatasetAdminInfo> = {
+  375: {
+    id: 375,
+    admin_level_1: "Spain",
+    admin_level_2: "Granada",
+    admin_level_3: "Arenas del Rey",
+    aquisition_year: 2023,
+    aquisition_month: 9,
+    aquisition_day: 16,
+    platform: "drone",
+    authors: ["Clemens Mosig", "Oscar Perez-Priego"],
+  },
+  400: {
+    id: 400,
+    admin_level_1: "Spain",
+    admin_level_2: "Malaga",
+    admin_level_3: "Canillas de Albaida",
+    aquisition_year: 2023,
+    aquisition_month: 9,
+    aquisition_day: 20,
+    platform: "drone",
+    authors: ["Clemens Mosig", "Oscar Perez-Priego"],
+  },
+  435: {
+    id: 435,
+    admin_level_1: "Panama",
+    admin_level_2: "La Chorrera",
+    admin_level_3: "",
+    aquisition_year: 2018,
+    aquisition_month: 11,
+    aquisition_day: 26,
+    platform: "drone",
+    authors: ["Helene C. Muller-Landau", "Vicente Garcia Vasquez", "Melvin Milton Hernandez"],
+  },
+  868: {
+    id: 868,
+    admin_level_1: "New Zealand",
+    admin_level_2: "Western Bay of Plenty",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 10,
+    aquisition_day: 25,
+    platform: "drone",
+    authors: ["Contributors of Open Imagery Network"],
+  },
+  1371: {
+    id: 1371,
+    admin_level_1: "Norway",
+    admin_level_2: "As",
+    admin_level_3: "",
+    aquisition_year: 2018,
+    aquisition_month: 5,
+    aquisition_day: 15,
+    platform: "drone",
+    authors: ["Stefano Puliti", "Rasmus Astrup"],
+  },
+  1381: {
+    id: 1381,
+    admin_level_1: "Norway",
+    admin_level_2: "Stange",
+    admin_level_3: "",
+    aquisition_year: 2018,
+    aquisition_month: 8,
+    aquisition_day: 21,
+    platform: "drone",
+    authors: ["Stefano Puliti", "Rasmus Astrup"],
+  },
+  1396: {
+    id: 1396,
+    admin_level_1: "Norway",
+    admin_level_2: "Lier",
+    admin_level_3: "",
+    aquisition_year: 2019,
+    aquisition_month: 5,
+    aquisition_day: 23,
+    platform: "drone",
+    authors: ["Stefano Puliti", "Rasmus Astrup"],
+  },
+  1406: {
+    id: 1406,
+    admin_level_1: "Norway",
+    admin_level_2: "Mandalseid",
+    admin_level_3: "",
+    aquisition_year: 2021,
+    aquisition_month: 6,
+    aquisition_day: 8,
+    platform: "drone",
+    authors: ["Stefano Puliti", "Rasmus Astrup"],
+  },
+  3251: {
+    id: 3251,
+    admin_level_1: "Indonesia",
+    admin_level_2: "Langkat",
+    admin_level_3: "Bukit Mas",
+    aquisition_year: 2012,
+    aquisition_month: 2,
+    aquisition_day: 15,
+    platform: "drone",
+    authors: ["Serge Wich"],
+  },
+  3341: {
+    id: 3341,
+    admin_level_1: "Brazil",
+    admin_level_2: "Frederico Westphalen",
+    admin_level_3: "",
+    aquisition_year: 2017,
+    aquisition_month: 9,
+    aquisition_day: 22,
+    platform: "drone",
+    authors: ["Fabio Marcelo Breunig"],
+  },
+  3834: {
+    id: 3834,
+    admin_level_1: "Indonesia",
+    admin_level_2: "Kutai Timur",
+    admin_level_3: "Sangatta Selatan",
+    aquisition_year: 2014,
+    aquisition_month: 8,
+    aquisition_day: 19,
+    platform: "drone",
+    authors: ["Serge Wich"],
+  },
+  4010: {
+    id: 4010,
+    admin_level_1: "Portugal",
+    admin_level_2: "Ribeira Brava",
+    admin_level_3: "",
+    aquisition_year: 2024,
+    aquisition_month: 9,
+    aquisition_day: 11,
+    platform: "drone",
+    authors: ["Teja Kattenborn"],
+  },
+  4087: {
+    id: 4087,
+    admin_level_1: "Germany",
+    admin_level_2: "Tubingen",
+    admin_level_3: "Rottenburg am Neckar",
+    aquisition_year: 2025,
+    aquisition_month: 7,
+    aquisition_day: 27,
+    platform: "drone",
+    authors: ["PRIMA-Wald"],
+  },
+  4088: {
+    id: 4088,
+    admin_level_1: "Germany",
+    admin_level_2: "Ortenaukreis",
+    admin_level_3: "Oppenau",
+    aquisition_year: 2025,
+    aquisition_month: 7,
+    aquisition_day: 31,
+    platform: "drone",
+    authors: ["PRIMA-Wald"],
+  },
+  4181: {
+    id: 4181,
+    admin_level_1: "Chile",
+    admin_level_2: "Talca",
+    admin_level_3: "",
+    aquisition_year: 2017,
+    aquisition_month: 4,
+    aquisition_day: 12,
+    platform: "drone",
+    authors: ["Fabian Fassnacht"],
+  },
+  4182: {
+    id: 4182,
+    admin_level_1: "Chile",
+    admin_level_2: "Talca",
+    admin_level_3: "",
+    aquisition_year: 2016,
+    aquisition_month: 3,
+    aquisition_day: 16,
+    platform: "drone",
+    authors: ["Fabian Fassnacht"],
+  },
+  4471: {
+    id: 4471,
+    admin_level_1: "New Zealand",
+    admin_level_2: "Marlborough",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 8,
+    aquisition_day: 17,
+    platform: "drone",
+    authors: ["GeoNadir"],
+  },
+  5387: {
+    id: 5387,
+    admin_level_1: "United States",
+    admin_level_2: "Washington",
+    admin_level_3: "",
+    aquisition_year: 2015,
+    aquisition_month: 8,
+    aquisition_day: 7,
+    platform: "drone",
+    authors: ["DroneDB"],
+  },
+  5463: {
+    id: 5463,
+    admin_level_1: "United States",
+    admin_level_2: "Yuba",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 6,
+    aquisition_day: 23,
+    platform: "drone",
+    authors: ["UC Davis Forest Change Analysis Lab"],
+  },
+  5584: {
+    id: 5584,
+    admin_level_1: "United States",
+    admin_level_2: "Nevada",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 8,
+    aquisition_day: 4,
+    platform: "drone",
+    authors: ["UC Davis Forest Change Analysis Lab"],
+  },
+  5756: {
+    id: 5756,
+    admin_level_1: "United States",
+    admin_level_2: "Santa Clara",
+    admin_level_3: "",
+    aquisition_year: 2020,
+    aquisition_month: 5,
+    aquisition_day: 12,
+    platform: "drone",
+    authors: ["UC Natural Reserve System and Becca Fenwick, Justin Cummings, Jacob Flannagan, Clancy McConnell, Sean Hogan"],
+  },
+  5783: {
+    id: 5783,
+    admin_level_1: "United States",
+    admin_level_2: "Santa Clara",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 8,
+    aquisition_day: 17,
+    platform: "drone",
+    authors: ["UC Natural Reserve System and Becca Fenwick, Justin Cummings, Jacob Flannagan, Clancy McConnell, Sean Hogan"],
+  },
+  5786: {
+    id: 5786,
+    admin_level_1: "United States",
+    admin_level_2: "Santa Clara",
+    admin_level_3: "",
+    aquisition_year: 2023,
+    aquisition_month: 8,
+    aquisition_day: 17,
+    platform: "drone",
+    authors: ["UC Natural Reserve System and Becca Fenwick, Justin Cummings, Jacob Flannagan, Clancy McConnell, Sean Hogan"],
+  },
+  5931: {
+    id: 5931,
+    admin_level_1: "United States",
+    admin_level_2: "Riverside",
+    admin_level_3: "",
+    aquisition_year: 2024,
+    aquisition_month: 8,
+    aquisition_day: 11,
+    platform: "drone",
+    authors: ["UC Davis Forest Change Analysis Lab"],
+  },
+  6445: {
+    id: 6445,
+    admin_level_1: "South Korea",
+    admin_level_2: "Andong",
+    admin_level_3: "",
+    aquisition_year: 2025,
+    aquisition_month: 7,
+    aquisition_day: 3,
+    platform: "drone",
+    authors: ["Youngryel Ryu"],
+  },
+};
+
+const makeReferencePatchBase = (
+  dataset: ReferenceDatasetSite,
+  resolutionCm: ReferencePatchResolution,
+  patchIndex = 0,
+) => {
+  if (resolutionCm === 20) {
+    return `${dataset.id}_20_${dataset.exportSeed}_20cm`;
+  }
+
+  if (resolutionCm === 10) {
+    return `${dataset.id}_${dataset.exportSeed}_${patchIndex}_10cm`;
+  }
+
+  const row = Math.floor(patchIndex / 4);
+  const column = patchIndex % 4;
+  return `${dataset.id}_${row}_${column}_5cm`;
+};
+
+export const getReferencePatchImages = (
+  dataset: ReferenceDatasetSite,
+  resolutionCm: ReferencePatchResolution,
+  patchIndex = 0,
+): ReferencePatchImageSet => {
+  const base = makeReferencePatchBase(dataset, resolutionCm, patchIndex);
+  const folder = `${REFERENCE_EXPORT_BASE_URL}/${dataset.id}/png`;
+
+  return {
+    resolutionCm,
+    patchIndex,
+    label: `Patch ${patchIndex + 1}`,
+    rgb: `${folder}/${base}.png`,
+    treeCoverMask: `${folder}/${base}_forestcover_ref.png`,
+    mortalityMask: `${folder}/${base}_deadwood_ref.png`,
+  };
+};
+
+export const getReferencePatchGridImages = (
+  dataset: ReferenceDatasetSite,
+  resolutionCm: ReferencePatchResolution,
+): ReferencePatchImageSet[] => {
+  const patchCountByResolution: Record<ReferencePatchResolution, number> = {
+    20: 1,
+    10: 4,
+    5: 16,
+  };
+
+  return Array.from({ length: patchCountByResolution[resolutionCm] }, (_, index) =>
+    getReferencePatchImages(dataset, resolutionCm, index),
+  );
+};
+
+export const dteAerialReferenceDataset: ReferenceDatasetCollection = {
+  slug: "dte-aerial",
+  name: "deadtrees.earth-aerial",
+  shortName: "DTE-aerial",
+  title: "deadtrees.earth-aerial: A Multi-Resolution Aerial Image Dataset for Tree Cover and Mortality Detection",
+  status: "available",
+  summary:
+    "A curated aerial benchmark for tree cover and mortality detection, built from high-resolution drone and aircraft orthophotos with expert reference masks.",
+  stats: [
+    { label: "Golden test sites", value: "25" },
+    { label: "Benchmark patches", value: "525" },
+    { label: "Patch size", value: "1024 px" },
+    { label: "Resolutions", value: "5, 10, 20 cm" },
+  ],
+  links: {
+    dataset: "#dataset-download-placeholder",
+    citation: "#citation-placeholder",
+    croissant: "#croissant-placeholder",
+  },
+  sites: [
+    {
+      id: 375,
+      fileName: "spain_16_09_2023_andy_8_ortho.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "7f4f2ccf-ea6d-4121-b458-1e7df383cb8b/375_thumbnail.jpg",
+      exportSeed: "1761659176350",
+      center: { lon: -3.85384, lat: 36.90486 },
+      patchCount: 21,
+    },
+    {
+      id: 400,
+      fileName: "spain_20_09_2023_south_tejeda_4_ortho.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "d20ffc69-1256-46b5-8abe-42743ab91bde/400_thumbnail.jpg",
+      exportSeed: "1762246508822",
+      center: { lon: -3.9977, lat: 36.85925 },
+      patchCount: 21,
+    },
+    {
+      id: 435,
+      fileName: "BCI_50ha_2018_11_26_global.tif",
+      biome: "Tropical and Subtropical Moist Broadleaf Forests",
+      license: "CC BY",
+      citationUrl: "https://doi.org/10.25573/data.24782016",
+      thumbnailPath: "c8a27049-d93d-436d-b4e5-5f423aab985f/435_thumbnail.jpg",
+      exportSeed: "1761655691349",
+      center: { lon: -79.85098, lat: 9.15454 },
+      patchCount: 21,
+    },
+    {
+      id: 868,
+      fileName: "6544f584f0cdb700011d7aba.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "f05f654d-747b-4ea9-b06b-3dc667574b0b/868_thumbnail.jpg",
+      exportSeed: "1769430182985",
+      center: { lon: 176.19853, lat: -37.8236 },
+      patchCount: 21,
+    },
+    {
+      id: 1371,
+      fileName: "20180515.tif",
+      biome: "Boreal Forests/Taiga",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "1f481b77-6ad5-4e65-94a8-fb6bd9f842e7/1371_thumbnail.jpg",
+      exportSeed: "1762700398977",
+      center: { lon: 10.78414, lat: 59.67004 },
+      patchCount: 21,
+    },
+    {
+      id: 1381,
+      fileName: "20180821.tif",
+      biome: "Boreal Forests/Taiga",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "d1a407af-e423-4609-9252-af9bd256f0e1/1381_thumbnail.jpg",
+      exportSeed: "1762819003883",
+      center: { lon: 11.5016, lat: 60.62977 },
+      patchCount: 21,
+    },
+    {
+      id: 1396,
+      fileName: "20190523.tif",
+      biome: "Boreal Forests/Taiga",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "c5953896-538c-4f3e-8cfa-2f0ade81da20/1396_thumbnail.jpg",
+      exportSeed: "1761725189801",
+      center: { lon: 10.14918, lat: 59.85898 },
+      patchCount: 21,
+    },
+    {
+      id: 1406,
+      fileName: "20210608_2.tif",
+      biome: "Boreal Forests/Taiga",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "0d099013-e7b6-4024-9884-97e162ac6b9c/1406_thumbnail.jpg",
+      exportSeed: "1761638862743",
+      center: { lon: 11.42959, lat: 64.26842 },
+      patchCount: 21,
+    },
+    {
+      id: 3251,
+      fileName: "aras_nepal_15022012_RGB_orthomosaic.tif",
+      biome: "Tropical and Subtropical Moist Broadleaf Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "9be88d59-2140-4e7a-aae5-45aa01ef40d7/3251_thumbnail.jpg",
+      exportSeed: "1761645491783",
+      center: { lon: 98.08785, lat: 3.96959 },
+      patchCount: 26,
+    },
+    {
+      id: 3341,
+      fileName: "Voo_P4_20170922_80mag_9min_Mosaico.tif",
+      biome: "Tropical and Subtropical Moist Broadleaf Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "0c3e6ddc-6bd3-4249-b67f-c7d1b869e3f4/3341_thumbnail.jpg",
+      exportSeed: "1761050217641",
+      center: { lon: -53.42594, lat: -27.39328 },
+      patchCount: 21,
+    },
+    {
+      id: 3834,
+      fileName: "2013_08_27_Tanjung Survey 110m horizontal 150m vert_RGB_orthomosaic.tif",
+      biome: "Tropical and Subtropical Moist Broadleaf Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "c0fc439e-a9ac-49ff-b8e5-bae5fbea038a/3834_thumbnail.jpg",
+      exportSeed: "1761123016903",
+      center: { lon: 117.44007, lat: 0.57411 },
+      patchCount: 21,
+    },
+    {
+      id: 4010,
+      fileName: "odm_orthophoto_lombo.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "d88adc65-e486-40bf-8f23-0d86d0b3754c/4010_thumbnail.jpg",
+      exportSeed: "1768248869627",
+      center: { lon: -17.01648, lat: 32.74154 },
+      patchCount: 21,
+    },
+    {
+      id: 4087,
+      fileName: "DJI_202507271025_012_Sonntag.zip",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "89e162a7-d91d-4884-a077-35b0e95d751c/4087_thumbnail.jpg",
+      exportSeed: "1761034949701",
+      center: { lon: 8.96256, lat: 48.44915 },
+      patchCount: 21,
+    },
+    {
+      id: 4088,
+      fileName: "PIRMA-Wald_Test_Ohlsbach.zip",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "049caac4-df9c-4735-8bd6-9515bd8a9cfc/4088_thumbnail.jpg",
+      exportSeed: "1761813561329",
+      center: { lon: 8.19973, lat: 48.51928 },
+      patchCount: 21,
+    },
+    {
+      id: 4181,
+      fileName: "674.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: "https://data.geonadir.com/image-collection-details/674",
+      thumbnailPath: "f499c10d-66d5-4be5-8294-78c0c18c6f39/4181_thumbnail.jpg",
+      exportSeed: "1768225381580",
+      center: { lon: -72.17642, lat: -35.2324 },
+      patchCount: 21,
+    },
+    {
+      id: 4182,
+      fileName: "679.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: "https://data.geonadir.com/image-collection-details/679",
+      thumbnailPath: "a19c6e39-ed10-4dd7-af91-25f63f5d9da1/4182_thumbnail.jpg",
+      exportSeed: "1764090893821",
+      center: { lon: -72.1375, lat: -35.26552 },
+      patchCount: 21,
+    },
+    {
+      id: 4471,
+      fileName: "3066.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: "https://data.geonadir.com/image-collection-details/3066",
+      thumbnailPath: "1b0d5cff-a5fa-4a97-9af0-e6baeddd4b99/4471_thumbnail.jpg",
+      exportSeed: "1768211503784",
+      center: { lon: 173.66067, lat: -41.57676 },
+      patchCount: 21,
+    },
+    {
+      id: 5387,
+      fileName: "odm_orthophoto.tif",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "05b87d57-5680-4478-aacb-9a6966922138/5387_thumbnail.jpg",
+      exportSeed: "1761037805083",
+      center: { lon: -72.74669, lat: 44.33445 },
+      patchCount: 21,
+    },
+    {
+      id: 5463,
+      fileName: "mission_000097_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Temperate Coniferous Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "c2874a35-bee4-4866-a727-550b22a25f90/5463_thumbnail.jpg",
+      exportSeed: "1761562313850",
+      center: { lon: -121.05988, lat: 39.47847 },
+      patchCount: 21,
+    },
+    {
+      id: 5584,
+      fileName: "mission_000252_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Temperate Coniferous Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "ad8b3ad0-771d-4d03-8d43-2f9369a34ed4/5584_thumbnail.jpg",
+      exportSeed: "1761219556800",
+      center: { lon: -120.45045, lat: 39.4227 },
+      patchCount: 21,
+    },
+    {
+      id: 5756,
+      fileName: "mission_000547_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "e071bb98-c403-4703-b7d2-27acaf666052/5756_thumbnail.jpg",
+      exportSeed: "1760969308574",
+      center: { lon: -121.72501, lat: 37.39333 },
+      patchCount: 21,
+    },
+    {
+      id: 5783,
+      fileName: "mission_000610_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "150d415c-ed3e-4b90-af1b-dda191e86fc9/5783_thumbnail.jpg",
+      exportSeed: "1761552733222",
+      center: { lon: -121.72784, lat: 37.37656 },
+      patchCount: 21,
+    },
+    {
+      id: 5786,
+      fileName: "mission_000613_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "d17b518f-d500-404b-b1ad-bc8c03ee1557/5786_thumbnail.jpg",
+      exportSeed: "1761224373009",
+      center: { lon: -121.72519, lat: 37.3933 },
+      patchCount: 21,
+    },
+    {
+      id: 5931,
+      fileName: "mission_001307_ortho-dsm-ptcloud_openforestobservatory.tif",
+      biome: "Mediterranean Forests, Woodlands, and Scrub",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "c2983bf0-c668-4dc2-a782-8f6b67ec715b/5931_thumbnail.jpg",
+      exportSeed: "1761036665707",
+      center: { lon: -116.76793, lat: 33.81106 },
+      patchCount: 21,
+    },
+    {
+      id: 6445,
+      fileName: "250703_1803.zip",
+      biome: "Temperate Broadleaf and Mixed Forests",
+      license: "CC BY",
+      citationUrl: null,
+      thumbnailPath: "6e340ecf-c978-47f2-9448-6a1bc0e08a6e/6445_thumbnail.jpg",
+      exportSeed: "1769163187091",
+      center: { lon: 128.56302, lat: 36.476 },
+      patchCount: 21,
+    },
+  ],
+};
+
+export const referenceDatasetCollections = [dteAerialReferenceDataset];

--- a/frontend/src/data/referenceDatasets.ts
+++ b/frontend/src/data/referenceDatasets.ts
@@ -46,8 +46,6 @@ export interface ReferenceDatasetCollection {
   stats: Array<{ label: string; value: string }>;
   links: {
     dataset: string;
-    citation: string;
-    croissant: string;
   };
   sites: ReferenceDatasetSite[];
 }
@@ -400,8 +398,6 @@ export const dteAerialReferenceDataset: ReferenceDatasetCollection = {
   ],
   links: {
     dataset: "#dataset-download-placeholder",
-    citation: "#citation-placeholder",
-    croissant: "#croissant-placeholder",
   },
   sites: [
     {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -139,6 +139,39 @@
   animation-play-state: paused;
 }
 
+/* Reference dataset gallery: force scrollbars to be always visible so the
+ * 2-axis scroll (datasets vertically, patches horizontally) is discoverable
+ * even on macOS where overlay scrollbars hide by default. */
+.reference-gallery-scroll {
+  scrollbar-gutter: stable;
+  scrollbar-color: rgba(27, 94, 53, 0.45) rgba(207, 216, 210, 0.6);
+  scrollbar-width: thin;
+}
+
+.reference-gallery-scroll::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+  background-color: rgba(207, 216, 210, 0.6);
+}
+
+.reference-gallery-scroll::-webkit-scrollbar-track {
+  background-color: rgba(207, 216, 210, 0.6);
+}
+
+.reference-gallery-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(27, 94, 53, 0.45);
+  border: 2px solid rgba(207, 216, 210, 0.6);
+  border-radius: 999px;
+}
+
+.reference-gallery-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(27, 94, 53, 0.7);
+}
+
+.reference-gallery-scroll::-webkit-scrollbar-corner {
+  background-color: rgba(207, 216, 210, 0.6);
+}
+
 /* Improve checkbox visibility across the app (especially on white cards/modals). */
 .ant-checkbox .ant-checkbox-inner {
   border-color: #6b7280;

--- a/frontend/src/pages/DteAerialReferenceDataset.tsx
+++ b/frontend/src/pages/DteAerialReferenceDataset.tsx
@@ -1,0 +1,1019 @@
+import {
+  BookOutlined,
+  CalendarOutlined,
+  DatabaseOutlined,
+  DownloadOutlined,
+  FileTextOutlined,
+  GlobalOutlined,
+  LeftOutlined,
+  RightOutlined,
+  SelectOutlined,
+  TableOutlined,
+  TeamOutlined,
+} from "@ant-design/icons";
+import { Button, Modal, Segmented, Select, Tag, Tooltip } from "antd";
+import { useQuery } from "@tanstack/react-query";
+import Feature from "ol/Feature";
+import type MapBrowserEvent from "ol/MapBrowserEvent";
+import Point from "ol/geom/Point";
+import VectorLayer from "ol/layer/Vector";
+import { Map as OLMap, View } from "ol";
+import VectorSource from "ol/source/Vector";
+import { fromLonLat } from "ol/proj";
+import { Circle as CircleStyle, Fill, Stroke, Style } from "ol/style";
+import Overlay from "ol/Overlay";
+import "ol/ol.css";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import {
+  dteAerialReferenceDatasetAdminInfoById,
+  dteAerialReferenceDataset,
+  getReferencePatchGridImages,
+  ReferencePatchImageSet,
+  ReferenceDatasetSite,
+  ReferencePatchResolution,
+  ReferenceDatasetAdminInfo,
+} from "../data/referenceDatasets";
+import {
+  GROUND_TRUTH_COLORS,
+  GroundTruthMask,
+} from "../components/ReferenceDatasets/GroundTruthMask";
+import { Settings } from "../config";
+import { supabase } from "../hooks/useSupabase";
+import {
+  createOpenFreeMapLibertyLayerGroup,
+  createStandardMapControls,
+} from "../utils/basemaps";
+
+type SortKey = "dataset" | "biome" | "west-east" | "north-south";
+type GalleryResolutionFilter = "all" | "20" | "10" | "5";
+type PatchViewerMode = "rgb" | "overlay" | "mask";
+
+// Gallery horizontal scroll step: one PatchCard width (190px) + flex gap (12px).
+const GALLERY_PATCH_STEP_PX = 202;
+
+interface SelectedReferencePatch {
+  site: ReferenceDatasetSite;
+  patch: ReferencePatchImageSet;
+}
+
+const sortOptions: Array<{ label: string; value: SortKey }> = [
+  { label: "Dataset ID", value: "dataset" },
+  { label: "Biome", value: "biome" },
+  { label: "West to east", value: "west-east" },
+  { label: "North to south", value: "north-south" },
+];
+
+const getShortBiome = (biome: string) =>
+  biome
+    .replace("Tropical and Subtropical", "Tropical")
+    .replace("Mediterranean Forests, Woodlands, and Scrub", "Mediterranean")
+    .replace("Temperate Broadleaf and Mixed Forests", "Temperate broadleaf")
+    .replace("Temperate Coniferous Forests", "Temperate conifer")
+    .replace("Boreal Forests/Taiga", "Boreal");
+
+const makeThumbnailUrl = (site: ReferenceDatasetSite) =>
+  `https://data2.deadtrees.earth/thumbnails/v1/${site.thumbnailPath}`;
+
+const normalizeMetadataValue = (value?: string | null) => {
+  const trimmed = value?.trim();
+  return trimmed || null;
+};
+
+interface DatasetLocationLabels {
+  primary: string;
+  secondary: string | null;
+}
+
+const formatDatasetLocationLabels = (
+  adminInfo: ReferenceDatasetAdminInfo | undefined,
+  isLoading: boolean,
+): DatasetLocationLabels => {
+  if (!adminInfo) {
+    return {
+      primary: isLoading ? "Loading metadata" : "Location unavailable",
+      secondary: null,
+    };
+  }
+
+  const country = normalizeMetadataValue(adminInfo.admin_level_1);
+  const region = normalizeMetadataValue(adminInfo.admin_level_2);
+  const locality = normalizeMetadataValue(adminInfo.admin_level_3);
+
+  if (locality) {
+    const parents = [region, country].filter(Boolean).join(", ");
+    return { primary: locality, secondary: parents || null };
+  }
+
+  if (region) {
+    return { primary: region, secondary: country };
+  }
+
+  if (country) {
+    return { primary: country, secondary: null };
+  }
+
+  return { primary: "Location unavailable", secondary: null };
+};
+
+const formatAcquisitionDate = (
+  adminInfo: ReferenceDatasetAdminInfo | undefined,
+  isLoading: boolean,
+) => {
+  if (!adminInfo) return isLoading ? "Loading" : "Unknown";
+  if (!adminInfo.aquisition_year) return "Unknown";
+
+  const year = Number(adminInfo.aquisition_year);
+  const month = adminInfo.aquisition_month ? Number(adminInfo.aquisition_month) : undefined;
+  const day = adminInfo.aquisition_day ? Number(adminInfo.aquisition_day) : undefined;
+
+  return new Date(year, month ? month - 1 : 0, day ?? 1).toLocaleDateString("en-US", {
+    year: "numeric",
+    ...(month && { month: "short" }),
+    ...(day && { day: "numeric" }),
+  });
+};
+
+const formatPlatform = (platform: string | null | undefined, isLoading: boolean) => {
+  const normalized = normalizeMetadataValue(platform);
+  if (!normalized) return isLoading ? "Loading" : "Unknown";
+  return normalized.slice(0, 1).toUpperCase() + normalized.slice(1);
+};
+
+const sortSites = (sites: ReferenceDatasetSite[], sortKey: SortKey) => {
+  const sorted = [...sites];
+
+  if (sortKey === "biome") {
+    return sorted.sort((a, b) => a.biome.localeCompare(b.biome) || a.id - b.id);
+  }
+
+  if (sortKey === "west-east") {
+    return sorted.sort((a, b) => a.center.lon - b.center.lon);
+  }
+
+  if (sortKey === "north-south") {
+    return sorted.sort((a, b) => b.center.lat - a.center.lat);
+  }
+
+  return sorted.sort((a, b) => a.id - b.id);
+};
+
+function WorldSiteMap({ sites }: { sites: ReferenceDatasetSite[] }) {
+  const mapElementRef = useRef<HTMLDivElement | null>(null);
+  const tooltipElementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!mapElementRef.current || !tooltipElementRef.current) return;
+    const tooltipElement = tooltipElementRef.current;
+
+    const defaultMarkerStyle = new Style({
+      image: new CircleStyle({
+        radius: 7,
+        fill: new Fill({ color: GROUND_TRUTH_COLORS.forestCover }),
+        stroke: new Stroke({ color: "#ffffff", width: 2.5 }),
+      }),
+    });
+
+    const hoverMarkerStyle = new Style({
+      image: new CircleStyle({
+        radius: 11,
+        fill: new Fill({ color: GROUND_TRUTH_COLORS.deadwood }),
+        stroke: new Stroke({ color: "#ffffff", width: 3 }),
+      }),
+    });
+
+    const markerSource = new VectorSource({
+      features: sites.map((site) => {
+        const feature = new Feature({
+          geometry: new Point(fromLonLat([site.center.lon, site.center.lat])),
+          datasetId: site.id,
+          biome: getShortBiome(site.biome),
+        });
+        feature.setStyle(defaultMarkerStyle);
+        return feature;
+      }),
+    });
+
+    const markerLayer = new VectorLayer({
+      source: markerSource,
+      zIndex: 10,
+    });
+
+    const tooltipOverlay = new Overlay({
+      element: tooltipElement,
+      offset: [0, -16],
+      positioning: "bottom-center",
+      stopEvent: false,
+    });
+
+    const map = new OLMap({
+      target: mapElementRef.current,
+      layers: [createOpenFreeMapLibertyLayerGroup(), markerLayer],
+      overlays: [tooltipOverlay],
+      controls: createStandardMapControls({
+        includeZoom: false,
+        includeAttribution: true,
+      }),
+      view: new View({
+        center: fromLonLat([10, 18]),
+        zoom: 1.7,
+        minZoom: 1,
+        maxZoom: 6,
+      }),
+    });
+
+    const extent = markerSource.getExtent();
+    if (extent.every(Number.isFinite)) {
+      map.getView().fit(extent, {
+        padding: [28, 28, 28, 28],
+        maxZoom: 3.2,
+      });
+    }
+
+    let hoveredFeature: Feature | null = null;
+
+    const handlePointerMove = (event: MapBrowserEvent<PointerEvent>) => {
+      const featureAtPixel = map.forEachFeatureAtPixel(event.pixel, (feature) => feature);
+      const nextFeature = featureAtPixel instanceof Feature ? featureAtPixel : null;
+
+      if (hoveredFeature && hoveredFeature !== nextFeature) {
+        hoveredFeature.setStyle(defaultMarkerStyle);
+      }
+
+      hoveredFeature = nextFeature;
+      map.getTargetElement().style.cursor = nextFeature ? "pointer" : "";
+
+      if (!nextFeature) {
+        tooltipOverlay.setPosition(undefined);
+        return;
+      }
+
+      nextFeature.setStyle(hoverMarkerStyle);
+      const geometry = nextFeature.getGeometry();
+      if (geometry instanceof Point) {
+        tooltipOverlay.setPosition(geometry.getCoordinates());
+      }
+
+      tooltipElement.textContent = `Dataset #${nextFeature.get("datasetId")} · ${nextFeature.get("biome")}`;
+    };
+
+    map.on("pointermove", handlePointerMove);
+
+    return () => {
+      map.un("pointermove", handlePointerMove);
+      map.setTarget(undefined);
+    };
+  }, [sites]);
+
+  return (
+    <div className="relative h-80 overflow-hidden rounded-2xl bg-[#eef3f0] shadow-xl ring-1 ring-black/5">
+      <div ref={mapElementRef} className="h-full w-full" />
+      <div
+        ref={tooltipElementRef}
+        className="pointer-events-none rounded-md bg-white/95 px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-black/10"
+      />
+    </div>
+  );
+}
+
+function ImageTile({ src, alt }: { src: string; alt: string }) {
+  return (
+    <div className="aspect-square overflow-hidden rounded-md bg-gray-100">
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        className="h-full w-full object-cover"
+      />
+    </div>
+  );
+}
+
+function PatchCard({
+  site,
+  patch,
+  onSelect,
+}: {
+  site: ReferenceDatasetSite;
+  patch: ReferencePatchImageSet;
+  onSelect: (selection: SelectedReferencePatch) => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="reference-patch-card"
+      data-resolution={`${patch.resolutionCm}`}
+      className="w-[190px] shrink-0 cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors duration-150 hover:border-[#1B5E35]/60 hover:bg-white"
+      aria-label={`Dataset ${site.id} ${patch.resolutionCm} cm ${patch.label}`}
+      onClick={() => onSelect({ site, patch })}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold uppercase text-gray-500">
+          {patch.label}
+        </span>
+        <Tag className="m-0">{patch.resolutionCm} cm</Tag>
+      </div>
+      <div>
+        <div className="mb-1 text-[11px] font-semibold uppercase text-gray-500">
+          RGB
+        </div>
+        <ImageTile
+          src={patch.rgb}
+          alt={`Dataset ${site.id} ${patch.label} RGB patch at ${patch.resolutionCm} cm`}
+        />
+      </div>
+      <div className="mt-3">
+        <div className="mb-1 text-[11px] font-semibold uppercase text-gray-500">
+          Ground truth
+        </div>
+        <GroundTruthMask
+          forestCoverSrc={patch.treeCoverMask}
+          deadwoodSrc={patch.mortalityMask}
+          alt={`Dataset ${site.id} ${patch.label} combined forest cover and deadwood ground truth mask at ${patch.resolutionCm} cm`}
+          size={160}
+          className="rounded-md"
+        />
+      </div>
+    </button>
+  );
+}
+
+function PatchModalViewer({
+  selection,
+  adminInfo,
+  mode,
+  onModeChange,
+  onClose,
+}: {
+  selection: SelectedReferencePatch | null;
+  adminInfo: ReferenceDatasetAdminInfo | undefined;
+  mode: PatchViewerMode;
+  onModeChange: (mode: PatchViewerMode) => void;
+  onClose: () => void;
+}) {
+  if (!selection) return null;
+
+  const { site, patch } = selection;
+  const location = formatDatasetLocationLabels(adminInfo, false);
+  const shortBiome = getShortBiome(site.biome);
+  const capturedDate = formatAcquisitionDate(adminInfo, false);
+  const subtitleParts = [
+    location.primary !== "Location unavailable" ? location.primary : null,
+    location.secondary,
+    shortBiome,
+    capturedDate !== "Unknown" ? capturedDate : null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <Modal
+      open
+      centered
+      width={920}
+      footer={null}
+      title={null}
+      onCancel={onClose}
+      destroyOnClose
+      aria-label={`Dataset ${site.id} ${patch.label} at ${patch.resolutionCm} cm`}
+    >
+      <div className="space-y-5">
+        <div className="-mt-1 pr-8">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-lg font-bold tabular-nums text-gray-950">
+              #{site.id}
+            </span>
+            <span className="text-gray-300" aria-hidden>
+              ·
+            </span>
+            <span className="text-lg font-semibold text-gray-800">
+              {patch.label}
+            </span>
+            <Tag color="green" className="m-0 ml-1">
+              {patch.resolutionCm} cm
+            </Tag>
+          </div>
+          {subtitleParts.length > 0 && (
+            <div className="mt-1 text-sm text-gray-500">
+              {subtitleParts.join(" · ")}
+            </div>
+          )}
+        </div>
+
+        <Segmented
+          block
+          value={mode}
+          options={[
+            { label: "RGB", value: "rgb" },
+            { label: "Overlay", value: "overlay" },
+            { label: "Mask", value: "mask" },
+          ]}
+          onChange={(value) => onModeChange(value as PatchViewerMode)}
+        />
+
+        <div
+          className="relative mx-auto aspect-square w-full overflow-hidden rounded-xl bg-gray-100 shadow-lg ring-1 ring-black/5"
+          style={{ maxWidth: "min(820px, calc(100vh - 260px))" }}
+        >
+          <img
+            src={patch.rgb}
+            alt={`Dataset ${site.id} ${patch.label} RGB patch at ${patch.resolutionCm} cm`}
+            className="h-full w-full object-cover"
+          />
+          <GroundTruthMask
+            forestCoverSrc={patch.treeCoverMask}
+            deadwoodSrc={patch.mortalityMask}
+            alt={`Dataset ${site.id} ${patch.label} forest cover and deadwood overlay at ${patch.resolutionCm} cm`}
+            mode="transparent"
+            opacity={0.55}
+            size={512}
+            className={`absolute inset-0 h-full w-full border-0 transition-opacity duration-150 ${
+              mode === "overlay" ? "opacity-100" : "opacity-0"
+            }`}
+          />
+          <div
+            className={`absolute inset-0 transition-opacity duration-150 ${
+              mode === "mask" ? "opacity-100" : "opacity-0"
+            }`}
+          >
+            <GroundTruthMask
+              forestCoverSrc={patch.treeCoverMask}
+              deadwoodSrc={patch.mortalityMask}
+              alt={`Dataset ${site.id} ${patch.label} ground truth mask at ${patch.resolutionCm} cm`}
+              size={512}
+              className="h-full w-full border-0"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-wide">
+            <span className="text-gray-500">Legend</span>
+            <span className="inline-flex items-center gap-1.5 rounded-md bg-[#BDBDBD]/25 px-2 py-1 text-gray-700">
+              <span
+                className="h-2.5 w-2.5 rounded-sm"
+                style={{ backgroundColor: GROUND_TRUTH_COLORS.background }}
+              />
+              Background
+            </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-white"
+              style={{ backgroundColor: GROUND_TRUTH_COLORS.forestCover }}
+            >
+              <span className="h-2.5 w-2.5 rounded-sm bg-white/90" />
+              Forest cover
+            </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-white"
+              style={{ backgroundColor: GROUND_TRUTH_COLORS.deadwood }}
+            >
+              <span className="h-2.5 w-2.5 rounded-sm bg-white/90" />
+              Deadwood
+            </span>
+          </div>
+          <Button
+            type="link"
+            size="small"
+            href={`/dataset/${site.id}`}
+            icon={<SelectOutlined />}
+            className="px-0 font-semibold text-[#1B5E35]"
+          >
+            Open dataset #{site.id}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+const galleryResolutionOptions: Array<{
+  label: string;
+  value: GalleryResolutionFilter;
+}> = [
+  { label: "All", value: "all" },
+  { label: "5", value: "5" },
+  { label: "10", value: "10" },
+  { label: "20", value: "20" },
+];
+
+function DatasetAdminCell({
+  site,
+  adminInfo,
+  isAdminInfoLoading,
+  resolutionFilter,
+  onResolutionChange,
+}: {
+  site: ReferenceDatasetSite;
+  adminInfo: ReferenceDatasetAdminInfo | undefined;
+  isAdminInfoLoading: boolean;
+  resolutionFilter: GalleryResolutionFilter;
+  onResolutionChange: (value: GalleryResolutionFilter) => void;
+}) {
+  const location = formatDatasetLocationLabels(adminInfo, isAdminInfoLoading);
+  const capturedDate = formatAcquisitionDate(adminInfo, isAdminInfoLoading);
+  const platform = formatPlatform(adminInfo?.platform, isAdminInfoLoading);
+  const shortBiome = getShortBiome(site.biome);
+  const authors = (adminInfo?.authors ?? []).filter((author): author is string =>
+    Boolean(author && author.trim().length > 0),
+  );
+  const authorsLabel = authors.length > 0 ? authors.join(", ") : null;
+
+  return (
+    <div className="sticky left-0 z-10 flex w-[200px] shrink-0 flex-col border-r border-gray-200 bg-white">
+      <div className="relative aspect-square w-full overflow-hidden bg-gray-100">
+        <img
+          src={makeThumbnailUrl(site)}
+          alt={`Dataset ${site.id} thumbnail`}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+        <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
+        <div className="absolute left-2 top-2 rounded-md bg-white/95 px-1.5 py-0.5 text-[11px] font-bold tabular-nums text-gray-900 shadow-sm">
+          #{site.id}
+        </div>
+        <div className="absolute bottom-2 left-2 right-2">
+          <span className="inline-flex max-w-full items-center rounded-md bg-white/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#1B5E35] shadow-sm">
+            <span className="truncate">{shortBiome}</span>
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col px-3 pb-3 pt-3">
+        <div>
+          <p
+            className="m-0 text-[13px] font-semibold leading-[18px] text-gray-950"
+            title={location.primary}
+          >
+            {location.primary}
+          </p>
+          {location.secondary && (
+            <p
+              className="m-0 mt-0.5 text-[11px] leading-[14px] text-gray-500"
+              title={location.secondary}
+            >
+              {location.secondary}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-2.5 space-y-1 text-[11px] leading-4 text-gray-700">
+          <div className="flex items-center gap-1.5">
+            <CalendarOutlined
+              aria-hidden
+              className="shrink-0 text-[12px] text-gray-400"
+            />
+            <span className="truncate font-medium">{capturedDate}</span>
+            <span aria-hidden className="text-gray-300">·</span>
+            <span className="truncate font-medium">{platform}</span>
+          </div>
+          {authorsLabel && (
+            <div className="flex items-start gap-1.5">
+              <TeamOutlined
+                aria-hidden
+                className="mt-[2px] shrink-0 text-[12px] text-gray-400"
+              />
+              <span
+                className="line-clamp-2 font-medium"
+                title={authorsLabel}
+              >
+                {authorsLabel}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500">
+            Resolution{" "}
+            <span className="font-normal text-gray-400">(cm)</span>
+          </div>
+          <Tooltip
+            title="Filter the entire gallery by patch resolution"
+            mouseEnterDelay={0.4}
+          >
+            <Segmented
+              block
+              size="small"
+              value={resolutionFilter}
+              options={galleryResolutionOptions}
+              onChange={(value) =>
+                onResolutionChange(value as GalleryResolutionFilter)
+              }
+              aria-label="Filter all dataset rows by patch resolution"
+            />
+          </Tooltip>
+
+          <Button
+            block
+            size="small"
+            className="mt-2"
+            href={`/dataset/${site.id}`}
+            icon={<SelectOutlined />}
+          >
+            Explore #{site.id}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DatasetPatchRow({
+  site,
+  resolutionFilter,
+  adminInfo,
+  isAdminInfoLoading,
+  onSelectPatch,
+  onScrollGallery,
+  onResolutionChange,
+}: {
+  site: ReferenceDatasetSite;
+  resolutionFilter: GalleryResolutionFilter;
+  adminInfo: ReferenceDatasetAdminInfo | undefined;
+  isAdminInfoLoading: boolean;
+  onSelectPatch: (selection: SelectedReferencePatch) => void;
+  onScrollGallery: (direction: -1 | 1) => void;
+  onResolutionChange: (value: GalleryResolutionFilter) => void;
+}) {
+  const patches = useMemo(
+    () =>
+      resolutionFilter === "all"
+        ? [
+            ...getReferencePatchGridImages(site, 20),
+            ...getReferencePatchGridImages(site, 10),
+            ...getReferencePatchGridImages(site, 5),
+          ]
+        : getReferencePatchGridImages(site, Number(resolutionFilter) as ReferencePatchResolution),
+    [resolutionFilter, site],
+  );
+
+  return (
+    <div className="group/row flex min-w-max">
+      <DatasetAdminCell
+        site={site}
+        adminInfo={adminInfo}
+        isAdminInfoLoading={isAdminInfoLoading}
+        resolutionFilter={resolutionFilter}
+        onResolutionChange={onResolutionChange}
+      />
+      <div className="relative flex gap-3 bg-[#eef3f0] p-4 transition-colors duration-150 group-hover/row:bg-[#e6ece8]">
+        <Tooltip title="Previous patches" mouseEnterDelay={0.3}>
+          <div className="pointer-events-none sticky left-[216px] z-20 flex w-0 shrink-0 items-center">
+            <Button
+              shape="circle"
+              size="large"
+              icon={<LeftOutlined />}
+              aria-label="Scroll gallery one patch left"
+              className="pointer-events-auto border-gray-200 bg-white/95 text-gray-700 opacity-85 shadow-sm transition group-hover/row:opacity-100 hover:border-[#1B5E35]/60 hover:text-[#1B5E35]"
+              onClick={() => onScrollGallery(-1)}
+            />
+          </div>
+        </Tooltip>
+        <Tooltip title="Next patches" mouseEnterDelay={0.3}>
+          <div className="pointer-events-none sticky left-[calc(100vw-104px)] z-20 flex w-0 shrink-0 items-center">
+            <Button
+              shape="circle"
+              size="large"
+              icon={<RightOutlined />}
+              aria-label="Scroll gallery one patch right"
+              className="pointer-events-auto border-gray-200 bg-white/95 text-gray-700 opacity-85 shadow-sm transition group-hover/row:opacity-100 hover:border-[#1B5E35]/60 hover:text-[#1B5E35]"
+              onClick={() => onScrollGallery(1)}
+            />
+          </div>
+        </Tooltip>
+        {patches.map((patch) => (
+          <PatchCard
+            key={`${site.id}-${patch.resolutionCm}-${patch.patchIndex}`}
+            site={site}
+            patch={patch}
+            onSelect={onSelectPatch}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DteAerialReferenceDataset() {
+  const [resolutionFilter, setResolutionFilter] = useState<GalleryResolutionFilter>("all");
+  const [sortKey, setSortKey] = useState<SortKey>("dataset");
+  const [selectedPatch, setSelectedPatch] = useState<SelectedReferencePatch | null>(null);
+  const [patchViewerMode, setPatchViewerMode] = useState<PatchViewerMode>("overlay");
+  const [, startResolutionTransition] = useTransition();
+  const galleryScrollRef = useRef<HTMLDivElement>(null);
+  const collection = dteAerialReferenceDataset;
+  const datasetIds = useMemo(() => collection.sites.map((site) => site.id), [collection.sites]);
+  const heroTagline = collection.title.startsWith(`${collection.name}: `)
+    ? collection.title.slice(collection.name.length + 2)
+    : collection.title;
+
+  const handleResolutionChange = useCallback((value: GalleryResolutionFilter) => {
+    startResolutionTransition(() => {
+      setResolutionFilter(value);
+    });
+  }, []);
+
+  const handleScrollGallery = useCallback((direction: -1 | 1) => {
+    const container = galleryScrollRef.current;
+    if (!container) return;
+    container.scrollBy({
+      left: direction * GALLERY_PATCH_STEP_PX,
+      behavior: "smooth",
+    });
+  }, []);
+
+  const handleSelectPatch = useCallback((selection: SelectedReferencePatch) => {
+    setSelectedPatch(selection);
+    setPatchViewerMode("overlay");
+  }, []);
+
+  const { data: adminInfoRows, isLoading: isAdminInfoLoading } = useQuery({
+    queryKey: ["reference-dataset-admin-info", collection.slug, datasetIds.join(",")],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(Settings.DATA_TABLE_PUBLIC)
+        .select(
+          "id, admin_level_1, admin_level_2, admin_level_3, aquisition_year, aquisition_month, aquisition_day, platform, authors",
+        )
+        .in("id", datasetIds);
+
+      if (error) throw error;
+      return (data ?? []) as ReferenceDatasetAdminInfo[];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const sortedSites = useMemo(
+    () => sortSites(collection.sites, sortKey),
+    [collection.sites, sortKey],
+  );
+
+  const adminInfoByDatasetId = useMemo(() => {
+    const rowsById = new Map<number, ReferenceDatasetAdminInfo>(
+      Object.entries(dteAerialReferenceDatasetAdminInfoById).map(([id, adminInfo]) => [
+        Number(id),
+        adminInfo,
+      ]),
+    );
+    adminInfoRows?.forEach((row) => rowsById.set(Number(row.id), row));
+    return rowsById;
+  }, [adminInfoRows]);
+
+  const biomeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    collection.sites.forEach((site) => {
+      counts.set(getShortBiome(site.biome), (counts.get(getShortBiome(site.biome)) ?? 0) + 1);
+    });
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  }, [collection.sites]);
+
+  return (
+    <main className="min-h-screen bg-[#f8faf9] pt-24 md:pt-32">
+      <PatchModalViewer
+        selection={selectedPatch}
+        adminInfo={selectedPatch ? adminInfoByDatasetId.get(selectedPatch.site.id) : undefined}
+        mode={patchViewerMode}
+        onModeChange={setPatchViewerMode}
+        onClose={() => setSelectedPatch(null)}
+      />
+      <section className="border-b border-gray-200/80 bg-white">
+        <div className="mx-auto grid max-w-7xl gap-10 px-4 py-16 md:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] md:gap-12 md:px-8 md:py-24">
+          <div>
+            <p className="m-0 text-sm font-semibold uppercase tracking-wider text-[#1B5E35] md:text-base">
+              Reference dataset · {collection.shortName}
+            </p>
+            <h1 className="m-0 mt-3 text-4xl font-semibold leading-[1.1] text-gray-950 md:text-5xl">
+              {collection.name}
+            </h1>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-600">
+              {heroTagline}
+            </p>
+            <div className="mt-5 flex flex-wrap items-center gap-2">
+              <Tag color="green" className="m-0">
+                Golden test set
+              </Tag>
+              <Tag className="m-0">Static v1</Tag>
+            </div>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button
+                type="primary"
+                size="large"
+                icon={<DownloadOutlined />}
+                href={collection.links.dataset}
+                className="min-h-11"
+              >
+                Download dataset
+              </Button>
+              <Button
+                size="large"
+                icon={<BookOutlined />}
+                href={collection.links.citation}
+                className="min-h-11"
+              >
+                Citation
+              </Button>
+              <Button
+                size="large"
+                icon={<FileTextOutlined />}
+                href={collection.links.croissant}
+                className="min-h-11"
+              >
+                Croissant metadata
+              </Button>
+              <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#1B5E35]">
+                Coming soon
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <WorldSiteMap sites={collection.sites} />
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-10 md:px-8 md:py-12">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-2">
+            {collection.stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-lg border border-gray-200 bg-white p-5"
+              >
+                <div className="text-2xl font-semibold text-[#1B5E35]">
+                  {stat.value}
+                </div>
+                <div className="mt-1 text-xs font-semibold uppercase text-gray-500">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-white p-5">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <GlobalOutlined />
+              Biome coverage
+            </div>
+            <div className="mt-4 space-y-2.5">
+              {biomeCounts.map(([biome, count]) => (
+                <div
+                  key={biome}
+                  className="grid grid-cols-[140px_minmax(0,1fr)_28px] items-center gap-3"
+                >
+                  <span
+                    className="truncate text-[13px] font-medium text-gray-700"
+                    title={biome}
+                  >
+                    {biome}
+                  </span>
+                  <span className="h-1.5 overflow-hidden rounded-full bg-gray-100">
+                    <span
+                      className="block h-full rounded-full bg-[#1B5E35]"
+                      style={{
+                        width: `${(count / collection.sites.length) * 100}%`,
+                      }}
+                    />
+                  </span>
+                  <span className="text-right text-[13px] font-semibold tabular-nums text-gray-800">
+                    {count}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-16">
+        <div className="mx-auto max-w-7xl px-4 md:px-8">
+          <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-[#1B5E35]">
+            <TableOutlined />
+            Dataset gallery
+          </div>
+          <h2 className="mt-2 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
+            Browse every benchmark patch
+          </h2>
+          <p className="mt-3 max-w-3xl text-base leading-7 text-gray-600">
+            {collection.stats[0].value} sites · {collection.stats[1].value} patches across 5, 10, and 20 cm resolutions.
+            Filter each row by resolution from its title cell, or change the dataset order below.
+          </p>
+
+          <div className="mt-6 mb-5 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm">
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Sort
+              </label>
+              <Select
+                size="middle"
+                className="min-w-[180px]"
+                value={sortKey}
+                options={sortOptions}
+                onChange={setSortKey}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-wide">
+              <span className="text-gray-500">Legend</span>
+              <span className="inline-flex items-center gap-1.5 rounded-md bg-[#BDBDBD]/25 px-2 py-1 text-gray-700">
+                <span
+                  className="h-2.5 w-2.5 rounded-sm"
+                  style={{ backgroundColor: GROUND_TRUTH_COLORS.background }}
+                />
+                Background
+              </span>
+              <span
+                className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-white"
+                style={{ backgroundColor: GROUND_TRUTH_COLORS.forestCover }}
+              >
+                <span className="h-2.5 w-2.5 rounded-sm bg-white/90" />
+                Forest cover
+              </span>
+              <span
+                className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-white"
+                style={{ backgroundColor: GROUND_TRUTH_COLORS.deadwood }}
+              >
+                <span className="h-2.5 w-2.5 rounded-sm bg-white/90" />
+                Deadwood
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          ref={galleryScrollRef}
+          className="reference-gallery-scroll overflow-x-auto border-y border-[#b9c4be] bg-[#eef3f0]"
+        >
+          <div className="min-w-max divide-y-2 divide-[#b9c4be]/60">
+            {sortedSites.map((site) => (
+              <DatasetPatchRow
+                key={site.id}
+                site={site}
+                resolutionFilter={resolutionFilter}
+                adminInfo={adminInfoByDatasetId.get(site.id)}
+                isAdminInfoLoading={isAdminInfoLoading}
+                onSelectPatch={handleSelectPatch}
+                onScrollGallery={handleScrollGallery}
+                onResolutionChange={handleResolutionChange}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-gray-200 bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-20">
+          <div className="mb-8 max-w-3xl">
+            <p className="m-0 text-sm font-semibold uppercase tracking-wider text-[#1B5E35]">
+              Release artifacts
+            </p>
+            <h2 className="m-0 mt-3 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
+              What you'll be able to download
+            </h2>
+            <p className="mt-3 text-base leading-7 text-gray-600">
+              The gallery above is the live preview of the dataset. The official release will bundle the patches with metadata, citation, and machine-readable schemas.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {[
+              {
+                icon: <DatabaseOutlined className="text-xl text-[#1B5E35]" />,
+                title: "Dataset package",
+                description:
+                  "RGB patches and reference masks at 5, 10, and 20 cm, packaged for Hugging Face and FreiData.",
+              },
+              {
+                icon: <BookOutlined className="text-xl text-[#1B5E35]" />,
+                title: "Citation",
+                description:
+                  "Paper citation, DOI, BibTeX entry, and per-site attribution following CC BY.",
+              },
+              {
+                icon: <FileTextOutlined className="text-xl text-[#1B5E35]" />,
+                title: "Croissant metadata",
+                description:
+                  "Machine-readable schema describing splits, fields, and responsible AI considerations.",
+              },
+            ].map((card) => (
+              <div
+                key={card.title}
+                className="flex flex-col rounded-2xl border border-gray-200 bg-white p-6 transition-shadow hover:shadow-sm"
+              >
+                <div className="flex items-center justify-between">
+                  {card.icon}
+                  <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#1B5E35]">
+                    Coming soon
+                  </span>
+                </div>
+                <h3 className="m-0 mt-4 text-lg font-semibold text-gray-950">
+                  {card.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-gray-600">
+                  {card.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/DteAerialReferenceDataset.tsx
+++ b/frontend/src/pages/DteAerialReferenceDataset.tsx
@@ -62,13 +62,16 @@ const sortOptions: Array<{ label: string; value: SortKey }> = [
   { label: "North to south", value: "north-south" },
 ];
 
-const getShortBiome = (biome: string) =>
-  biome
-    .replace("Tropical and Subtropical", "Tropical")
-    .replace("Mediterranean Forests, Woodlands, and Scrub", "Mediterranean")
-    .replace("Temperate Broadleaf and Mixed Forests", "Temperate broadleaf")
-    .replace("Temperate Coniferous Forests", "Temperate conifer")
-    .replace("Boreal Forests/Taiga", "Boreal");
+const getCoarseBiomeGroup = (biome: string) => {
+  const normalized = biome.toLowerCase();
+  if (normalized.includes("tropical")) return "(Sub)tropical";
+  if (normalized.includes("mediterranean")) return "Drylands";
+  if (normalized.includes("boreal") || normalized.includes("montane")) {
+    return "Boreal and montane";
+  }
+  if (normalized.includes("temperate")) return "Temperate";
+  return biome;
+};
 
 const makeThumbnailUrl = (site: ReferenceDatasetSite) =>
   `https://data2.deadtrees.earth/thumbnails/v1/${site.thumbnailPath}`;
@@ -142,7 +145,11 @@ const sortSites = (sites: ReferenceDatasetSite[], sortKey: SortKey) => {
   const sorted = [...sites];
 
   if (sortKey === "biome") {
-    return sorted.sort((a, b) => a.biome.localeCompare(b.biome) || a.id - b.id);
+    return sorted.sort(
+      (a, b) =>
+        getCoarseBiomeGroup(a.biome).localeCompare(getCoarseBiomeGroup(b.biome)) ||
+        a.id - b.id,
+    );
   }
 
   if (sortKey === "west-east") {
@@ -185,7 +192,7 @@ function WorldSiteMap({ sites }: { sites: ReferenceDatasetSite[] }) {
         const feature = new Feature({
           geometry: new Point(fromLonLat([site.center.lon, site.center.lat])),
           datasetId: site.id,
-          biome: getShortBiome(site.biome),
+          biome: getCoarseBiomeGroup(site.biome),
         });
         feature.setStyle(defaultMarkerStyle);
         return feature;
@@ -353,12 +360,12 @@ function PatchModalViewer({
 
   const { site, patch } = selection;
   const location = formatDatasetLocationLabels(adminInfo, false);
-  const shortBiome = getShortBiome(site.biome);
+  const coarseBiome = getCoarseBiomeGroup(site.biome);
   const capturedDate = formatAcquisitionDate(adminInfo, false);
   const subtitleParts = [
     location.primary !== "Location unavailable" ? location.primary : null,
     location.secondary,
-    shortBiome,
+    coarseBiome,
     capturedDate !== "Unknown" ? capturedDate : null,
   ].filter(Boolean) as string[];
 
@@ -508,7 +515,7 @@ function DatasetAdminCell({
   const location = formatDatasetLocationLabels(adminInfo, isAdminInfoLoading);
   const capturedDate = formatAcquisitionDate(adminInfo, isAdminInfoLoading);
   const platform = formatPlatform(adminInfo?.platform, isAdminInfoLoading);
-  const shortBiome = getShortBiome(site.biome);
+  const coarseBiome = getCoarseBiomeGroup(site.biome);
   const authors = (adminInfo?.authors ?? []).filter((author): author is string =>
     Boolean(author && author.trim().length > 0),
   );
@@ -529,7 +536,7 @@ function DatasetAdminCell({
         </div>
         <div className="absolute bottom-2 left-2 right-2">
           <span className="inline-flex max-w-full items-center rounded-md bg-white/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#1B5E35] shadow-sm">
-            <span className="truncate">{shortBiome}</span>
+            <span className="truncate">{coarseBiome}</span>
           </span>
         </div>
       </div>
@@ -758,7 +765,8 @@ export default function DteAerialReferenceDataset() {
   const biomeCounts = useMemo(() => {
     const counts = new Map<string, number>();
     collection.sites.forEach((site) => {
-      counts.set(getShortBiome(site.biome), (counts.get(getShortBiome(site.biome)) ?? 0) + 1);
+      const biomeGroup = getCoarseBiomeGroup(site.biome);
+      counts.set(biomeGroup, (counts.get(biomeGroup) ?? 0) + 1);
     });
     return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
   }, [collection.sites]);
@@ -830,7 +838,7 @@ export default function DteAerialReferenceDataset() {
           <div className="rounded-lg border border-gray-200 bg-white p-5">
             <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
               <GlobalOutlined />
-              Biome coverage
+              Coarse biome coverage
             </div>
             <div className="mt-4 space-y-2.5">
               {biomeCounts.map(([biome, count]) => (

--- a/frontend/src/pages/DteAerialReferenceDataset.tsx
+++ b/frontend/src/pages/DteAerialReferenceDataset.tsx
@@ -377,7 +377,7 @@ function PatchModalViewer({
         <div className="-mt-1 pr-8">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-lg font-bold tabular-nums text-gray-950">
-              #{site.id}
+              {site.id}
             </span>
             <span className="text-gray-300" aria-hidden>
               ·
@@ -474,7 +474,7 @@ function PatchModalViewer({
             icon={<SelectOutlined />}
             className="px-0 font-semibold text-[#1B5E35]"
           >
-            Open dataset #{site.id}
+            Open dataset {site.id}
           </Button>
         </div>
       </div>
@@ -606,7 +606,7 @@ function DatasetAdminCell({
             href={`/dataset/${site.id}`}
             icon={<SelectOutlined />}
           >
-            Explore #{site.id}
+            Open {site.id}
           </Button>
         </div>
       </div>

--- a/frontend/src/pages/DteAerialReferenceDataset.tsx
+++ b/frontend/src/pages/DteAerialReferenceDataset.tsx
@@ -525,7 +525,7 @@ function DatasetAdminCell({
         />
         <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
         <div className="absolute left-2 top-2 rounded-md bg-white/95 px-1.5 py-0.5 text-[11px] font-bold tabular-nums text-gray-900 shadow-sm">
-          #{site.id}
+          {site.id}
         </div>
         <div className="absolute bottom-2 left-2 right-2">
           <span className="inline-flex max-w-full items-center rounded-md bg-white/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#1B5E35] shadow-sm">

--- a/frontend/src/pages/DteAerialReferenceDataset.tsx
+++ b/frontend/src/pages/DteAerialReferenceDataset.tsx
@@ -1,9 +1,7 @@
 import {
-  BookOutlined,
   CalendarOutlined,
   DatabaseOutlined,
   DownloadOutlined,
-  FileTextOutlined,
   GlobalOutlined,
   LeftOutlined,
   RightOutlined,
@@ -802,25 +800,6 @@ export default function DteAerialReferenceDataset() {
               >
                 Download dataset
               </Button>
-              <Button
-                size="large"
-                icon={<BookOutlined />}
-                href={collection.links.citation}
-                className="min-h-11"
-              >
-                Citation
-              </Button>
-              <Button
-                size="large"
-                icon={<FileTextOutlined />}
-                href={collection.links.croissant}
-                className="min-h-11"
-              >
-                Croissant metadata
-              </Button>
-              <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#1B5E35]">
-                Coming soon
-              </span>
             </div>
           </div>
 
@@ -958,59 +937,30 @@ export default function DteAerialReferenceDataset() {
         </div>
       </section>
 
-      <section className="border-t border-gray-200 bg-white">
+      <section
+        id="dataset-download-placeholder"
+        className="border-t border-gray-200 bg-white"
+      >
         <div className="mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-20">
-          <div className="mb-8 max-w-3xl">
+          <div className="max-w-3xl">
             <p className="m-0 text-sm font-semibold uppercase tracking-wider text-[#1B5E35]">
               Release artifacts
             </p>
             <h2 className="m-0 mt-3 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
-              What you'll be able to download
+              Dataset package
             </h2>
             <p className="mt-3 text-base leading-7 text-gray-600">
-              The gallery above is the live preview of the dataset. The official release will bundle the patches with metadata, citation, and machine-readable schemas.
+              The gallery above is the live preview of the dataset. The final release link will point to the dataset package once the Hugging Face upload is available.
             </p>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-3">
-            {[
-              {
-                icon: <DatabaseOutlined className="text-xl text-[#1B5E35]" />,
-                title: "Dataset package",
-                description:
-                  "RGB patches and reference masks at 5, 10, and 20 cm, packaged for Hugging Face and FreiData.",
-              },
-              {
-                icon: <BookOutlined className="text-xl text-[#1B5E35]" />,
-                title: "Citation",
-                description:
-                  "Paper citation, DOI, BibTeX entry, and per-site attribution following CC BY.",
-              },
-              {
-                icon: <FileTextOutlined className="text-xl text-[#1B5E35]" />,
-                title: "Croissant metadata",
-                description:
-                  "Machine-readable schema describing splits, fields, and responsible AI considerations.",
-              },
-            ].map((card) => (
-              <div
-                key={card.title}
-                className="flex flex-col rounded-2xl border border-gray-200 bg-white p-6 transition-shadow hover:shadow-sm"
-              >
-                <div className="flex items-center justify-between">
-                  {card.icon}
-                  <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#1B5E35]">
-                    Coming soon
-                  </span>
-                </div>
-                <h3 className="m-0 mt-4 text-lg font-semibold text-gray-950">
-                  {card.title}
-                </h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">
-                  {card.description}
-                </p>
-              </div>
-            ))}
+            <Button
+              type="primary"
+              size="large"
+              icon={<DatabaseOutlined />}
+              href={collection.links.dataset}
+              className="mt-6 min-h-11"
+            >
+              Download dataset
+            </Button>
           </div>
         </div>
       </section>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Collapse } from "antd";
 
 import Hero from "../components/Home/Hero";
 import HowItWorks from "../components/Home/HowItWorks";
+import ReferenceDatasetsSection from "../components/Home/ReferenceDatasets";
 import PlatformFeatures from "../components/Home/PlatformFeatures";
 import GetInContact from "../components/Home/GetInContact";
 
@@ -194,6 +195,7 @@ export default function HomePage() {
     <div className="w-full bg-white">
       <Hero />
       <HowItWorks />
+      <ReferenceDatasetsSection />
       <PlatformFeatures />
       <GetInContact />
       <FAQ />

--- a/frontend/src/pages/ReferenceDatasets.tsx
+++ b/frontend/src/pages/ReferenceDatasets.tsx
@@ -1,0 +1,195 @@
+import { ArrowRightOutlined, DatabaseOutlined } from "@ant-design/icons";
+import { Button, Tag } from "antd";
+import { useNavigate } from "react-router-dom";
+
+import {
+  getReferencePatchImages,
+  referenceDatasetCollections,
+  type ReferenceDatasetCollection,
+  type ReferenceDatasetSite,
+} from "../data/referenceDatasets";
+import { GroundTruthMask } from "../components/ReferenceDatasets/GroundTruthMask";
+
+const FEATURED_PREVIEW_SITE_IDS = [375, 435, 1396, 4087, 5584, 6445];
+
+type PreviewMode = "rgb" | "mask";
+
+const PREVIEW_MODES: PreviewMode[] = ["rgb", "mask", "rgb", "mask", "rgb", "mask"];
+
+const pickPreviewSites = (
+  sites: ReferenceDatasetSite[],
+  preferredIds: number[],
+  count: number,
+): ReferenceDatasetSite[] => {
+  const byId = new Map(sites.map((site) => [site.id, site]));
+  const preferred = preferredIds
+    .map((id) => byId.get(id))
+    .filter((site): site is ReferenceDatasetSite => Boolean(site));
+  if (preferred.length >= count) return preferred.slice(0, count);
+  const rest = sites.filter((site) => !preferredIds.includes(site.id));
+  return [...preferred, ...rest].slice(0, count);
+};
+
+function FeaturedCollectionCard({
+  collection,
+  onOpen,
+}: {
+  collection: ReferenceDatasetCollection;
+  onOpen: () => void;
+}) {
+  const previewSites = pickPreviewSites(
+    collection.sites,
+    FEATURED_PREVIEW_SITE_IDS,
+    6,
+  );
+  const isAvailable = collection.status === "available";
+
+  return (
+    <article className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+      <div className="grid grid-cols-3 gap-px bg-gray-200 sm:grid-cols-6">
+        {previewSites.map((site, index) => {
+          const previewPatch = getReferencePatchImages(site, 20, 0);
+          const mode = PREVIEW_MODES[index % PREVIEW_MODES.length];
+          if (mode === "mask") {
+            return (
+              <GroundTruthMask
+                key={site.id}
+                forestCoverSrc={previewPatch.treeCoverMask}
+                deadwoodSrc={previewPatch.mortalityMask}
+                alt={`Reference mask from site ${site.id}`}
+                size={256}
+              />
+            );
+          }
+          return (
+            <div key={site.id} className="aspect-square bg-gray-100">
+              <img
+                src={previewPatch.rgb}
+                alt={`Benchmark patch from site ${site.id}`}
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-8 p-6 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] md:p-10">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Tag color={isAvailable ? "green" : "default"} className="m-0">
+              {isAvailable ? "Available" : "Coming soon"}
+            </Tag>
+            <Tag className="m-0">{collection.shortName}</Tag>
+            {isAvailable && <Tag className="m-0">Static v1</Tag>}
+          </div>
+
+          <h2 className="m-0 mt-5 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
+            {collection.name}
+          </h2>
+          <p className="mt-4 text-base leading-7 text-gray-600">
+            {collection.summary}
+          </p>
+
+          <div className="mt-7 flex flex-wrap items-center gap-3">
+            <Button
+              type="primary"
+              size="large"
+              icon={<DatabaseOutlined />}
+              onClick={onOpen}
+              className="min-h-11"
+              disabled={!isAvailable}
+            >
+              Open gallery
+            </Button>
+            <Button
+              type="link"
+              size="large"
+              icon={<ArrowRightOutlined />}
+              onClick={onOpen}
+              className="px-0 font-semibold text-[#1B5E35]"
+              disabled={!isAvailable}
+            >
+              See all {collection.sites.length} sites
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 self-start sm:grid-cols-2">
+          {collection.stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-lg border border-gray-100 bg-gray-50 p-4"
+            >
+              <div className="text-2xl font-semibold text-[#1B5E35]">
+                {stat.value}
+              </div>
+              <div className="mt-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function ReferenceDatasets() {
+  const navigate = useNavigate();
+  const featured = referenceDatasetCollections;
+
+  return (
+    <main className="min-h-screen bg-[#f8faf9] pt-24 md:pt-32">
+      <section className="border-b border-gray-200/80 bg-white">
+        <div className="mx-auto max-w-4xl px-4 py-16 text-center md:px-8 md:py-24">
+          <p className="m-0 text-sm font-semibold uppercase tracking-wider text-[#1B5E35] md:text-base">
+            Reference datasets
+          </p>
+          <h1 className="m-0 mt-3 text-4xl font-semibold leading-[1.1] text-gray-950 md:text-5xl">
+            Curated benchmark datasets from deadtrees.earth
+          </h1>
+          <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-600">
+            Stable dataset releases with gallery views, benchmark splits, reference masks,
+            metadata, and citation material for scientific reuse.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-12 md:px-8 md:py-16">
+        <div className="grid gap-6">
+          {featured.map((collection) => (
+            <FeaturedCollectionCard
+              key={collection.slug}
+              collection={collection}
+              onOpen={() =>
+                navigate(`/reference-datasets/${collection.slug}`)
+              }
+            />
+          ))}
+        </div>
+
+        <div className="mt-10 rounded-2xl border border-dashed border-gray-300 bg-white/60 px-6 py-8 text-center md:px-10">
+          <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#1B5E35]">
+            More coming
+          </span>
+          <h3 className="m-0 mt-4 text-lg font-semibold text-gray-900 md:text-xl">
+            Additional reference releases are in preparation
+          </h3>
+          <p className="mx-auto mt-2 max-w-2xl text-sm leading-6 text-gray-600">
+            New benchmark collections — including satellite-derived products and
+            extended aerial sites — will appear here as they are finalised. If
+            you have a dataset to contribute,{" "}
+            <a
+              href="mailto:info@deadtrees.earth?subject=Reference dataset contribution"
+              className="font-semibold text-[#1B5E35] underline"
+            >
+              get in touch
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/ReferenceDatasets.tsx
+++ b/frontend/src/pages/ReferenceDatasets.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightOutlined, DatabaseOutlined } from "@ant-design/icons";
+import { DatabaseOutlined } from "@ant-design/icons";
 import { Button, Tag } from "antd";
 import { useNavigate } from "react-router-dom";
 
@@ -100,17 +100,7 @@ function FeaturedCollectionCard({
               className="min-h-11"
               disabled={!isAvailable}
             >
-              Open gallery
-            </Button>
-            <Button
-              type="link"
-              size="large"
-              icon={<ArrowRightOutlined />}
-              onClick={onOpen}
-              className="px-0 font-semibold text-[#1B5E35]"
-              disabled={!isAvailable}
-            >
-              See all {collection.sites.length} sites
+              Open DTE-aerial
             </Button>
           </div>
         </div>

--- a/frontend/src/pages/ReferenceDatasets.tsx
+++ b/frontend/src/pages/ReferenceDatasets.tsx
@@ -100,7 +100,7 @@ function FeaturedCollectionCard({
               className="min-h-11"
               disabled={!isAvailable}
             >
-              Open DTE-aerial
+              Open DTE-aerial-bench
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add the `/reference-datasets` overview and `/reference-datasets/dte-aerial` detail page
- add the DTE-aerial reference dataset metadata, patch gallery, mask/RGB overlay modal, and map preview
- add navigation and gallery scrollbar affordances so the dataset rows and patch columns are discoverable

## Why
This gives the team a reviewable preview surface for the new reference dataset gallery before the final public dataset release links and copy are available.

## Notes
- dataset download/release links still use placeholders until the final artifacts are available
- the gallery uses static reference export URLs plus live public metadata enrichment when available

## Validation
- `npm --prefix frontend run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds sizable new UI pages with client-side image composition/caching and a new public Supabase metadata query, which could impact performance and reliability if endpoints/URLs change.
> 
> **Overview**
> Introduces a new **Reference Data** section with routes for `/reference-datasets` and `/reference-datasets/dte-aerial` (plus a legacy redirect), and links it from the main navigation.
> 
> Adds a DTE-aerial detail page that renders a sortable, horizontally scrollable patch gallery with an RGB/*mask overlay* modal viewer and an OpenLayers world map preview, backed by new static dataset metadata/helpers (`referenceDatasets.ts`) and a reusable `GroundTruthMask` component that composes two mask images into a single colored PNG (with lazy rendering + caching).
> 
> Tweaks global CSS to make the gallery’s 2-axis scrolling more discoverable via always-visible custom scrollbars (`.reference-gallery-scroll`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2593373b483df040d5538292fcc2de102e667e25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->