### PR TITLE
fix(frontend): align reference patch assets and geometry

### DIFF
--- a/frontend/src/components/MLTiles/MLTileMap.tsx
+++ b/frontend/src/components/MLTiles/MLTileMap.tsx
@@ -29,6 +29,7 @@ import {
 import { Settings } from "../../config";
 import { createOpenFreeMapLibertyLayerGroup } from "../../utils/basemaps";
 import { palette } from "../../theme/palette";
+import { polygonToBBox } from "../../utils/utm";
 
 interface Props {
   datasetId: number;
@@ -310,7 +311,7 @@ export default function MLTileMap({
       updateTileGeometry({
         tileId,
         geometry: gjCorrected,
-        bbox: polygonToBBoxShort(gjCorrected),
+        bbox: polygonToBBox(gjCorrected),
         aoiCoveragePercent: placementValidation.overlapPercent ? Math.round(placementValidation.overlapPercent) : null,
       });
       // Use tilesRef.current to access the latest tiles array
@@ -667,11 +668,4 @@ function enforceTileDimensions(geometry: Polygon, resolution: TileResolution): P
       [cx - half, cy - half],
     ],
   ]);
-}
-
-function polygonToBBoxShort(geometry: GeoJSON.Polygon): { minx: number; miny: number; maxx: number; maxy: number } {
-  const coords = geometry.coordinates[0];
-  const [minx, miny] = coords[0];
-  const [maxx, maxy] = coords[2];
-  return { minx, miny, maxx, maxy };
 }

--- a/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchEditorView.tsx
@@ -8,6 +8,7 @@ import {
   useUpdatePatchStatus,
   useUpdatePatchLayerValidation,
   useDeleteReferencePatch,
+  useUpdatePatchGeometry,
 } from "../../hooks/useReferencePatches";
 import { useSaveReferenceGeometries } from "../../hooks/useReferenceGeometries";
 import { clipGeometriesInBatches } from "../../hooks/useReferenceGeometriesBatch";
@@ -70,6 +71,7 @@ export default function ReferencePatchEditorView({
   const { mutateAsync: updateStatus } = useUpdatePatchStatus();
   const { mutateAsync: updateLayerValidation } = useUpdatePatchLayerValidation();
   const { mutateAsync: deletePatch } = useDeleteReferencePatch();
+  const { mutateAsync: updatePatchGeometry } = useUpdatePatchGeometry();
   const { mutateAsync: saveGeometries } = useSaveReferenceGeometries();
 
   // Initialize editor hooks (only when map is ready)
@@ -157,10 +159,7 @@ export default function ReferencePatchEditorView({
     async (parentPatch: IReferencePatch) => {
       const { createUtmSquare, getTargetGroundSize } = await import("../../utils/utm");
 
-      const parentGeom = parentPatch.geometry;
-      const parentCoords = parentGeom.coordinates[0];
-      const [minx, miny] = parentCoords[0];
-      const [maxx, maxy] = parentCoords[2];
+      const { bbox_minx: minx, bbox_miny: miny, bbox_maxx: maxx, bbox_maxy: maxy } = parentPatch;
       const centerX = (minx + maxx) / 2;
       const centerY = (miny + maxy) / 2;
       const halfWidth = (maxx - minx) / 2;
@@ -641,8 +640,31 @@ export default function ReferencePatchEditorView({
           }
         }
 
-        const patchToGenerate =
-          geometryToUse !== basePatch.geometry ? { ...basePatch, geometry: geometryToUse } : basePatch;
+        const { polygonToBBox } = await import("../../utils/utm");
+        const bboxToUse = polygonToBBox(geometryToUse);
+        const bboxChanged =
+          Math.abs(bboxToUse.minx - basePatch.bbox_minx) > 0.001 ||
+          Math.abs(bboxToUse.miny - basePatch.bbox_miny) > 0.001 ||
+          Math.abs(bboxToUse.maxx - basePatch.bbox_maxx) > 0.001 ||
+          Math.abs(bboxToUse.maxy - basePatch.bbox_maxy) > 0.001;
+
+        const patchWithCurrentGeometry: IReferencePatch = {
+          ...basePatch,
+          geometry: geometryToUse,
+          bbox_minx: bboxToUse.minx,
+          bbox_miny: bboxToUse.miny,
+          bbox_maxx: bboxToUse.maxx,
+          bbox_maxy: bboxToUse.maxy,
+        };
+
+        const patchToGenerate = bboxChanged
+          ? await updatePatchGeometry({
+              patchId: basePatch.id,
+              geometry: geometryToUse,
+              bbox: bboxToUse,
+              aoiCoveragePercent: basePatch.aoi_coverage_percent,
+            })
+          : patchWithCurrentGeometry;
 
         // Step 1: Auto-copy model predictions as v1 reference data
         await autoCopyPredictionsAsReference(patchToGenerate);
@@ -688,6 +710,7 @@ export default function ReferencePatchEditorView({
       allPatches,
       getPatchGeometryFromMap,
       autoCopyPredictionsAsReference,
+      updatePatchGeometry,
       refetchPatches,
     ],
   );

--- a/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
@@ -37,6 +37,7 @@ import {
   webMercatorToUtm,
   createUtmSquare,
   getTargetGroundSize,
+  polygonToBBox,
 } from "../../utils/utm";
 import { createOpenFreeMapLibertyLayerGroup } from "../../utils/basemaps";
 import { palette } from "../../theme/palette";
@@ -337,7 +338,7 @@ export default function ReferencePatchMap({
       updatePatchGeometry({
         patchId,
         geometry: gjCorrectedUtm,
-        bbox: polygonToBBoxShort(gjCorrectedUtm),
+        bbox: polygonToBBox(gjCorrectedUtm),
         aoiCoveragePercent: placementValidation.overlapPercent ? Math.round(placementValidation.overlapPercent) : null,
       });
       // Use patchesRef.current to access the latest patches array
@@ -1037,11 +1038,4 @@ function enforcePatchDimensions(geometry: Polygon, resolution: PatchResolution, 
   // Convert to OpenLayers Polygon
   const coords = webMercatorGeoJsonGeom.coordinates[0];
   return new Polygon([coords]);
-}
-
-function polygonToBBoxShort(geometry: GeoJSON.Polygon): { minx: number; miny: number; maxx: number; maxy: number } {
-  const coords = geometry.coordinates[0];
-  const [minx, miny] = coords[0];
-  const [maxx, maxy] = coords[2];
-  return { minx, miny, maxx, maxy };
 }

--- a/frontend/src/data/releases.test.ts
+++ b/frontend/src/data/releases.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { dteAerialRelease, getDteAerialPatchImages } from "./releases";
+
+describe("DTE aerial release assets", () => {
+  it("uses the current dataset 3251 reference export seed", () => {
+    const dataset3251 = dteAerialRelease.dteAerial.sites.find(
+      (site) => site.id === 3251,
+    );
+
+    expect(dataset3251).toBeDefined();
+    expect(dataset3251?.exportSeed).toBe("1776848107785");
+    expect(dataset3251?.patchCount).toBe(21);
+
+    const patch20cm = getDteAerialPatchImages(dataset3251!, 20);
+    const patch10cm = getDteAerialPatchImages(dataset3251!, 10, 0);
+
+    expect(patch20cm.rgb).toContain("/3251/png/3251_20_1776848107785_20cm.png");
+    expect(patch10cm.rgb).toContain("/3251/png/3251_1776848107785_0_10cm.png");
+  });
+});

--- a/frontend/src/data/releases.ts
+++ b/frontend/src/data/releases.ts
@@ -652,9 +652,9 @@ export const dteAerialRelease: DteAerialRelease = {
       license: "CC BY",
       citationUrl: null,
       thumbnailPath: "9be88d59-2140-4e7a-aae5-45aa01ef40d7/3251_thumbnail.jpg",
-      exportSeed: "1761645491783",
+      exportSeed: "1776848107785",
       center: { lon: 98.08785, lat: 3.96959 },
-      patchCount: 26,
+      patchCount: 21,
     },
     {
       id: 3341,

--- a/frontend/src/utils/utm.test.ts
+++ b/frontend/src/utils/utm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createUtmSquare, polygonToBBox } from "./utm";
+
+describe("UTM geometry helpers", () => {
+  it("calculates a bbox from all polygon coordinates", () => {
+    expect(polygonToBBox(createUtmSquare(1000, 2000, 200))).toEqual({
+      minx: 900,
+      miny: 1900,
+      maxx: 1100,
+      maxy: 2100,
+    });
+  });
+
+  it("does not depend on the first and third coordinates being bbox corners", () => {
+    const geometry: GeoJSON.Polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [10, 10],
+          [0, 20],
+          [5, 5],
+          [20, 0],
+          [10, 10],
+        ],
+      ],
+    };
+
+    expect(polygonToBBox(geometry)).toEqual({
+      minx: 0,
+      miny: 0,
+      maxx: 20,
+      maxy: 20,
+    });
+  });
+});

--- a/frontend/src/utils/utm.ts
+++ b/frontend/src/utils/utm.ts
@@ -154,6 +154,23 @@ export function createUtmSquare(centerX: number, centerY: number, sizeMeters: nu
   };
 }
 
+export function polygonToBBox(geometry: GeoJSON.Polygon): { minx: number; miny: number; maxx: number; maxy: number } {
+  const coords = geometry.coordinates[0] ?? [];
+  if (coords.length === 0) {
+    throw new Error("Cannot calculate bbox for polygon without coordinates");
+  }
+
+  const xs = coords.map(([x]) => x);
+  const ys = coords.map(([, y]) => y);
+
+  return {
+    minx: Math.min(...xs),
+    miny: Math.min(...ys),
+    maxx: Math.max(...xs),
+    maxy: Math.max(...ys),
+  };
+}
+
 /**
  * Transform a GeoJSON Polygon from UTM to Web Mercator
  * @param polygon GeoJSON Polygon in UTM coordinates


### PR DESCRIPTION
## What changed

- Point dataset 3251 in the public DTE aerial benchmark catalog at the current reference export seed and 21-patch count.
- Persist a moved 20 cm reference patch before generating its 10 cm and 5 cm child patches, so future editor-generated families do not split into stale parent geometry and moved children.
- Share a bbox helper for UTM polygons and add regression coverage for bbox calculation and dataset 3251 benchmark asset paths.

## Why

Dataset 3251 had been reworked in the reference editor, but the public benchmark catalog still referenced the old seed. After stale export artifacts were correctly cleaned up, the frontend tried to load old 20 cm and 10 cm PNG paths. Separately, existing production data showed that moved base patches could leave the root bbox stale while children were generated from the moved geometry.

The existing production rows for benchmark datasets 3251 and 6445 were repaired separately: only their 20 cm root patch rows were aligned to the union of their 10 cm children, then both datasets were force re-exported.

## Validation

- Local review of the staged diff: no blocking findings.
- `git diff --check`
- `npm run test -- src/data/releases.test.ts src/utils/utm.test.ts`
- `npx eslint src/components/ReferencePatches/ReferencePatchEditorView.tsx src/components/ReferencePatches/ReferencePatchMap.tsx src/data/releases.ts src/data/releases.test.ts src/utils/utm.ts src/utils/utm.test.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `npm run build`
- Live asset probes returned 200 for current dataset 3251 20 cm, 3251 10 cm, and 6445 20 cm PNGs.
- Production DB check returned zero parent/child bbox mismatches for benchmark datasets 3251 and 6445 after the separate repair.

## Risk

Low frontend risk. This changes one public benchmark catalog entry and makes reference patch generation persist the current base geometry before child creation. The production data repair was intentionally limited to two root patch rows; child patches and annotation geometries were not moved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reference patch generation/translation flows and persists geometry+bbox updates to the DB, so incorrect bbox calculations or mutation timing could affect downstream patch creation and asset alignment. Scope is limited to frontend logic plus a single benchmark catalog entry and added regression tests.
> 
> **Overview**
> **Fixes reference patch geometry drift during child patch generation.** When generating 10cm/5cm sub-patches, the editor now computes the current UTM bbox from the (possibly moved) base geometry and **persists geometry+bbox via `useUpdatePatchGeometry` before creating children**, preventing families from splitting into stale parents and moved children.
> 
> **Standardizes bbox computation.** Adds a shared `polygonToBBox` helper in `utm.ts` (using all polygon coordinates) and switches the map translation flow to use it, removing an ad-hoc bbox helper.
> 
> **Updates public benchmark metadata + adds regression tests.** Dataset `3251` in `releases.ts` now points to the new `exportSeed` and `patchCount`, with new Vitest coverage for dataset 3251 asset paths and `polygonToBBox` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3792439f37193e79d07d2aceeafe42d767ee22c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->