### PR TITLE
perf(database): simplify forest cover MVT geometries

### DIFF
--- a/supabase/migrations/20260506093000_simplify_forest_cover_mvt_geometries.sql
+++ b/supabase/migrations/20260506093000_simplify_forest_cover_mvt_geometries.sql
@@ -1,0 +1,149 @@
+CREATE OR REPLACE FUNCTION public.get_forest_cover_tiles_with_corrections(
+    z integer,
+    x integer,
+    y integer,
+    filter_label_id bigint,
+    resolution integer DEFAULT 4096,
+    filter_correction_status text DEFAULT NULL::text
+)
+ RETURNS text
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    mvt bytea;
+BEGIN
+    WITH
+    bbox AS (
+        SELECT ST_TileEnvelope(z, x, y) AS bbox_3857
+    ),
+    settings AS (
+        SELECT
+            CASE WHEN z < 6 THEN 1000000
+                 WHEN z < 8 THEN 500000
+                 WHEN z < 10 THEN 100000
+                 WHEN z < 12 THEN 50000
+                 WHEN z < 14 THEN 10000
+                 ELSE 0 END AS min_area
+    )
+    SELECT ST_AsMVT(tile_data, 'forest_cover', resolution)
+    INTO mvt
+    FROM (
+        SELECT
+            ST_AsMVTGeom(
+                ST_SimplifyPreserveTopology(
+                    ST_Transform(g.geometry, 3857),
+                    (ST_XMax(b.bbox_3857) - ST_XMin(b.bbox_3857)) / NULLIF(resolution, 0) * 2.0
+                ),
+                b.bbox_3857,
+                resolution,
+                128,
+                true
+            ) AS geom,
+            g.id,
+            g.label_id,
+            g.properties,
+            g.is_deleted,
+            COALESCE(c.review_status, 'original') AS correction_status,
+            c.operation AS correction_operation,
+            c.id AS correction_id
+        FROM
+            public.v2_forest_cover_geometries g
+        CROSS JOIN bbox b
+        CROSS JOIN settings s
+        LEFT JOIN LATERAL (
+            SELECT id, review_status, operation
+            FROM v2_geometry_corrections
+            WHERE geometry_id = g.id AND layer_type = 'forest_cover'
+            ORDER BY created_at DESC
+            LIMIT 1
+        ) c ON true
+        WHERE
+            g.label_id = filter_label_id
+            AND g.area_m2 >= s.min_area
+            AND g.geometry && ST_Transform(b.bbox_3857, ST_SRID(g.geometry))
+            AND ST_Intersects(g.geometry, ST_Transform(b.bbox_3857, ST_SRID(g.geometry)))
+            AND (
+                CASE filter_correction_status
+                    WHEN 'all' THEN true
+                    WHEN 'pending' THEN c.review_status = 'pending'
+                    ELSE g.is_deleted = false
+                END
+            )
+        LIMIT 50000
+    ) AS tile_data
+    WHERE tile_data.geom IS NOT NULL;
+
+    RETURN encode(mvt, 'base64');
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_forest_cover_vector_tiles_perf(
+    z integer,
+    x integer,
+    y integer,
+    filter_label_id integer,
+    resolution integer DEFAULT 4096
+)
+ RETURNS text
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    mvt bytea;
+BEGIN
+    WITH
+    bbox AS (
+        SELECT ST_TileEnvelope(z, x, y) AS bbox_3857
+    ),
+    settings AS (
+        SELECT
+            CASE WHEN z < 6 THEN 1000000
+                 WHEN z < 8 THEN 500000
+                 WHEN z < 10 THEN 100000
+                 WHEN z < 12 THEN 50000
+                 WHEN z < 14 THEN 10000
+                 ELSE 0 END AS min_area
+    )
+    SELECT ST_AsMVT(tile_data, 'forest_cover', resolution)
+    INTO mvt
+    FROM (
+        SELECT
+            ST_AsMVTGeom(
+                ST_SimplifyPreserveTopology(
+                    ST_Transform(g.geometry, 3857),
+                    (ST_XMax(b.bbox_3857) - ST_XMin(b.bbox_3857)) / NULLIF(resolution, 0) * 2.0
+                ),
+                b.bbox_3857,
+                resolution,
+                128,
+                true
+            ) AS geom,
+            g.id,
+            g.label_id,
+            g.properties,
+            COALESCE(c.review_status, 'original') AS correction_status,
+            c.operation AS correction_operation
+        FROM
+            public.v2_forest_cover_geometries g
+            CROSS JOIN bbox b
+            CROSS JOIN settings s
+            LEFT JOIN LATERAL (
+                SELECT review_status, operation
+                FROM v2_geometry_corrections
+                WHERE geometry_id = g.id AND layer_type = 'forest_cover'
+                ORDER BY created_at DESC LIMIT 1
+            ) c ON true
+        WHERE
+            g.label_id = filter_label_id
+            AND g.is_deleted = false
+            AND g.area_m2 >= s.min_area
+            AND g.geometry && ST_Transform(b.bbox_3857, ST_SRID(g.geometry))
+            AND ST_Intersects(g.geometry, ST_Transform(b.bbox_3857, ST_SRID(g.geometry)))
+        LIMIT 50000
+    ) AS tile_data
+    WHERE tile_data.geom IS NOT NULL;
+
+    RETURN encode(mvt, 'base64');
+END;
+$function$;


### PR DESCRIPTION
## What changed

- Adds a Supabase migration that applies `ST_SimplifyPreserveTopology` inside both forest-cover MVT functions:
  - `get_forest_cover_tiles_with_corrections`
  - `get_forest_cover_vector_tiles_perf`
- Uses a tile-resolution-based Web Mercator tolerance before `ST_AsMVTGeom`, so lower zooms emit less detailed forest-cover vectors while preserving topology.

## Why

The ingestion-side simplification from the previous PR fixes future combined-model outputs and the dataset `8272` canary was backfilled, but production MVT functions still render stored geometries directly. Existing unsimplified forest-cover labels can therefore still produce oversized vector tiles, slow dataset detail loading, and occasional tile-load failures.

This migration adds a defensive display-time simplification layer for forest cover tiles while the stored-geometry backfill is rolled out.

## Validation

- Applied the migration successfully to the local DeadTrees Supabase DB.
- Verified both changed functions compile as `STABLE`.
- Executed both local functions with a sample tile request.
- Ran a read-only production simulation for dataset `8272`, label `24372`: sampled forest tile payloads dropped by roughly 27-61% compared with the current production function output.

## Risk

This only changes forest-cover vector tile output. Stored geometries are not modified. Because simplification is applied in Web Mercator using the current tile resolution, visual detail is reduced mostly at lower zoom levels; high zooms retain much more detail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side geometry generation for map tiles, which can affect visual fidelity and edge-case topology/coverage in rendered forest-cover layers, though scope is limited to these two functions and does not modify stored data.
> 
> **Overview**
> Adds a new Supabase migration that replaces the two forest-cover MVT functions to apply `ST_SimplifyPreserveTopology` (in Web Mercator) before `ST_AsMVTGeom`, using a tolerance derived from the tile bbox width and requested `resolution`.
> 
> This reduces feature complexity/byte size for low-zoom forest-cover tiles while keeping existing filters (label id, min-area-by-zoom, correction-status handling, and 50k feature cap) intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb511a3bebbf597c96649abe64af92639dec74cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->