### PR TITLE
fix(nginx): preserve bandwidth for prepackaged downloads

### DIFF
--- a/docs/playbooks/prepackaged-dataset-release-deploy.md
+++ b/docs/playbooks/prepackaged-dataset-release-deploy.md
@@ -63,7 +63,7 @@ location /prepackaged/v1/ {
     limit_conn prepackaged_global 3;
     limit_req zone=prepackaged_start_rate burst=3 nodelay;
     limit_rate_after 512m;
-    limit_rate 40m;
+    limit_rate 20m;
 
     sendfile on;
     tcp_nopush on;

--- a/nginx/api-conf/storage-server.conf
+++ b/nginx/api-conf/storage-server.conf
@@ -71,7 +71,7 @@ server {
         limit_conn prepackaged_global 3;
         limit_req zone=prepackaged_start_rate burst=3 nodelay;
         limit_rate_after 512m;
-        limit_rate 40m;
+        limit_rate 20m;
 
         sendfile on;
         tcp_nopush on;

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -60,7 +60,7 @@ server {
         limit_conn prepackaged_global 3;
         limit_req zone=prepackaged_start_rate burst=3 nodelay;
         limit_rate_after 512m;
-        limit_rate 40m;
+        limit_rate 20m;
 
         sendfile on;
         tcp_nopush on;


### PR DESCRIPTION
## What changed
- Lower prepackaged package transfer cap from 40m to 20m after the first 512m.
- Keep the same 3 global concurrent download cap and 5/day per-user API grant limit.
- Update local/test Nginx config and deployment playbook to match.

## Why
The storage server public interface reports 1 Gbit/s. With three concurrent prepackaged downloads, 40m could nearly saturate the public link and leave little headroom for COG/API traffic. 20m caps worst-case prepackaged traffic around 480 Mbit/s.

## Validation
- docker exec deadtrees-test-nginx-1 nginx -t
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/docs change that only reduces bandwidth for `prepackaged` downloads; main impact is slower transfers if the limit is too restrictive.
> 
> **Overview**
> Reduces the Nginx `limit_rate` for `/prepackaged/v1/` downloads from `40m` to `20m` (after the first `512m`) to keep more headroom for other storage-server traffic.
> 
> Updates both the Docker/reference (`nginx/api-conf/storage-server.conf`), local test config (`nginx/test-conf/storage-server.conf`), and the deployment playbook so environments stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0484646da8333105a728da18412fe9bde091e678. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->