### PR TITLE
docs(playbooks): document prepackaged deploy context

### DIFF
--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -33,6 +33,14 @@ GitHub Actions on pushes to `main`:
 - `.github/workflows/create-release.yml` creates the CalVer GitHub Release and
   builds/pushes the API image to `ghcr.io/deadwood-ai/deadwood-api`.
 
+Do not use local/manual SQL as the normal production migration path. If the
+Supabase workflow fails, diagnose the workflow failure before proceeding with
+dependent host or API changes. For out-of-order migration errors, where a PR
+adds a migration timestamped earlier than the latest migration already recorded
+in production, prefer a reviewed follow-up migration with a newer timestamp or
+an explicit workflow fix. Manual migration repair or direct production SQL
+execution should be an explicitly approved emergency action only.
+
 Processing server automation is not represented as a GitHub workflow. It is a
 host-local cron setup on `processing-server`:
 

--- a/docs/playbooks/prepackaged-dataset-release-deploy.md
+++ b/docs/playbooks/prepackaged-dataset-release-deploy.md
@@ -9,11 +9,30 @@ The production storage server uses host Nginx managed by systemd. It does not
 serve public traffic through the tracked Docker Nginx config.
 
 - API code deploys automatically from `main` through `/apps/deadtrees/auto_deploy_api.sh`.
+- Production Supabase migrations should be applied by the GitHub
+  `Supabase Migrate On Merge` workflow, not by local/manual SQL.
 - Host Nginx config is local-only at `/apps/deadtrees/nginx/conf/storage-server.conf`.
 - `/etc/nginx/sites-enabled/storage-server.conf` points to that local-only file.
 - The tracked `nginx/api-conf/storage-server.conf` is a reference for Docker-style
   Nginx and local review; production needs the same relevant blocks applied
   manually to the host Nginx file.
+
+## Production Migration Policy
+
+Avoid manual production Supabase migrations. They should happen through the
+merge-to-main workflow so schema history, reviewed SQL, and deployment state
+stay aligned.
+
+If the GitHub migration workflow fails, stop before changing host Nginx and
+diagnose the workflow failure first. For out-of-order migration errors such as
+"local migration files to be inserted before the last migration on remote
+database", prefer a reviewed follow-up migration with a newer timestamp or an
+explicit workflow fix. Do not apply local SQL to production as a normal
+workaround.
+
+The direct Postgres port is the right target for migration tooling if the
+workflow itself needs debugging. Application traffic and MCP checks may use the
+pooler, but migration runners should avoid the transaction pooler.
 
 ## Before Updating Host Nginx
 
@@ -24,6 +43,31 @@ curl -fsS https://data2.deadtrees.earth/api/v1/prepackaged/packages
 ```
 
 The response should be a JSON list of package definitions and versions.
+
+Confirm that the API container is running the expected production settings:
+
+```bash
+ssh storage-server 'docker exec deadtrees-api-1 python -c "
+from shared.settings import settings
+print(settings.DEV_MODE)
+print(settings.PREPACKAGED_DOWNLOAD_BASE_URL)
+print(settings.PREPACKAGED_GRANTS_PER_USER_PER_DAY)
+print(settings.PREPACKAGED_GRANTS_GLOBAL_PER_DAY)
+"'
+```
+
+Expected:
+
+```text
+False
+https://data2.deadtrees.earth/prepackaged/v1
+5
+30
+```
+
+If `PREPACKAGED_DOWNLOAD_BASE_URL` points to `localhost`, the API has not
+deployed the production URL fix or the settings defaults are being evaluated
+before environment parsing.
 
 ## Host Nginx Update
 
@@ -110,7 +154,8 @@ curl -sk -o /dev/null -w "%{http_code}\n" \
 Expected: `404`.
 
 After a signed-in frontend download attempt, confirm the dedicated prepackaged
-access log does not contain query-string tokens:
+access log does not contain query-string tokens and the grant URL uses the
+production storage host:
 
 ```bash
 sudo tail -20 /var/log/nginx/prepackaged_access.log
@@ -118,4 +163,30 @@ sudo grep -R "token=" /var/log/nginx/prepackaged_access.log
 ```
 
 Expected: the `tail` output logs `/prepackaged/v1/<file>.zip` without query
-arguments, and the `grep` command returns no matches.
+arguments, and the `grep` command returns no matches. In the browser, newly
+minted download URLs should start with
+`https://data2.deadtrees.earth/prepackaged/v1/`, never `http://localhost:8080/`.
+
+## Bandwidth Context
+
+On the current storage server, the public route uses `enp41s0`, which reports a
+1 Gbit/s link:
+
+```bash
+ip route get 1.1.1.1
+sudo ethtool enp41s0 | grep -E "Speed|Duplex|Link detected"
+```
+
+Nginx `limit_rate` uses bytes per second, not bits per second. The current
+prepackaged package cap is:
+
+```nginx
+limit_conn prepackaged_global 3;
+limit_rate_after 512m;
+limit_rate 20m;
+```
+
+This allows roughly 20 MB/s per download after the first 512 MB, or about
+60 MB/s across the three global concurrent package downloads. That leaves
+headroom on the 1 Gbit/s public interface for COG, API, and normal website
+traffic.


### PR DESCRIPTION
## What changed
- Document the production migration policy for prepackaged dataset deploys and general releases.
- Add post-deploy checks for prepackaged API settings, signed URL host, token-safe logs, and Nginx bandwidth context.
- Capture the current storage-server bandwidth assumptions and conservative prepackaged download cap.

## Why
This records the lessons from the prepackaged dataset rollout so future agents avoid manual production Supabase migrations and verify the actual deployment surfaces before changing host Nginx.

## Validation
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates operational documentation, but it may affect production procedures if followed incorrectly.
> 
> **Overview**
> Clarifies production release/deploy procedure by explicitly **discouraging manual Supabase SQL in production**, directing engineers to fix the `supabase-migrate-on-merge` workflow (including out-of-order migration cases) before proceeding with dependent changes.
> 
> Expands the prepackaged dataset deploy checklist with **runtime config verification** (e.g., `PREPACKAGED_DOWNLOAD_BASE_URL`), **post-deploy checks** to ensure signed URLs use the production host and access logs don’t leak tokens, and adds bandwidth/rate-limit context for the Nginx download caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab47ef89fc78041530638d5af094a9af8250215. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->