### PR TITLE
fix(export): remove stale reference patch artifacts

### DIFF
--- a/api/src/export/export_reference_patches.py
+++ b/api/src/export/export_reference_patches.py
@@ -38,6 +38,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 import os
+import re
 
 import geopandas as gpd
 import numpy as np
@@ -343,6 +344,111 @@ def build_filename_base(patch: dict) -> str:
 	tile_id = patch_index.split('_')[-2:] if '_' in patch_index else [patch_index]
 	tile_id = '_'.join(tile_id) if len(tile_id) > 1 else tile_id[0]
 	return f'{dataset_id}_{tile_id}_{resolution_cm}cm'
+
+
+def get_export_base_resolution(filename_base: str) -> Optional[int]:
+	"""Extract the patch resolution from a generated export filename base."""
+	match = re.search(r'_(5|10|20)cm$', filename_base)
+	return int(match.group(1)) if match else None
+
+
+def get_raster_filename_base(path: Path) -> str:
+	"""Return the patch filename base for raster image/mask files."""
+	base = path.stem
+	for suffix in ('_deadwood_ref', '_forestcover_ref'):
+		if base.endswith(suffix):
+			return base[: -len(suffix)]
+	return base
+
+
+def get_metadata_filename_base(path: Path) -> tuple[str, bool]:
+	"""Return the patch filename base and whether this is vector metadata."""
+	base = path.stem
+	if base.endswith('_vector'):
+		return base[: -len('_vector')], True
+	return base, False
+
+
+def should_cleanup_export_base(filename_base: str, expected_bases: set[str], resolution_cm: Optional[int]) -> bool:
+	"""Return whether a generated patch export is outside the current DB patch set."""
+	if resolution_cm is not None and get_export_base_resolution(filename_base) != resolution_cm:
+		return False
+	return filename_base not in expected_bases
+
+
+def cleanup_removed_patch_exports(
+	output_base_dir: Path,
+	patches: list[dict],
+	reference_dataset_ids: list[int],
+	dataset_id: Optional[int] = None,
+	resolution_cm: Optional[int] = None,
+) -> int:
+	"""Remove export artifacts for patches that no longer exist in reference_patches.
+
+	This complements cleanup_removed_datasets: if a reference patch is replaced, the
+	dataset stays active, but old PNG/GeoTIFF/metadata/GeoPackage files must not
+	remain visible in the public export directory.
+	"""
+	if not output_base_dir.exists():
+		return 0
+
+	expected_raster_bases: dict[int, set[str]] = {}
+	for patch in patches:
+		expected_raster_bases.setdefault(patch['dataset_id'], set()).add(build_filename_base(patch))
+
+	vector_candidates = get_vector_export_candidates(patches, resolution_cm=resolution_cm)
+	expected_vector_bases: dict[int, set[str]] = {}
+	for patch in vector_candidates:
+		expected_vector_bases.setdefault(patch['dataset_id'], set()).add(build_filename_base(patch))
+
+	target_dataset_ids = [dataset_id] if dataset_id is not None else reference_dataset_ids
+	removed_count = 0
+
+	for target_dataset_id in target_dataset_ids:
+		dataset_output_dir = output_base_dir / str(target_dataset_id)
+		if not dataset_output_dir.exists():
+			continue
+
+		dataset_raster_bases = expected_raster_bases.get(target_dataset_id, set())
+		dataset_vector_bases = expected_vector_bases.get(target_dataset_id, set())
+
+		for subdir_name in ('geotiff', 'png'):
+			subdir = dataset_output_dir / subdir_name
+			if not subdir.exists():
+				continue
+			for path in subdir.iterdir():
+				if not path.is_file() or path.suffix.lower() not in {'.tif', '.png'}:
+					continue
+				filename_base = get_raster_filename_base(path)
+				if should_cleanup_export_base(filename_base, dataset_raster_bases, resolution_cm):
+					path.unlink()
+					removed_count += 1
+
+		metadata_dir = dataset_output_dir / 'metadata'
+		if metadata_dir.exists():
+			for path in metadata_dir.iterdir():
+				if not path.is_file() or path.suffix.lower() != '.json':
+					continue
+				filename_base, is_vector_metadata = get_metadata_filename_base(path)
+				expected_bases = dataset_vector_bases if is_vector_metadata else dataset_raster_bases
+				if should_cleanup_export_base(filename_base, expected_bases, resolution_cm):
+					path.unlink()
+					removed_count += 1
+
+		gpkg_dir = dataset_output_dir / 'gpkg'
+		if gpkg_dir.exists():
+			for path in gpkg_dir.iterdir():
+				if not path.is_file() or path.suffix.lower() != '.gpkg':
+					continue
+				filename_base = path.stem
+				if should_cleanup_export_base(filename_base, dataset_vector_bases, resolution_cm):
+					path.unlink()
+					removed_count += 1
+
+	if removed_count > 0:
+		print(f'✓ Cleaned up {removed_count} stale patch export file(s)\n')
+
+	return removed_count
 
 
 def patch_has_deadwood_reference(patch: dict) -> bool:
@@ -1075,6 +1181,15 @@ def main():
 	if not patches:
 		print('✓ No new patches to export')
 		return 0
+
+	print('🗑️  Checking for removed patch exports...')
+	cleanup_removed_patch_exports(
+		output_base_dir,
+		patches,
+		reference_dataset_ids,
+		dataset_id=args.dataset_id,
+		resolution_cm=args.resolution,
+	)
 
 	# Pre-filter patches that actually need export. This keeps no-change cron runs
 	# compact and avoids printing the full dataset breakdown every time.

--- a/api/src/export/export_reference_patches.py
+++ b/api/src/export/export_reference_patches.py
@@ -107,7 +107,7 @@ def fetch_validated_patches(
 	resolution_cm: Optional[int] = None,
 	deadwood_only: bool = False,
 	forest_cover_only: bool = False,
-) -> list[dict]:
+) -> Optional[list[dict]]:
 	"""Fetch validated patches from reference_patches table.
 
 	By default, fetches patches where EITHER deadwood_validated OR forest_cover_validated is true.
@@ -221,7 +221,7 @@ def fetch_validated_patches(
 			return patches
 	except Exception as e:
 		print(f'❌ Error fetching patches: {e}')
-		return []
+		return None
 
 
 def fetch_cog_info(token: str, dataset_id: int) -> Optional[dict]:
@@ -1178,7 +1178,20 @@ def main():
 		forest_cover_only=False,
 	)
 
+	if patches is None:
+		print('❌ Could not fetch validated patches; skipping stale export cleanup')
+		return 1
+
 	if not patches:
+		if args.dataset_id is not None or args.resolution is not None:
+			print('🗑️  Checking for removed patch exports...')
+			cleanup_removed_patch_exports(
+				output_base_dir,
+				patches,
+				reference_dataset_ids,
+				dataset_id=args.dataset_id,
+				resolution_cm=args.resolution,
+			)
 		print('✓ No new patches to export')
 		return 0
 

--- a/api/tests/test_export_reference_patches.py
+++ b/api/tests/test_export_reference_patches.py
@@ -213,6 +213,114 @@ def test_vector_export_needs_export_checks_gpkg_and_metadata(tmp_path):
 	assert export_module.vector_export_needs_export(output_dir, filename_base, patch_updated_at) is False
 
 
+def test_cleanup_removed_patch_exports_removes_stale_replaced_patch_files(tmp_path):
+	dataset_dir = tmp_path / '3251'
+	for subdir in ('geotiff', 'png', 'metadata', 'gpkg'):
+		(dataset_dir / subdir).mkdir(parents=True)
+
+	current_root = make_patch(
+		1,
+		'20_1776848107785',
+		dataset_id=3251,
+		deadwood_validated=True,
+		forest_cover_validated=True,
+	)
+	current_child = make_patch(
+		2,
+		'1776848107785_0',
+		dataset_id=3251,
+		resolution_cm=10,
+		parent_tile_id=1,
+		deadwood_validated=True,
+		forest_cover_validated=True,
+	)
+	current_leaf = make_patch(
+		3,
+		'0_0',
+		dataset_id=3251,
+		resolution_cm=5,
+		parent_tile_id=2,
+		deadwood_validated=True,
+		forest_cover_validated=True,
+	)
+	patches = [current_root, current_child, current_leaf]
+
+	current_bases = [export_module.build_filename_base(patch) for patch in patches]
+	stale_bases = [
+		'3251_20_1761645491783_20cm',
+		'3251_1761645491783_0_10cm',
+	]
+
+	for filename_base in current_bases + stale_bases:
+		(dataset_dir / 'geotiff' / f'{filename_base}.tif').write_text('rgb')
+		(dataset_dir / 'geotiff' / f'{filename_base}_deadwood_ref.tif').write_text('deadwood')
+		(dataset_dir / 'geotiff' / f'{filename_base}_forestcover_ref.tif').write_text('forest')
+		(dataset_dir / 'png' / f'{filename_base}.png').write_text('rgb')
+		(dataset_dir / 'png' / f'{filename_base}_deadwood_ref.png').write_text('deadwood')
+		(dataset_dir / 'png' / f'{filename_base}_forestcover_ref.png').write_text('forest')
+		(dataset_dir / 'metadata' / f'{filename_base}.json').write_text('{}')
+
+	for filename_base in [current_bases[0], stale_bases[0]]:
+		(dataset_dir / 'gpkg' / f'{filename_base}.gpkg').write_text('gpkg')
+		(dataset_dir / 'metadata' / f'{filename_base}_vector.json').write_text('{}')
+
+	(dataset_dir / 'metadata' / 'README.txt').write_text('leave me alone')
+
+	removed_count = export_module.cleanup_removed_patch_exports(
+		tmp_path,
+		patches,
+		reference_dataset_ids=[3251],
+	)
+
+	assert removed_count == 16
+	for filename_base in current_bases:
+		assert (dataset_dir / 'geotiff' / f'{filename_base}.tif').exists()
+		assert (dataset_dir / 'png' / f'{filename_base}.png').exists()
+		assert (dataset_dir / 'metadata' / f'{filename_base}.json').exists()
+	assert (dataset_dir / 'gpkg' / f'{current_bases[0]}.gpkg').exists()
+	assert (dataset_dir / 'metadata' / f'{current_bases[0]}_vector.json').exists()
+	assert (dataset_dir / 'metadata' / 'README.txt').exists()
+
+	for filename_base in stale_bases:
+		assert not (dataset_dir / 'geotiff' / f'{filename_base}.tif').exists()
+		assert not (dataset_dir / 'png' / f'{filename_base}.png').exists()
+		assert not (dataset_dir / 'metadata' / f'{filename_base}.json').exists()
+	assert not (dataset_dir / 'gpkg' / f'{stale_bases[0]}.gpkg').exists()
+	assert not (dataset_dir / 'metadata' / f'{stale_bases[0]}_vector.json').exists()
+
+
+def test_cleanup_removed_patch_exports_respects_resolution_filter(tmp_path):
+	dataset_dir = tmp_path / '3251'
+	for subdir in ('geotiff', 'png', 'metadata'):
+		(dataset_dir / subdir).mkdir(parents=True)
+
+	current_5cm = make_patch(
+		1,
+		'0_0',
+		dataset_id=3251,
+		resolution_cm=5,
+		deadwood_validated=True,
+	)
+	stale_5cm_base = '3251_0_1_5cm'
+	stale_10cm_base = '3251_1761645491783_0_10cm'
+
+	for filename_base in [export_module.build_filename_base(current_5cm), stale_5cm_base, stale_10cm_base]:
+		(dataset_dir / 'geotiff' / f'{filename_base}.tif').write_text('rgb')
+		(dataset_dir / 'png' / f'{filename_base}.png').write_text('rgb')
+		(dataset_dir / 'metadata' / f'{filename_base}.json').write_text('{}')
+
+	removed_count = export_module.cleanup_removed_patch_exports(
+		tmp_path,
+		[current_5cm],
+		reference_dataset_ids=[3251],
+		resolution_cm=5,
+	)
+
+	assert removed_count == 3
+	assert not (dataset_dir / 'geotiff' / f'{stale_5cm_base}.tif').exists()
+	assert (dataset_dir / 'geotiff' / f'{stale_10cm_base}.tif').exists()
+
+
 def test_fetch_latest_reference_geometry_created_at_uses_latest_geometry_table_timestamp(monkeypatch):
 	tables = {
 		'reference_patch_deadwood_geometries': [

--- a/api/tests/test_export_reference_patches.py
+++ b/api/tests/test_export_reference_patches.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -319,6 +320,44 @@ def test_cleanup_removed_patch_exports_respects_resolution_filter(tmp_path):
 	assert removed_count == 3
 	assert not (dataset_dir / 'geotiff' / f'{stale_5cm_base}.tif').exists()
 	assert (dataset_dir / 'geotiff' / f'{stale_10cm_base}.tif').exists()
+
+
+def test_main_runs_scoped_stale_cleanup_when_no_validated_patches(monkeypatch, tmp_path):
+	cleanup_calls = []
+
+	monkeypatch.setattr(sys, 'argv', ['export_reference_patches.py', '--output-dir', str(tmp_path), '--dataset-id', '3251'])
+	monkeypatch.setattr(export_module, 'login', lambda _user, _password: 'token')
+	monkeypatch.setattr(export_module, 'fetch_reference_datasets', lambda _token: [3251])
+	monkeypatch.setattr(export_module, 'fetch_validated_patches', lambda *_args, **_kwargs: [])
+	monkeypatch.setattr(export_module, 'cleanup_removed_datasets', lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(
+		export_module,
+		'cleanup_removed_patch_exports',
+		lambda *args, **kwargs: cleanup_calls.append((args, kwargs)) or 0,
+	)
+
+	assert export_module.main() == 0
+	assert len(cleanup_calls) == 1
+	assert cleanup_calls[0][0][1] == []
+	assert cleanup_calls[0][1] == {'dataset_id': 3251, 'resolution_cm': None}
+
+
+def test_main_skips_stale_cleanup_when_patch_fetch_fails(monkeypatch, tmp_path):
+	cleanup_calls = []
+
+	monkeypatch.setattr(sys, 'argv', ['export_reference_patches.py', '--output-dir', str(tmp_path), '--dataset-id', '3251'])
+	monkeypatch.setattr(export_module, 'login', lambda _user, _password: 'token')
+	monkeypatch.setattr(export_module, 'fetch_reference_datasets', lambda _token: [3251])
+	monkeypatch.setattr(export_module, 'fetch_validated_patches', lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(export_module, 'cleanup_removed_datasets', lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(
+		export_module,
+		'cleanup_removed_patch_exports',
+		lambda *args, **kwargs: cleanup_calls.append((args, kwargs)) or 0,
+	)
+
+	assert export_module.main() == 1
+	assert cleanup_calls == []
 
 
 def test_fetch_latest_reference_geometry_created_at_uses_latest_geometry_table_timestamp(monkeypatch):

--- a/docs/playbooks/dataset-debugging.md
+++ b/docs/playbooks/dataset-debugging.md
@@ -74,28 +74,22 @@ Remember: ortho file size values are MB, not bytes.
 
 ## Reference Export Checks
 
-For user reports about reference/training tile counts, stale public reference
-downloads, or files under `/reference/{uuid}/{dataset_id}/...`, compare the
-database patch set with the public export artifacts before changing data.
-
-Count current validated patches in production:
+For reference/training tile count reports under
+`/reference/{uuid}/{dataset_id}/...`, compare current DB patches with public
+export artifacts before changing data:
 
 ```sql
 select
 	resolution_cm,
 	count(*) as total,
 	count(*) filter (where parent_tile_id is null) as roots,
-	count(*) filter (where parent_tile_id is not null) as children,
-	count(*) filter (where deadwood_validated is true) as deadwood_validated,
-	count(*) filter (where forest_cover_validated is true) as forest_cover_validated,
 	max(updated_at) as max_updated_at
 from reference_patches
 where dataset_id = :dataset_id
+  and (deadwood_validated is true or forest_cover_validated is true)
 group by resolution_cm
 order by resolution_cm desc;
 ```
-
-Then compare against the public export directory listing:
 
 ```bash
 curl -fsSL "https://data2.deadtrees.earth/reference/${REFERENCE_EXPORT_UUID}/${DATASET_ID}/metadata/" \
@@ -103,11 +97,9 @@ curl -fsSL "https://data2.deadtrees.earth/reference/${REFERENCE_EXPORT_UUID}/${D
   | sort
 ```
 
-If the database count is correct but public files are higher, suspect stale
-export artifacts rather than duplicate database rows. The reference exporter is
-responsible for deleting generated patch files that no longer correspond to
-current `reference_patches` rows; do not manually delete production files unless
-the user explicitly approves that intervention.
+If DB counts are correct but public files are higher, suspect stale generated
+export artifacts. Do not manually delete production files without explicit user
+approval.
 
 ## Queue
 

--- a/docs/playbooks/dataset-debugging.md
+++ b/docs/playbooks/dataset-debugging.md
@@ -72,6 +72,43 @@ where dataset_id = :dataset_id;
 
 Remember: ortho file size values are MB, not bytes.
 
+## Reference Export Checks
+
+For user reports about reference/training tile counts, stale public reference
+downloads, or files under `/reference/{uuid}/{dataset_id}/...`, compare the
+database patch set with the public export artifacts before changing data.
+
+Count current validated patches in production:
+
+```sql
+select
+	resolution_cm,
+	count(*) as total,
+	count(*) filter (where parent_tile_id is null) as roots,
+	count(*) filter (where parent_tile_id is not null) as children,
+	count(*) filter (where deadwood_validated is true) as deadwood_validated,
+	count(*) filter (where forest_cover_validated is true) as forest_cover_validated,
+	max(updated_at) as max_updated_at
+from reference_patches
+where dataset_id = :dataset_id
+group by resolution_cm
+order by resolution_cm desc;
+```
+
+Then compare against the public export directory listing:
+
+```bash
+curl -fsSL "https://data2.deadtrees.earth/reference/${REFERENCE_EXPORT_UUID}/${DATASET_ID}/metadata/" \
+  | sed -n 's/.*href="\([^"]*_[0-9][0-9]*cm\.json\)".*/\1/p' \
+  | sort
+```
+
+If the database count is correct but public files are higher, suspect stale
+export artifacts rather than duplicate database rows. The reference exporter is
+responsible for deleting generated patch files that no longer correspond to
+current `reference_patches` rows; do not manually delete production files unless
+the user explicitly approves that intervention.
+
 ## Queue
 
 ```sql


### PR DESCRIPTION
## What changed
- Add cleanup for stale reference patch export artifacts inside active reference datasets.
- Remove obsolete raster, mask, metadata, and root GeoPackage files when their filename base no longer matches current `reference_patches` rows.
- Cover the dataset 3251 replacement case and scoped resolution cleanup with regression tests.
- Add dataset-debugging playbook guidance for comparing production `reference_patches` counts with public reference export listings.

## Why
Dataset 3251 had 21 current validated patches in production, but the public export still listed 26 because old patch files remained after a root patch was replaced. The existing exporter only cleaned up datasets removed from `reference_datasets`, not stale patch files within still-active datasets.

## Validation
- `venv/bin/python -m py_compile api/src/export/export_reference_patches.py api/tests/test_export_reference_patches.py`
- `venv/bin/deadtrees dev test api api/tests/test_export_reference_patches.py` -> 13 passed
- `git diff --check`

## Risk
The cleanup is limited to generated files in `geotiff`, `png`, `metadata`, and `gpkg` under reference export dataset directories. It respects `--dataset-id` and `--resolution`; production export files will not change until the exporter is deployed and run.