### PR TITLE
fix(api): make failed requeue status reset reliable

### DIFF
--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Body
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel, Field
 
-from shared.db import verify_token, use_client, login
+from shared.db import verify_token, use_client, use_service_client, login
 from shared.settings import settings
 from shared.models import TaskPayload, QueueTask, TaskTypeEnum
 from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandler
@@ -34,6 +34,37 @@ _TASK_TYPE_STATUS_FLAGS = {
 
 def _task_type_to_status_flags(task_type: TaskTypeEnum) -> tuple[str, ...]:
 	return _TASK_TYPE_STATUS_FLAGS.get(task_type, ())
+
+
+def _failed_requeue_reset_fields(task_types: list[TaskTypeEnum]) -> dict:
+	reset_fields = {
+		'has_error': False,
+		'error_message': None,
+		'current_status': 'idle',
+	}
+	for task_type in task_types:
+		for flag in _task_type_to_status_flags(task_type):
+			reset_fields[flag] = False
+	return reset_fields
+
+
+def _reset_failed_status_for_requeue(service_client, dataset_id: int, task_types: list[TaskTypeEnum]) -> None:
+	reset_fields = _failed_requeue_reset_fields(task_types)
+	response = (
+		service_client.table(settings.statuses_table)
+		.update(reset_fields)
+		.eq('dataset_id', dataset_id)
+		.execute()
+	)
+	updated_rows = getattr(response, 'data', None) or []
+	if len(updated_rows) != 1:
+		raise HTTPException(
+			status_code=500,
+			detail=(
+				f'Failed to clear error state for dataset {dataset_id}: '
+				f'expected exactly one status row update, got {len(updated_rows)}.'
+			),
+		)
 
 
 class ProcessRequest(BaseModel):
@@ -94,7 +125,26 @@ def create_processing_task(
 		)
 		raise HTTPException(status_code=400, detail=f'Invalid task type: {str(e)}')
 
-	# Check if dataset is currently being processed and clean up old queue items
+	# Load the dataset info with the caller's token before any privileged write.
+	try:
+		with use_client(token) as client:
+			response = client.table(settings.datasets_table).select('*').eq('id', dataset_id).execute()
+			if not response.data:
+				logger.warning(
+					f'Dataset not found: {dataset_id}',
+					LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token),
+				)
+				raise HTTPException(status_code=404, detail=f'Dataset <ID={dataset_id}> not found.')
+	except HTTPException:
+		raise
+	except Exception as e:
+		msg = f'Error loading dataset {dataset_id}: {str(e)}'
+		logger.error(
+			msg, LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token)
+		)
+		raise HTTPException(status_code=500, detail=msg)
+
+	# Check if dataset is currently being processed and clean up old queue items.
 	try:
 		with use_client(token) as client:
 			# If the processor already picked up a task, block reruns.
@@ -135,16 +185,8 @@ def create_processing_task(
 					)
 
 				if s.get('has_error', False):
-					reset_fields = {
-						'has_error': False,
-						'error_message': None,
-						'current_status': 'idle',
-					}
-					for task_type in validated_task_types:
-						for flag in _task_type_to_status_flags(task_type):
-							reset_fields[flag] = False
-					with use_client() as service_client:
-						service_client.table(settings.statuses_table).update(reset_fields).eq('dataset_id', dataset_id).execute()
+					with use_service_client() as service_client:
+						_reset_failed_status_for_requeue(service_client, dataset_id, validated_task_types)
 					logger.info(
 						f'Cleared error state for dataset {dataset_id} (requeue)',
 						LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token),
@@ -171,25 +213,6 @@ def create_processing_task(
 		raise
 	except Exception as e:
 		msg = f'Error checking queue status for dataset {dataset_id}: {str(e)}'
-		logger.error(
-			msg, LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token)
-		)
-		raise HTTPException(status_code=500, detail=msg)
-
-	# Load the dataset info
-	try:
-		with use_client(token) as client:
-			response = client.table(settings.datasets_table).select('*').eq('id', dataset_id).execute()
-			if not response.data:
-				logger.warning(
-					f'Dataset not found: {dataset_id}',
-					LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token),
-				)
-				raise HTTPException(status_code=404, detail=f'Dataset <ID={dataset_id}> not found.')
-	except HTTPException:
-		raise
-	except Exception as e:
-		msg = f'Error loading dataset {dataset_id}: {str(e)}'
 		logger.error(
 			msg, LogContext(category=LogCategory.ADD_PROCESS, user_id=user.id, dataset_id=dataset_id, token=token)
 		)

--- a/api/tests/routers/test_process.py
+++ b/api/tests/routers/test_process.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
+
 import pytest
 from fastapi.testclient import TestClient
 
+import api.src.routers.process as process_router
 from api.src.server import app
 from api.src.routers.process import _task_type_to_status_flags
-from shared.db import use_client, login
+from shared.db import use_client, use_service_client, login
 from shared.settings import settings
 from shared.models import TaskTypeEnum, LicenseEnum, PlatformEnum, DatasetAccessEnum, StatusEnum
 
@@ -324,13 +327,16 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 	first_task_id = response.json()['id']
 
 	# Simulate failed processing: task exists but is_processing=False (simulating completion/failure)
-	with use_client(auth_token) as supabaseClient:
+	with use_service_client() as supabaseClient:
 		# Update status to indicate error
 		supabaseClient.table(settings.statuses_table).update(
 			{
 				'has_error': True,
 				'error_message': 'Simulated processing failure',
 				'current_status': StatusEnum.idle,
+				'is_cog_done': True,
+				'is_thumbnail_done': True,
+				'is_metadata_done': True,
 			}
 		).eq('dataset_id', test_dataset).execute()
 
@@ -355,10 +361,77 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 		assert response.data[0]['priority'] == 1
 		assert response.data[0]['is_processing'] is False
 
+		status_response = supabaseClient.table(settings.statuses_table).select('*').eq('dataset_id', test_dataset).execute()
+		status = status_response.data[0]
+		assert status['has_error'] is False
+		assert status['error_message'] is None
+		assert status['current_status'] == StatusEnum.idle
+		assert status['is_cog_done'] is False
+		assert status['is_thumbnail_done'] is False
+		assert status['is_metadata_done'] is False
+
+
+class _ZeroRowStatusUpdateClient:
+	def table(self, table_name):
+		self.table_name = table_name
+		return self
+
+	def update(self, fields):
+		self.fields = fields
+		return self
+
+	def eq(self, column, value):
+		self.column = column
+		self.value = value
+		return self
+
+	def execute(self):
+		return SimpleNamespace(data=[])
+
+
+class _FakeServiceClientContext:
+	def __enter__(self):
+		return _ZeroRowStatusUpdateClient()
+
+	def __exit__(self, exc_type, exc, traceback):
+		return False
+
+
+def test_failed_status_reset_zero_rows_does_not_enqueue(test_dataset, auth_token, monkeypatch):
+	"""If the error reset does not update one status row, the API must not enqueue."""
+	with use_service_client() as supabaseClient:
+		supabaseClient.table(settings.statuses_table).update(
+			{
+				'has_error': True,
+				'error_message': 'Simulated stale error',
+				'current_status': StatusEnum.idle,
+			}
+		).eq('dataset_id', test_dataset).execute()
+
+	monkeypatch.setattr(process_router, 'use_service_client', lambda: _FakeServiceClientContext())
+
+	response = client.put(
+		f'/datasets/{test_dataset}/process',
+		json={'task_types': ['cog']},
+		headers={'Authorization': f'Bearer {auth_token}'},
+	)
+
+	assert response.status_code == 500
+	assert 'expected exactly one status row update, got 0' in response.json()['detail']
+
+	with use_client(auth_token) as supabaseClient:
+		queue_response = supabaseClient.table(settings.queue_table).select('*').eq('dataset_id', test_dataset).execute()
+		assert queue_response.data == []
+
+		status_response = supabaseClient.table(settings.statuses_table).select('*').eq('dataset_id', test_dataset).execute()
+		status = status_response.data[0]
+		assert status['has_error'] is True
+		assert status['error_message'] == 'Simulated stale error'
+
 
 def test_rerun_combined_task_resets_only_combined_prediction_flag(test_dataset, auth_token):
 	"""Rerunning the combined model should not reset legacy model completion flags."""
-	with use_client() as supabaseClient:
+	with use_service_client() as supabaseClient:
 		supabaseClient.table(settings.statuses_table).update(
 			{
 				'has_error': True,

--- a/shared/db.py
+++ b/shared/db.py
@@ -133,6 +133,24 @@ def use_client(access_token: Optional[str] = None) -> Generator[Client, None, No
 
 
 @contextmanager
+def use_service_client() -> Generator[Client, None, None]:
+	"""Creates a Supabase service-role client for server-side privileged writes."""
+	if not settings.SUPABASE_SERVICE_ROLE_KEY:
+		raise ValueError('SUPABASE_SERVICE_ROLE_KEY is required for service-role database access')
+
+	client = create_client(
+		settings.SUPABASE_URL,
+		settings.SUPABASE_SERVICE_ROLE_KEY,
+		options=ClientOptions(auto_refresh_token=False),
+	)
+
+	try:
+		yield client
+	finally:
+		pass
+
+
+@contextmanager
 def use_anon_client(access_token: Optional[str] = None) -> Generator[Client, None, None]:
 	"""Creates a Supabase client that behaves like an anonymous/public caller."""
 	if not settings.SUPABASE_ANON_KEY:

--- a/shared/tests/test_db.py
+++ b/shared/tests/test_db.py
@@ -1,3 +1,5 @@
+import pytest
+
 import shared.db as db
 
 
@@ -41,3 +43,11 @@ def test_login_verified_returns_first_valid_token(monkeypatch):
 	assert attempts == [True]
 	assert token == 'cached-token'
 	assert user == {'id': 'processor-user'}
+
+
+def test_use_service_client_requires_service_role_key(monkeypatch):
+	monkeypatch.setattr(db.settings, 'SUPABASE_SERVICE_ROLE_KEY', '')
+
+	with pytest.raises(ValueError, match='SUPABASE_SERVICE_ROLE_KEY is required'):
+		with db.use_service_client():
+			pass


### PR DESCRIPTION
## Summary

Fixes DT-456 by making failed dataset requeue clear status through a verified server-side status reset before inserting a new queue row.

## Why

Production requeues could return HTTP 200 and enqueue work while `v2_statuses.has_error` and `error_message` stayed stale. The processor then removed those queue rows immediately because the dataset still looked failed.

## Changes

- Add an explicit Supabase service-role client helper for privileged API-side writes.
- Check dataset access with the caller token before any privileged status reset.
- Clear failed status only through the service client and require exactly one updated status row before enqueueing.
- Extend process-router tests for successful failed requeue and zero-row reset failure.

## Validation

- `venv/bin/python -m pytest shared/tests/test_db.py`
- `docker compose -f docker-compose.test.yaml exec api-test python -m pytest -v api/tests/routers/test_process.py`

## Risk

Low. The privileged write is still gated by the existing authenticated dataset lookup, and the endpoint now fails closed if the status reset cannot be verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces server-side service-role DB writes and changes the `/process` rerun path to fail with 500 if the status reset cannot be verified, which could impact requeue behavior and depends on correct service-role configuration.
> 
> **Overview**
> Reworks failed-dataset requeue in `PUT /datasets/{id}/process` to **clear stale error state via a service-role Supabase client** before enqueueing, after first verifying the dataset exists/accessible using the caller token.
> 
> The status reset is centralized (`_reset_failed_status_for_requeue`) and now **requires exactly one status row update**; otherwise the endpoint returns 500 and does not enqueue. Adds `use_service_client()` to `shared/db.py` and extends tests to assert flags are reset on successful requeue and that zero-row status updates fail closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8934c48a022dbeb2c75142067fa5a49a6e77bc1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->