### PR TITLE
fix(frontend): bust DTE aerial benchmark asset cache

### DIFF
--- a/frontend/src/components/Releases/DteAerialReleaseGallery.tsx
+++ b/frontend/src/components/Releases/DteAerialReleaseGallery.tsx
@@ -246,7 +246,7 @@ function PatchModalViewer({
       footer={null}
       title={null}
       onCancel={onClose}
-      destroyOnHidden
+      destroyOnClose
       aria-label={`Dataset ${site.id} ${patch.label} at ${patch.resolutionCm} cm`}
     >
       <div className="space-y-5">

--- a/frontend/src/data/releases.ts
+++ b/frontend/src/data/releases.ts
@@ -8,6 +8,7 @@ export interface DteAerialSite {
   citationUrl: string | null;
   thumbnailPath: string;
   exportSeed: string;
+  assetVersion?: string;
   center: {
     lon: number;
     lat: number;
@@ -410,6 +411,9 @@ const makeDteAerialPatchBase = (
   return `${dataset.id}_${row}_${column}_5cm`;
 };
 
+const withDteAerialAssetVersion = (url: string, dataset: DteAerialSite) =>
+  `${url}?v=${encodeURIComponent(dataset.assetVersion ?? dataset.exportSeed)}`;
+
 export const getDteAerialPatchImages = (
   dataset: DteAerialSite,
   resolutionCm: DteAerialPatchResolution,
@@ -422,9 +426,15 @@ export const getDteAerialPatchImages = (
     resolutionCm,
     patchIndex,
     label: `Patch ${patchIndex + 1}`,
-    rgb: `${folder}/${base}.png`,
-    treeCoverMask: `${folder}/${base}_forestcover_ref.png`,
-    mortalityMask: `${folder}/${base}_deadwood_ref.png`,
+    rgb: withDteAerialAssetVersion(`${folder}/${base}.png`, dataset),
+    treeCoverMask: withDteAerialAssetVersion(
+      `${folder}/${base}_forestcover_ref.png`,
+      dataset,
+    ),
+    mortalityMask: withDteAerialAssetVersion(
+      `${folder}/${base}_deadwood_ref.png`,
+      dataset,
+    ),
   };
 };
 
@@ -732,6 +742,7 @@ export const dteAerialRelease: DteAerialRelease = {
       citationUrl: "https://data.geonadir.com/image-collection-details/3066",
       thumbnailPath: "1b0d5cff-a5fa-4a97-9af0-e6baeddd4b99/4471_thumbnail.jpg",
       exportSeed: "1768211503784",
+      assetVersion: "2026-05-05T11-48-31Z",
       center: { lon: 173.66067, lat: -41.57676 },
       patchCount: 21,
     },


### PR DESCRIPTION
## Summary
- Add a per-site asset version to DTE aerial release image URLs so refreshed benchmark PNGs bypass existing browser caches.
- Bump dataset 4471 to the timestamp of the refreshed reference export.
- Use the supported Ant Design `destroyOnClose` prop so the release gallery builds against the installed dependency version.

## Why
Dataset 4471 reference exports were refreshed on storage, but existing browsers could keep rendering stale PNGs because the storage server serves those files with long-lived immutable cache headers and unchanged filenames.

## Validation
- `npm run build`

## Risk
Low. The change only alters DTE aerial release image URLs by adding a version query parameter; the underlying storage paths remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes benchmark image URLs by adding a version query param and swaps an Ant Design modal prop; no backend, auth, or data writes involved.
> 
> **Overview**
> Adds an optional per-site `assetVersion` and appends `?v=` (falling back to `exportSeed`) to all DTE aerial benchmark patch image/mask URLs via `getDteAerialPatchImages`, ensuring refreshed reference exports bypass long-lived browser caches.
> 
> Updates site `4471` with a new `assetVersion` timestamp and changes the patch viewer modal to use Ant Design’s supported `destroyOnClose` prop (replacing `destroyOnHidden`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fefabde64eaa97cfee749a838c18350d201b835. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->