### PR TITLE
fix(processor): simplify combined forest cover geometries

### DIFF
--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -18,6 +18,7 @@ from processor.src.utils.segmentation import (
     mask_to_polygons,
     reproject_polygons,
 )
+from processor.src.utils.geometry_validation import count_polygon_points, simplify_polygons_preserving_topology
 
 CHECKPOINT_NAME = 'mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors'
 
@@ -27,6 +28,9 @@ CLASS_TREECOVER = 1
 CLASS_DEADWOOD = 2
 
 MINIMUM_INFERENCE_RESOLUTION = 0.05  # metres — match deadwood_v1
+# Keep simplification below one 5 cm inference pixel so boundaries are reduced
+# without allowing a whole-pixel displacement.
+FOREST_COVER_SIMPLIFICATION_TOLERANCE_M = 0.04
 BATCH_SIZE = 2
 NUM_DATALOADER_WORKERS = 0
 MINIMUM_POLYGON_AREA = 0.1  # m²
@@ -78,6 +82,7 @@ class CombinedInference:
         torch.set_float32_matmul_precision('high')
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model = self._load_model(model_path)
+        self.simplification_stats = {}
 
     def _load_model(self, model_path: str) -> SegformerForSemanticSegmentation:
         # Checkpoint was saved from a wrapper class (self.model = ...), so all
@@ -97,6 +102,7 @@ class CombinedInference:
     def inference(self, input_tif: str) -> tuple[list, list]:
         """Run inference on a GeoTIFF and return (deadwood_polygons, treecover_polygons)
         in the CRS of the input file."""
+        self.simplification_stats = {}
         vrt_src = image_reprojector(input_tif, min_res=MINIMUM_INFERENCE_RESOLUTION)
         dataset = InferenceDataset(
             image_src=vrt_src,
@@ -184,13 +190,45 @@ class CombinedInference:
             deadwood_mask, dataset.image_src, src_crs, orig_crs
         )
         treecover_polygons = self._mask_to_filtered_polygons(
-            treecover_mask, dataset.image_src, src_crs, orig_crs
+            treecover_mask,
+            dataset.image_src,
+            src_crs,
+            orig_crs,
+            simplification_tolerance=FOREST_COVER_SIMPLIFICATION_TOLERANCE_M,
+            stats_key='forest_cover',
         )
 
         return deadwood_polygons, treecover_polygons
 
-    def _mask_to_filtered_polygons(self, mask, image_src, inference_crs, orig_crs):
+    def _mask_to_filtered_polygons(
+        self,
+        mask,
+        image_src,
+        inference_crs,
+        orig_crs,
+        simplification_tolerance: float | None = None,
+        stats_key: str | None = None,
+    ):
         polygons = mask_to_polygons(mask, image_src)
+        if simplification_tolerance is not None:
+            points_before = count_polygon_points(polygons)
+            polygons = simplify_polygons_preserving_topology(polygons, simplification_tolerance)
+            points_after = count_polygon_points(polygons)
+
+            if stats_key:
+                self.simplification_stats[stats_key] = {
+                    'tolerance_m': simplification_tolerance,
+                    'simplification_crs': inference_crs.to_string()
+                    if hasattr(inference_crs, 'to_string')
+                    else str(inference_crs),
+                    'polygons': len(polygons),
+                    'points_before': points_before,
+                    'points_after': points_after,
+                }
+
+            if len(polygons) == 0:
+                return []
+
         polygons = filter_polygons_by_area(polygons, MINIMUM_POLYGON_AREA)
         polygons = reproject_polygons(polygons, inference_crs, orig_crs)
         return polygons

--- a/processor/src/deadwood_treecover_combined_v2/predict_combined.py
+++ b/processor/src/deadwood_treecover_combined_v2/predict_combined.py
@@ -32,6 +32,8 @@ def predict_combined(dataset_id: int, file_path: Path, user_id: str, token: str)
 
         log('Running combined inference', file_path=str(file_path))
         deadwood_polygons, treecover_polygons = model.inference(str(file_path))
+        if forest_cover_stats := model.simplification_stats.get('forest_cover'):
+            log('Applied topology-preserving forest cover simplification during inference', **forest_cover_stats)
 
         with rasterio.open(str(file_path)) as src:
             src_crs = src.crs

--- a/processor/src/utils/crs.py
+++ b/processor/src/utils/crs.py
@@ -1,0 +1,18 @@
+try:
+	import utm
+except ImportError:  # pragma: no cover - local CLI test env does not install processor extras
+	utm = None
+
+
+def get_utm_string_from_latlon(lat, lon):
+	if utm:
+		zone_number = utm.from_latlon(lat, lon)[2]
+	else:
+		zone_number = int((lon + 180.0) // 6.0) + 1
+		zone_number = min(max(zone_number, 1), 60)
+
+	utm_code = 32600 + zone_number
+	if lat < 0:
+		utm_code += 100
+
+	return f'EPSG:{utm_code}'

--- a/processor/src/utils/geometry_validation.py
+++ b/processor/src/utils/geometry_validation.py
@@ -10,10 +10,55 @@ Geometries can become invalid due to:
 These utilities should be called AFTER all reprojections but BEFORE saving to database.
 """
 
+try:
+	from shapely import get_num_coordinates
+except ImportError:  # pragma: no cover - Shapely < 2 fallback
+	get_num_coordinates = None
 from shapely.geometry import Polygon, MultiPolygon
 from shapely.validation import explain_validity
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
+
+
+def _as_polygons(geometry: Polygon | MultiPolygon) -> list[Polygon]:
+	if isinstance(geometry, Polygon):
+		return [geometry]
+	if isinstance(geometry, MultiPolygon):
+		return list(geometry.geoms)
+	return []
+
+
+def count_polygon_points(polygons: list[Polygon | MultiPolygon]) -> int:
+	"""Count exterior and interior ring vertices across polygons."""
+	total = 0
+	for geometry in polygons:
+		if geometry is None or geometry.is_empty:
+			continue
+		if get_num_coordinates is not None:
+			total += get_num_coordinates(geometry)
+			continue
+		for polygon in _as_polygons(geometry):
+			total += len(polygon.exterior.coords) + sum(len(ring.coords) for ring in polygon.interiors)
+	return total
+
+
+def simplify_polygons_preserving_topology(polygons: list[Polygon | MultiPolygon], tolerance: float) -> list[Polygon]:
+	"""Simplify polygons with topology preservation and discard empty results."""
+	if tolerance <= 0:
+		return [polygon for geometry in polygons for polygon in _as_polygons(geometry)]
+
+	simplified = []
+	for geometry in polygons:
+		if geometry is None or geometry.is_empty:
+			continue
+
+		simplified_geometry = geometry.simplify(tolerance, preserve_topology=True)
+		if simplified_geometry.is_empty:
+			continue
+
+		simplified.extend(_as_polygons(simplified_geometry))
+
+	return simplified
 
 
 def validate_and_fix_polygon(polygon: Polygon, min_area: float = 0.0) -> Polygon | None:

--- a/processor/src/utils/segmentation.py
+++ b/processor/src/utils/segmentation.py
@@ -6,19 +6,11 @@ import numpy as np
 import rasterio
 import rasterio.warp
 import shapely
-import utm
 from rasterio.vrt import WarpedVRT
 from shapely.affinity import affine_transform
 from shapely.geometry import Polygon
 
-
-def get_utm_string_from_latlon(lat, lon):
-	zone = utm.from_latlon(lat, lon)
-	utm_code = 32600 + zone[2]
-	if lat < 0:
-		utm_code -= 100
-
-	return f'EPSG:{utm_code}'
+from .crs import get_utm_string_from_latlon
 
 
 def merge_polygons(contours, hierarchy):

--- a/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_simplification.py
+++ b/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_simplification.py
@@ -1,0 +1,67 @@
+import pytest
+from rasterio.crs import CRS
+from shapely.geometry import Point
+
+pytest.importorskip('safetensors')
+pytest.importorskip('torch')
+pytest.importorskip('torchvision')
+pytest.importorskip('transformers')
+
+from processor.src.deadwood_treecover_combined_v2.inference import combined_inference
+from processor.src.deadwood_treecover_combined_v2.inference.combined_inference import CombinedInference
+from processor.src.utils.geometry_validation import count_polygon_points
+
+
+def test_forest_cover_simplification_runs_before_reproject(monkeypatch):
+	polygon = Point(0, 0).buffer(10, resolution=128)
+	inference_crs = CRS.from_epsg(32634)
+	orig_crs = CRS.from_epsg(4326)
+	reproject_call = {}
+	events = []
+	original_simplify = combined_inference.simplify_polygons_preserving_topology
+
+	monkeypatch.setattr(combined_inference, 'mask_to_polygons', lambda mask, image_src: [polygon])
+
+	def fake_simplify(polygons, tolerance):
+		events.append('simplify')
+		return original_simplify(polygons, tolerance)
+
+	def fake_filter(polygons, min_area):
+		events.append('filter')
+		return polygons
+
+	monkeypatch.setattr(combined_inference, 'simplify_polygons_preserving_topology', fake_simplify)
+	monkeypatch.setattr(combined_inference, 'filter_polygons_by_area', fake_filter)
+
+	def fake_reproject_polygons(polygons, src_crs, dst_crs):
+		reproject_call['src_crs'] = src_crs
+		reproject_call['dst_crs'] = dst_crs
+		reproject_call['points'] = count_polygon_points(polygons)
+		return polygons
+
+	monkeypatch.setattr(combined_inference, 'reproject_polygons', fake_reproject_polygons)
+
+	inference = CombinedInference.__new__(CombinedInference)
+	inference.simplification_stats = {}
+
+	result = inference._mask_to_filtered_polygons(
+		mask=None,
+		image_src=object(),
+		inference_crs=inference_crs,
+		orig_crs=orig_crs,
+		simplification_tolerance=0.04,
+		stats_key='forest_cover',
+	)
+
+	assert result
+	assert events == ['simplify', 'filter']
+	assert reproject_call['src_crs'] == inference_crs
+	assert reproject_call['dst_crs'] == orig_crs
+	assert reproject_call['points'] < count_polygon_points([polygon])
+	assert inference.simplification_stats['forest_cover'] == {
+		'tolerance_m': 0.04,
+		'simplification_crs': 'EPSG:32634',
+		'polygons': 1,
+		'points_before': count_polygon_points([polygon]),
+		'points_after': reproject_call['points'],
+	}

--- a/processor/tests/utils/test_geometry_simplification.py
+++ b/processor/tests/utils/test_geometry_simplification.py
@@ -1,0 +1,39 @@
+import pytest
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+from processor.src.utils.geometry_validation import count_polygon_points, simplify_polygons_preserving_topology
+
+
+def test_simplify_polygons_preserving_topology_reduces_vertices():
+	polygon = Point(0, 0).buffer(10, resolution=128)
+	points_before = count_polygon_points([polygon])
+
+	simplified = simplify_polygons_preserving_topology([polygon], tolerance=0.05)
+
+	assert len(simplified) == 1
+	assert simplified[0].is_valid
+	assert count_polygon_points(simplified) < points_before
+	assert simplified[0].area == pytest.approx(polygon.area, rel=0.05)
+
+
+def test_simplify_polygons_preserving_topology_keeps_holes():
+	polygon = Polygon(
+		Point(0, 0).buffer(10, resolution=128).exterior.coords,
+		[Point(0, 0).buffer(2, resolution=64).exterior.coords],
+	)
+
+	simplified = simplify_polygons_preserving_topology([polygon], tolerance=0.05)
+
+	assert len(simplified) == 1
+	assert simplified[0].is_valid
+	assert len(simplified[0].interiors) == 1
+
+
+def test_simplify_polygons_preserving_topology_flattens_multipolygons():
+	multipolygon = MultiPolygon([Point(0, 0).buffer(10, resolution=32), Point(30, 0).buffer(5, resolution=32)])
+
+	simplified = simplify_polygons_preserving_topology([multipolygon], tolerance=0.05)
+
+	assert len(simplified) == 2
+	assert all(isinstance(polygon, Polygon) for polygon in simplified)
+	assert count_polygon_points(simplified) < count_polygon_points([multipolygon])

--- a/processor/tests/utils/test_segmentation_crs.py
+++ b/processor/tests/utils/test_segmentation_crs.py
@@ -1,0 +1,9 @@
+from processor.src.utils.crs import get_utm_string_from_latlon
+
+
+def test_get_utm_string_from_latlon_uses_northern_epsg_codes():
+	assert get_utm_string_from_latlon(42.28, 18.86) == 'EPSG:32634'
+
+
+def test_get_utm_string_from_latlon_uses_southern_epsg_codes():
+	assert get_utm_string_from_latlon(-32.87, 24.81) == 'EPSG:32735'

--- a/scripts/simplify_forest_cover_label.sh
+++ b/scripts/simplify_forest_cover_label.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Usage:
+  scripts/simplify_forest_cover_label.sh LABEL_ID [--apply] [--metric-srid SRID] [--tolerance-m METERS]
+
+Runs a measured dry run by default. Pass --apply only after reviewing the metrics.
+
+Connection:
+  By default this runs against the local Supabase Postgres container
+  "supabase_db_deadwood-api". Set DB_CONTAINER to override it.
+
+  Set DATABASE_URL to run against a direct Postgres connection instead.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+	usage >&2
+	exit 2
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+label_id="$1"
+shift
+
+metric_srid="0"
+tolerance_m="0.04"
+apply="0"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--apply)
+			apply="1"
+			shift
+			;;
+		--metric-srid)
+			metric_srid="${2:?Missing value for --metric-srid}"
+			shift 2
+			;;
+		--tolerance-m)
+			tolerance_m="${2:?Missing value for --tolerance-m}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown argument: $1" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+sql_file="${script_dir}/sql/simplify_forest_cover_label.sql"
+
+psql_vars=(
+	-v ON_ERROR_STOP=1
+	-v "label_id=${label_id}"
+	-v "metric_srid=${metric_srid}"
+	-v "tolerance_m=${tolerance_m}"
+	-v "apply=${apply}"
+)
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+	exec psql "${DATABASE_URL}" "${psql_vars[@]}" -f "${sql_file}"
+fi
+
+db_container="${DB_CONTAINER:-supabase_db_deadwood-api}"
+exec docker exec -i "${db_container}" psql -U postgres -d postgres "${psql_vars[@]}" < "${sql_file}"

--- a/scripts/sql/simplify_forest_cover_label.sql
+++ b/scripts/sql/simplify_forest_cover_label.sql
@@ -1,0 +1,183 @@
+-- Simplify one forest-cover label in-place after a measured dry run.
+--
+-- Usage:
+--   scripts/simplify_forest_cover_label.sh 14189
+--   scripts/simplify_forest_cover_label.sh 14189 --metric-srid 32636 --apply
+--
+-- Set metric_srid=0 to estimate a UTM zone from the label centroid.
+-- Set apply=1 only after reviewing the printed metrics.
+
+\if :{?label_id}
+\else
+  \quit 'Missing required psql variable: label_id'
+\endif
+
+\if :{?metric_srid}
+\else
+  \set metric_srid 0
+\endif
+
+\if :{?tolerance_m}
+\else
+  \set tolerance_m 0.04
+\endif
+
+\if :{?apply}
+\else
+  \set apply 0
+\endif
+
+\echo 'Forest-cover simplification backfill'
+\echo '  label_id: ' :label_id
+\echo '  metric_srid: ' :metric_srid
+\echo '  tolerance_m: ' :tolerance_m
+\echo '  apply: ' :apply
+
+BEGIN;
+SET LOCAL statement_timeout = '10min';
+
+CREATE TEMP TABLE _forest_cover_simplification_candidate ON COMMIT DROP AS
+WITH label_center AS (
+    SELECT ST_Extent(geometry)::geometry AS bbox
+    FROM public.v2_forest_cover_geometries
+    WHERE label_id = :label_id
+),
+params AS (
+    SELECT
+        :label_id::bigint AS label_id,
+        :tolerance_m::double precision AS tolerance_m,
+        CASE
+            WHEN :metric_srid::integer > 0 THEN :metric_srid::integer
+            WHEN ((ST_YMin(bbox) + ST_YMax(bbox)) / 2.0) >= 0
+                THEN 32600 + least(greatest(floor((((ST_XMin(bbox) + ST_XMax(bbox)) / 2.0) + 180.0) / 6.0)::integer + 1, 1), 60)
+            ELSE 32700 + least(greatest(floor((((ST_XMin(bbox) + ST_XMax(bbox)) / 2.0) + 180.0) / 6.0)::integer + 1, 1), 60)
+        END AS metric_srid
+    FROM label_center
+),
+simplified AS (
+    SELECT
+        g.id,
+        g.geometry AS old_geometry,
+        p.metric_srid,
+        ST_Transform(
+            ST_SimplifyPreserveTopology(
+                ST_Transform(g.geometry, p.metric_srid),
+                p.tolerance_m
+            ),
+            4326
+        ) AS raw_geometry
+    FROM public.v2_forest_cover_geometries g
+    CROSS JOIN params p
+    WHERE g.label_id = p.label_id
+),
+repaired AS (
+    SELECT
+        id,
+        old_geometry,
+        metric_srid,
+        raw_geometry,
+        CASE
+            WHEN ST_IsValid(raw_geometry) THEN raw_geometry
+            ELSE ST_Buffer(raw_geometry, 0)
+        END AS new_geometry
+    FROM simplified
+)
+SELECT *
+FROM repaired;
+
+SELECT DISTINCT metric_srid AS resolved_metric_srid
+FROM _forest_cover_simplification_candidate;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM _forest_cover_simplification_candidate) THEN
+        RAISE EXCEPTION 'No v2_forest_cover_geometries rows found for the requested label_id. Nothing to simplify.';
+    END IF;
+END $$;
+
+SELECT
+    variant,
+    rows,
+    points,
+    pg_size_pretty(geom_bytes::bigint) AS geom_size,
+    round(area_m2::numeric, 2) AS area_m2,
+    invalid_rows,
+    geom_types
+FROM (
+    SELECT
+        'before' AS variant,
+        count(*) AS rows,
+        sum(ST_NPoints(old_geometry)) AS points,
+        sum(pg_column_size(old_geometry)) AS geom_bytes,
+        sum(ST_Area(old_geometry::geography)) AS area_m2,
+        count(*) FILTER (WHERE NOT ST_IsValid(old_geometry)) AS invalid_rows,
+        string_agg(DISTINCT GeometryType(old_geometry), ', ' ORDER BY GeometryType(old_geometry)) AS geom_types
+    FROM _forest_cover_simplification_candidate
+    UNION ALL
+    SELECT
+        'simplified_raw' AS variant,
+        count(*) AS rows,
+        sum(ST_NPoints(raw_geometry)) AS points,
+        sum(pg_column_size(raw_geometry)) AS geom_bytes,
+        sum(ST_Area(raw_geometry::geography)) AS area_m2,
+        count(*) FILTER (WHERE NOT ST_IsValid(raw_geometry)) AS invalid_rows,
+        string_agg(DISTINCT GeometryType(raw_geometry), ', ' ORDER BY GeometryType(raw_geometry)) AS geom_types
+    FROM _forest_cover_simplification_candidate
+    UNION ALL
+    SELECT
+        'simplified_repaired' AS variant,
+        count(*) AS rows,
+        sum(ST_NPoints(new_geometry)) AS points,
+        sum(pg_column_size(new_geometry)) AS geom_bytes,
+        sum(ST_Area(new_geometry::geography)) AS area_m2,
+        count(*) FILTER (WHERE NOT ST_IsValid(new_geometry)) AS invalid_rows,
+        string_agg(DISTINCT GeometryType(new_geometry), ', ' ORDER BY GeometryType(new_geometry)) AS geom_types
+    FROM _forest_cover_simplification_candidate
+) metrics
+ORDER BY
+    CASE variant
+        WHEN 'before' THEN 1
+        WHEN 'simplified_raw' THEN 2
+        ELSE 3
+    END;
+
+SELECT
+    id,
+    GeometryType(new_geometry) AS geom_type,
+    ST_IsValid(new_geometry) AS is_valid,
+    ST_IsEmpty(new_geometry) AS is_empty
+FROM _forest_cover_simplification_candidate
+WHERE
+    ST_IsEmpty(new_geometry)
+    OR NOT ST_IsValid(new_geometry)
+    OR GeometryType(new_geometry) <> 'POLYGON'
+LIMIT 20;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM _forest_cover_simplification_candidate
+        WHERE
+            ST_IsEmpty(new_geometry)
+            OR NOT ST_IsValid(new_geometry)
+            OR GeometryType(new_geometry) <> 'POLYGON'
+    ) THEN
+        RAISE EXCEPTION 'Simplification produced rows that cannot be safely stored as geometry(Polygon,4326). See blocked row sample above.';
+    END IF;
+END $$;
+
+\if :apply
+    UPDATE public.v2_forest_cover_geometries g
+    SET
+        geometry = c.new_geometry::geometry(Polygon, 4326),
+        area_m2 = ST_Area(c.new_geometry::geography)
+    FROM _forest_cover_simplification_candidate c
+    WHERE g.id = c.id;
+
+    COMMIT;
+    \echo 'Committed forest-cover simplification.'
+\else
+    ROLLBACK;
+    \echo 'Dry run only. Re-run with -v apply=1 to commit.'
+\endif


### PR DESCRIPTION
## Summary

- Simplifies combined-model forest-cover polygons while they are still in the metric inference CRS, then applies the existing minimum-area filter before reprojecting back to the source dataset CRS for storage.
- Keeps point-count metrics so processing logs show the vertex reduction from simplification.
- Adds shared topology-preserving geometry helpers for simplification and point counting.
- Adds a dry-run-first PostGIS backfill script for already-ingested forest-cover labels: `scripts/simplify_forest_cover_label.sh` and `scripts/sql/simplify_forest_cover_label.sql`.
- Fixes the UTM southern-hemisphere EPSG bug in `processor/src/utils/crs.py`. The old helper produced EPSG:325xx for southern UTM zones; WGS84 southern UTM zones should be EPSG:327xx.

## Why

The new combined forest-cover product can produce very detailed polygon boundaries. On dataset-detail views this caused a considerable slowdown and, for dense forest-cover labels, could also lead to failures while generating or loading vector map tiles.

The fix simplifies only the combined model forest-cover output at ingestion time, while the polygons are still in a metric CRS. That keeps the 4 cm tolerance meaningful in meters and avoids guessing or reprojecting again later in `predict_combined.py`.

Already-ingested labels are not changed by the inference fix. Those need a separate backfill step using the script in `scripts/simplify_forest_cover_label.sh`, which wraps the SQL in `scripts/sql/simplify_forest_cover_label.sql` and defaults to a dry run before any database update.

## Test coverage

- `processor/tests/deadwood_treecover_combined_v2/test_combined_inference_simplification.py` checks that simplification happens before the minimum-area filter and final reprojection out of the metric inference CRS.
- `processor/tests/utils/test_geometry_simplification.py` covers topology-preserving simplification, hole preservation, multipolygon flattening, and vertex reduction.
- `processor/tests/utils/test_segmentation_crs.py` covers northern and southern UTM EPSG code selection, including the southern hemisphere regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated forest-cover geometries (vertex reduction + CRS handling), which can affect downstream storage and rendering and needs verification on real datasets. Added backfill script can modify existing DB rows if run with `--apply`.
> 
> **Overview**
> Combined-model inference now *topology-preserving simplifies* forest-cover polygons **before reprojection** (using a meter-based tolerance tied to product resolution) and records per-run vertex-count metrics in `CombinedInference.simplification_stats`, which are logged by `predict_combined`.
> 
> Adds shared helpers in `geometry_validation` for `simplify_polygons_preserving_topology` and `count_polygon_points` (with tests), factors UTM EPSG selection into `utils/crs.py` (fixing southern-hemisphere codes), and introduces a dry-run-first PostGIS script (`simplify_forest_cover_label.sh`/`.sql`) to backfill simplification for already-stored forest-cover labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc17b2ac45a1cdb7badaa18e9bb5e5a594ed8103. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

