### PR TITLE
docs(agents): add Codex review guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,17 @@ the linked docs that match the task.
   path. Treat production database writes as off-limits unless the user explicitly authorizes
   a specific write.
 
+## Review guidelines
+
+- Prioritize concrete P0/P1 risks: correctness bugs, security regressions, data loss, broken authorization, production deployment hazards, and missing validation for high-risk changes.
+- Treat readability, maintainability, and testability as review concerns when they create concrete future risk: duplicated workflow logic, unclear ownership, hidden side effects, brittle coupling, hard-to-test flows, oversized unstructured functions, or confusing domain names.
+- For architecture-sensitive changes, check whether the PR spreads behavior across callers, weakens locality, or introduces shallow pass-through modules that make future changes harder to verify.
+- For changed interfaces, check that callers do not need to know hidden ordering, config, error modes, permission rules, storage details, or deployment assumptions that should stay behind one module interface.
+- For database, storage, deployment, or production-connected changes, require evidence of repo-approved validation and flag unsafe production assumptions.
+- For security, flag changes that weaken auth, authorization, RLS/policies, tenancy isolation, signed URL handling, upload validation, secret handling, logging of sensitive data, CORS/cookie/session controls, or privilege boundaries.
+- Treat credentials, bearer tokens, database URLs, private keys, raw production access notes, and PII in tracked files or logs as P1.
+- Do not flag subjective style preferences, formatting, or broad cleanup ideas unless they affect correctness, security, maintainability, or testability in the changed code.
+
 ## Git And PRs
 
 - Do not create draft PRs for this workspace. Open normal PRs when asked.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -31,6 +31,14 @@ frontend work.
   cross-cutting state.
 - Prefer `console.debug()` over `console.log()`.
 
+## Review guidelines
+
+- Apply the root review guidelines, especially for correctness, security, maintainability, and testability risks in changed frontend code.
+- Flag frontend changes that expose service-role keys, MCP tokens, SSH/VPN credentials, private API keys, or production-only values to browser code or tracked `frontend/.env*` files.
+- Flag auth, Supabase, React Query, upload, map, or COG-rendering changes that make permissions, cache invalidation, cancellation, cleanup, or error states hard to reason about or hard to test.
+- Treat large React components, duplicated data-fetching logic, unstable query keys, missing cleanup of OpenLayers resources, and hidden side effects as review issues when they create concrete regression risk.
+- Do not flag subjective UI style preferences unless they affect accessibility, data integrity, security, testability, or a documented product requirement.
+
 ## Query Keys
 
 Use stable tuple keys:


### PR DESCRIPTION
## Summary
- Add Codex PR review guidance to the root AGENTS.md.
- Add frontend-specific Codex review guidance to frontend/AGENTS.md.
- Focus reviews on P0/P1 correctness, security, production-safety, maintainability, and testability risks.

## Validation
- Ran `git diff --check`.
- Docs-only change; no runtime tests required.

## Risk
- Low. This only changes agent review instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is documentation-only and does not change runtime behavior. The main risk is process-related (review guidance changes) rather than functional regressions.
> 
> **Overview**
> Adds **Codex PR review guidelines** to `AGENTS.md`, focusing reviews on P0/P1 correctness, security, production-safety, and interface/architecture risk.
> 
> Adds a **frontend-specific review checklist** to `frontend/AGENTS.md`, emphasizing avoiding leaked secrets in browser/env files and highlighting risky areas like auth/Supabase/React Query, uploads, and OpenLayers cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee52070841aecab078c32ac2a926e7eb606c8dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->