### PR TITLE
docs(agents): clarify test command guidance

### DIFF
--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -41,17 +41,19 @@ processor or storage code.
 
 ## Testing
 
-Use the project CLI instead of direct container pytest:
+Use the project CLI for normal validation; reserve `deadtrees dev debug ...` for
+sessions where a debugger client will attach.
 
 ```bash
 source venv/bin/activate
 deadtrees dev test api
 deadtrees dev test processor
-deadtrees dev debug api --test-path=api/tests/routers/test_download.py
-deadtrees dev debug processor --test-path=processor/tests/test_process_cog.py
 ```
 
 Local work is good for API, shared-model, frontend, docs, and non-GPU checks.
+For targeted follow-up after the test stack is already running, direct
+container pytest is acceptable, for example
+`docker compose -f docker-compose.test.yaml exec api-test python -m pytest -v api/tests/routers/test_process.py`.
 Run large processor/model validations on the processing-server dev checkout only
 when explicitly needed and approved.
 
@@ -129,6 +131,8 @@ Known production gotchas:
 
 - PR titles must be Conventional Commit style and pass the title check.
 - Do not prefix PR titles with agent markers such as `[codex]`.
+- If a GitHub publishing skill suggests draft PRs or `[codex]` title prefixes,
+  follow these repo rules instead: open normal PRs and use Conventional Commit titles.
 - Use area labels such as `frontend`, `api`, `database`, `processing`, `ci`, or
   `docs` where available for release-note grouping.
 


### PR DESCRIPTION
## Summary

Clarifies the agent testing guidance after the DT-456 follow-up work.

## Why

During validation, `deadtrees dev debug ...` waited for a debugger client even though the goal was normal test execution. This update makes the normal validation path explicit and reserves debug commands for sessions that actually attach a debugger.

## Changes

- Keep the normal three-step test flow focused on activating the venv plus `deadtrees dev test api` and `deadtrees dev test processor`.
- Note that targeted container pytest is acceptable after the test stack is already running.
- Record that repo GitHub rules override generic publishing-skill defaults such as draft PRs or `[codex]` title prefixes.

## Validation

- `git diff --check`

## Risk

Docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only updates that clarify how to run tests and open PRs, with no runtime or deployment impact.
> 
> **Overview**
> Updates `docs/agents/rules.md` to **explicitly distinguish normal test validation** (`deadtrees dev test ...`) from `deadtrees dev debug ...` usage (only when attaching a debugger), and documents when *direct container `pytest`* is acceptable for targeted follow-ups.
> 
> Also adds a GitHub rule note that repo conventions (normal PRs, Conventional Commit titles, no `[codex]` prefixes) override generic publishing-skill defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ade7c3d7e684c5395105fb7fc99d08bec8097fea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->