### PR TITLE
fix(frontend): remove benchmark route aliases

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
+import { Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { ConfigProvider, Layout } from "antd";
 import { useEffect } from "react";
 import { trackPageView, initializePostHog } from "./utils/analytics";
@@ -95,12 +95,6 @@ function RouteScrollRestoration() {
   return null;
 }
 
-function LegacyRedirect({ to }: { to: string }) {
-  const { search, hash } = useLocation();
-
-  return <Navigate to={`${to}${search}${hash}`} replace />;
-}
-
 // Create a separate component for tracking that uses hooks
 function AppWithTracking() {
   const location = useLocation();
@@ -154,38 +148,6 @@ function AppWithTracking() {
           <Route
             path="benchmark-datasets/dte-aerial-bench"
             element={<DteAerialBenchmarkDataset />}
-          />
-          <Route
-            path="benchmark-datasets/dte-aerial"
-            element={<LegacyRedirect to="/benchmark-datasets/dte-aerial-bench" />}
-          />
-          <Route
-            path="reference-datasets"
-            element={<LegacyRedirect to="/benchmark-datasets" />}
-          />
-          <Route
-            path="reference-datasets/dte-aerial-bench"
-            element={
-              <LegacyRedirect to="/benchmark-datasets/dte-aerial-bench" />
-            }
-          />
-          <Route
-            path="reference-datasets/dte-aerial"
-            element={
-              <LegacyRedirect to="/benchmark-datasets/dte-aerial-bench" />
-            }
-          />
-          <Route
-            path="DTE-aerial"
-            element={
-              <LegacyRedirect to="/benchmark-datasets/dte-aerial-bench" />
-            }
-          />
-          <Route
-            path="DTE-aerial-bench"
-            element={
-              <LegacyRedirect to="/benchmark-datasets/dte-aerial-bench" />
-            }
           />
           <Route path="about" element={<About />} />
           <Route path="impressum" element={<Impressum />} />


### PR DESCRIPTION
## Summary

- Removes the temporary benchmark route aliases and legacy reference-dataset redirects.
- Keeps only the canonical public benchmark routes: `/benchmark-datasets` and `/benchmark-datasets/dte-aerial-bench`.
- Removes the now-unused redirect helper from the app router.

## Validation

- `npm run build`
- `curl -I http://localhost:5173/benchmark-datasets`
- `curl -I http://localhost:5173/benchmark-datasets/dte-aerial-bench`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes several legacy redirect routes, so any bookmarks or external links to the old benchmark/reference-dataset paths will now 404 unless handled elsewhere.
> 
> **Overview**
> Removes temporary benchmark route aliases and the `LegacyRedirect` helper from `App.tsx`, leaving only the canonical public benchmark routes (`/benchmark-datasets` and `/benchmark-datasets/dte-aerial-bench`).
> 
> Cleans up routing imports by dropping `Navigate` now that the redirects are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f219d0a440f538de89ab2f4018dc9aed0c6e03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->