### PR TITLE
fix(database): restore legacy model defaults

### DIFF
--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -507,7 +507,7 @@ def get_all_dataset_labels(dataset_id: int) -> List[Label]:
 
 
 def filter_exportable_dataset_labels(
-	labels: List[Label], preferences: Dict[LabelDataEnum, Dict]
+	labels: List[Label], preferences: Dict[LabelDataEnum, Optional[Dict]]
 ) -> List[Label]:
 	"""Keep only exportable label sources, and for model predictions only the preferred model version."""
 	result = []
@@ -517,10 +517,10 @@ def filter_exportable_dataset_labels(
 		if label.label_source not in EXPORTABLE_LABEL_SOURCES:
 			continue
 		if label.label_source == LabelSourceEnum.model_prediction:
-			preferred = preferences.get(label.label_data)
-			if preferred is None:
-				# No preference configured — skip model predictions for this layer type
+			if label.label_data not in preferences:
+				# No preference configured - skip model predictions for this layer type.
 				continue
+			preferred = preferences[label.label_data]
 			if label.model_metadata != preferred:
 				continue
 		result.append(label)

--- a/api/src/download/downloads.py
+++ b/api/src/download/downloads.py
@@ -507,7 +507,7 @@ def get_all_dataset_labels(dataset_id: int) -> List[Label]:
 
 
 def filter_exportable_dataset_labels(
-	labels: List[Label], preferences: Dict[LabelDataEnum, Optional[Dict]]
+	labels: List[Label], preferences: Dict[LabelDataEnum, Dict]
 ) -> List[Label]:
 	"""Keep only exportable label sources, and for model predictions only the preferred model version."""
 	result = []

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -1067,7 +1067,6 @@ def test_download_consolidated_labels_multiple_types(auth_token, test_dataset_fo
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.deadwood,
 		label_quality=2,
-		model_metadata=COMBINED_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1078,7 +1077,6 @@ def test_download_consolidated_labels_multiple_types(auth_token, test_dataset_fo
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.forest_cover,
 		label_quality=2,
-		model_metadata=COMBINED_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1514,7 +1512,6 @@ def test_download_dataset_with_multiple_labels(auth_token, test_dataset_for_down
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.deadwood,
 		label_quality=2,
-		model_metadata=COMBINED_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1525,7 +1522,6 @@ def test_download_dataset_with_multiple_labels(auth_token, test_dataset_for_down
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.forest_cover,
 		label_quality=2,
-		model_metadata=COMBINED_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -26,6 +26,8 @@ from shared.models import (
 	Dataset,
 	Label,
 	COMBINED_MODEL_CONFIG,
+	DEADWOOD_V1_MODEL_CONFIG,
+	TREECOVER_V1_MODEL_CONFIG,
 )
 from api.src.download.cleanup import cleanup_downloads_directory
 from api.src.download.downloads import (
@@ -60,20 +62,20 @@ def _download_test_label(
 	)
 
 
-def test_filter_exportable_dataset_labels_keeps_legacy_model_prediction_for_null_preference():
-	legacy_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=None)
+def test_filter_exportable_dataset_labels_keeps_legacy_model_prediction_for_legacy_preference():
+	legacy_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=TREECOVER_V1_MODEL_CONFIG)
 	combined_label = _download_test_label(2, LabelDataEnum.forest_cover, model_metadata=COMBINED_MODEL_CONFIG)
 
 	result = filter_exportable_dataset_labels(
 		[legacy_label, combined_label],
-		{LabelDataEnum.forest_cover: None},
+		{LabelDataEnum.forest_cover: TREECOVER_V1_MODEL_CONFIG},
 	)
 
 	assert [label.id for label in result] == [legacy_label.id]
 
 
 def test_filter_exportable_dataset_labels_skips_model_prediction_without_configured_preference():
-	model_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=None)
+	model_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=TREECOVER_V1_MODEL_CONFIG)
 	visual_label = _download_test_label(
 		2,
 		LabelDataEnum.forest_cover,
@@ -1067,6 +1069,7 @@ def test_download_consolidated_labels_multiple_types(auth_token, test_dataset_fo
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.deadwood,
 		label_quality=2,
+		model_metadata=DEADWOOD_V1_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1077,6 +1080,7 @@ def test_download_consolidated_labels_multiple_types(auth_token, test_dataset_fo
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.forest_cover,
 		label_quality=2,
+		model_metadata=TREECOVER_V1_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1512,6 +1516,7 @@ def test_download_dataset_with_multiple_labels(auth_token, test_dataset_for_down
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.deadwood,
 		label_quality=2,
+		model_metadata=DEADWOOD_V1_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 
@@ -1522,6 +1527,7 @@ def test_download_dataset_with_multiple_labels(auth_token, test_dataset_for_down
 		label_type=LabelTypeEnum.segmentation,
 		label_data=LabelDataEnum.forest_cover,
 		label_quality=2,
+		model_metadata=TREECOVER_V1_MODEL_CONFIG,
 		geometry=deadwood_geojson,
 	)
 

--- a/api/tests/routers/test_download.py
+++ b/api/tests/routers/test_download.py
@@ -24,6 +24,7 @@ from shared.models import (
 	LabelTypeEnum,
 	LabelDataEnum,
 	Dataset,
+	Label,
 	COMBINED_MODEL_CONFIG,
 )
 from api.src.download.cleanup import cleanup_downloads_directory
@@ -33,12 +34,55 @@ from api.src.download.downloads import (
 	build_dataset_metadata_row,
 	generate_bundle_job_id,
 	create_consolidated_geopackage,
+	filter_exportable_dataset_labels,
 )
 from shared.labels import create_label_with_geometries
 from shared.testing.fixtures import login
 import json
 
 client = TestClient(app)
+
+
+def _download_test_label(
+	label_id: int,
+	label_data: LabelDataEnum,
+	label_source: LabelSourceEnum = LabelSourceEnum.model_prediction,
+	model_metadata: dict | None = None,
+) -> Label:
+	return Label(
+		id=label_id,
+		dataset_id=1,
+		user_id='test-user',
+		label_source=label_source,
+		label_type=LabelTypeEnum.segmentation,
+		label_data=label_data,
+		model_metadata=model_metadata,
+	)
+
+
+def test_filter_exportable_dataset_labels_keeps_legacy_model_prediction_for_null_preference():
+	legacy_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=None)
+	combined_label = _download_test_label(2, LabelDataEnum.forest_cover, model_metadata=COMBINED_MODEL_CONFIG)
+
+	result = filter_exportable_dataset_labels(
+		[legacy_label, combined_label],
+		{LabelDataEnum.forest_cover: None},
+	)
+
+	assert [label.id for label in result] == [legacy_label.id]
+
+
+def test_filter_exportable_dataset_labels_skips_model_prediction_without_configured_preference():
+	model_label = _download_test_label(1, LabelDataEnum.forest_cover, model_metadata=None)
+	visual_label = _download_test_label(
+		2,
+		LabelDataEnum.forest_cover,
+		label_source=LabelSourceEnum.visual_interpretation,
+	)
+
+	result = filter_exportable_dataset_labels([model_label, visual_label], {})
+
+	assert [label.id for label in result] == [visual_label.id]
 
 
 def _wait_for_download_completed(dataset_id: int, auth_token: str, *, max_attempts: int = 40, sleep_s: float = 0.25):

--- a/frontend/src/hooks/useDatasetLabels.ts
+++ b/frontend/src/hooks/useDatasetLabels.ts
@@ -3,7 +3,7 @@ import { supabase } from "../hooks/useSupabase";
 import { ILabel, ILabelData } from "../types/labels";
 import { Settings } from "../config";
 import {
-  ModelConfig,
+  ModelPreferenceConfig,
   selectPreferredModelLabel,
 } from "../utils/modelPreferences";
 
@@ -15,13 +15,13 @@ interface UseDatasetLabelsProps {
 
 interface ModelPreference {
   label_data: string;
-  model_config: ModelConfig;
+  model_config: ModelPreferenceConfig;
 }
 
 function useModelPreferences() {
   return useQuery({
     queryKey: ["model-preferences"],
-    queryFn: async (): Promise<Map<string, Record<string, unknown>>> => {
+    queryFn: async (): Promise<Map<string, ModelPreferenceConfig>> => {
       const { data, error } = await supabase
         .from("v2_model_preferences")
         .select("label_data,model_config");

--- a/frontend/src/types/labels.ts
+++ b/frontend/src/types/labels.ts
@@ -43,7 +43,7 @@ export interface ILabel {
   label_type: ILabelType;
   label_data: ILabelData;
   label_quality?: number;
-  model_config?: Record<string, any>;
+  model_config?: Record<string, any> | null;
   created_at: string;
   updated_at: string;
 

--- a/frontend/src/utils/modelPreferences.test.ts
+++ b/frontend/src/utils/modelPreferences.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { ILabel, ILabelData, ILabelSource, ILabelType } from "../types/labels";
-import { selectPreferredModelLabel } from "./modelPreferences";
+import {
+  selectPreferredModelLabel,
+  TREECOVER_V1_MODEL_CONFIG,
+} from "./modelPreferences";
 
 function modelLabel(id: number, module: string | null): ILabel {
   return {
@@ -16,7 +19,7 @@ function modelLabel(id: number, module: string | null): ILabel {
           checkpoint_name:
             module === "deadwood_treecover_combined_v2"
               ? "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors"
-              : "legacy.safetensors",
+              : "restor/tcd-segformer-mit-b5",
         }
       : undefined,
     created_at: "2026-04-29T09:51:38.523681+00:00",
@@ -27,7 +30,7 @@ function modelLabel(id: number, module: string | null): ILabel {
 describe("model preference label selection", () => {
   it("defaults to legacy model labels when preferences are unavailable", () => {
     const labels = [
-      modelLabel(20762, null),
+      modelLabel(20762, "treecover_segmentation_oam_tcd"),
       modelLabel(20764, "deadwood_treecover_combined_v2"),
     ];
 
@@ -41,7 +44,7 @@ describe("model preference label selection", () => {
 
   it("uses configured model preferences when they are available", () => {
     const labels = [
-      modelLabel(20762, null),
+      modelLabel(20762, "treecover_segmentation_oam_tcd"),
       modelLabel(20764, "deadwood_treecover_combined_v2"),
     ];
 
@@ -62,13 +65,15 @@ describe("model preference label selection", () => {
     ).toBe(20764);
   });
 
-  it("uses null preferences to select legacy model labels", () => {
+  it("uses configured legacy preferences to select legacy model labels", () => {
     const labels = [
-      modelLabel(20762, null),
+      modelLabel(20762, "treecover_segmentation_oam_tcd"),
       modelLabel(20764, "deadwood_treecover_combined_v2"),
     ];
 
-    const preferences = new Map([[ILabelData.FOREST_COVER, null]]);
+    const preferences = new Map([
+      [ILabelData.FOREST_COVER, TREECOVER_V1_MODEL_CONFIG],
+    ]);
 
     expect(
       selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, preferences)

--- a/frontend/src/utils/modelPreferences.test.ts
+++ b/frontend/src/utils/modelPreferences.test.ts
@@ -25,23 +25,23 @@ function modelLabel(id: number, module: string | null): ILabel {
 }
 
 describe("model preference label selection", () => {
-  it("defaults to the combined model when preferences are unavailable", () => {
+  it("defaults to legacy model labels when preferences are unavailable", () => {
     const labels = [
-      modelLabel(20762, "treecover_segmentation_oam_tcd"),
+      modelLabel(20762, null),
       modelLabel(20764, "deadwood_treecover_combined_v2"),
     ];
 
     expect(
       selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, new Map())?.id,
-    ).toBe(20764);
+    ).toBe(20762);
     expect(
       selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, undefined)?.id,
-    ).toBe(20764);
+    ).toBe(20762);
   });
 
   it("uses configured model preferences when they are available", () => {
     const labels = [
-      modelLabel(20762, "treecover_segmentation_oam_tcd"),
+      modelLabel(20762, null),
       modelLabel(20764, "deadwood_treecover_combined_v2"),
     ];
 
@@ -49,11 +49,26 @@ describe("model preference label selection", () => {
       [
         ILabelData.FOREST_COVER,
         {
-          module: "treecover_segmentation_oam_tcd",
-          checkpoint_name: "legacy.safetensors",
+          module: "deadwood_treecover_combined_v2",
+          checkpoint_name:
+            "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors",
         },
       ],
     ]);
+
+    expect(
+      selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, preferences)
+        ?.id,
+    ).toBe(20764);
+  });
+
+  it("uses null preferences to select legacy model labels", () => {
+    const labels = [
+      modelLabel(20762, null),
+      modelLabel(20764, "deadwood_treecover_combined_v2"),
+    ];
+
+    const preferences = new Map([[ILabelData.FOREST_COVER, null]]);
 
     expect(
       selectPreferredModelLabel(labels, ILabelData.FOREST_COVER, preferences)

--- a/frontend/src/utils/modelPreferences.ts
+++ b/frontend/src/utils/modelPreferences.ts
@@ -1,21 +1,30 @@
 import { ILabel, ILabelData, ILabelSource } from "../types/labels";
 
 export type ModelConfig = Record<string, unknown>;
-export type ModelPreferenceConfig = ModelConfig | null;
+export type ModelPreferenceConfig = ModelConfig;
+
+export const DEADWOOD_V1_MODEL_CONFIG: ModelConfig = {
+  module: "deadwood_segmentation_v1_moehring",
+  checkpoint_name: "segformer_b5_full_epoch_100.safetensors",
+};
+
+export const TREECOVER_V1_MODEL_CONFIG: ModelConfig = {
+  module: "treecover_segmentation_oam_tcd",
+  checkpoint_name: "restor/tcd-segformer-mit-b5",
+};
 
 export const DEFAULT_MODEL_PREFERENCES: Record<
   ILabelData,
   ModelPreferenceConfig
 > = {
-  [ILabelData.DEADWOOD]: null,
-  [ILabelData.FOREST_COVER]: null,
+  [ILabelData.DEADWOOD]: DEADWOOD_V1_MODEL_CONFIG,
+  [ILabelData.FOREST_COVER]: TREECOVER_V1_MODEL_CONFIG,
 };
 
 function configMatches(
   labelConfig: ModelConfig | null | undefined,
   preferredConfig: ModelPreferenceConfig,
 ): boolean {
-  if (preferredConfig === null) return labelConfig == null;
   if (!labelConfig) return false;
   return Object.entries(preferredConfig).every(
     ([key, value]) => labelConfig[key] === value,

--- a/frontend/src/utils/modelPreferences.ts
+++ b/frontend/src/utils/modelPreferences.ts
@@ -1,21 +1,26 @@
 import { ILabel, ILabelData, ILabelSource } from "../types/labels";
 
 export type ModelConfig = Record<string, unknown>;
+export type ModelPreferenceConfig = ModelConfig | null;
 
 export const COMBINED_MODEL_CONFIG: ModelConfig = {
   module: "deadwood_treecover_combined_v2",
   checkpoint_name: "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors",
 };
 
-export const DEFAULT_MODEL_PREFERENCES: Record<ILabelData, ModelConfig> = {
-  [ILabelData.DEADWOOD]: COMBINED_MODEL_CONFIG,
-  [ILabelData.FOREST_COVER]: COMBINED_MODEL_CONFIG,
+export const DEFAULT_MODEL_PREFERENCES: Record<
+  ILabelData,
+  ModelPreferenceConfig
+> = {
+  [ILabelData.DEADWOOD]: null,
+  [ILabelData.FOREST_COVER]: null,
 };
 
 function configMatches(
-  labelConfig: ModelConfig | undefined,
-  preferredConfig: ModelConfig,
+  labelConfig: ModelConfig | null | undefined,
+  preferredConfig: ModelPreferenceConfig,
 ): boolean {
+  if (preferredConfig === null) return labelConfig == null;
   if (!labelConfig) return false;
   return Object.entries(preferredConfig).every(
     ([key, value]) => labelConfig[key] === value,
@@ -27,7 +32,7 @@ export function selectPreferredModelLabel<
 >(
   labels: T[],
   labelType: ILabelData,
-  preferences?: ReadonlyMap<string, ModelConfig>,
+  preferences?: ReadonlyMap<string, ModelPreferenceConfig>,
 ): T | null {
   const activeLabels = labels.filter((label) => label.is_active !== false);
   if (activeLabels.length === 0) return null;

--- a/frontend/src/utils/modelPreferences.ts
+++ b/frontend/src/utils/modelPreferences.ts
@@ -3,11 +3,6 @@ import { ILabel, ILabelData, ILabelSource } from "../types/labels";
 export type ModelConfig = Record<string, unknown>;
 export type ModelPreferenceConfig = ModelConfig | null;
 
-export const COMBINED_MODEL_CONFIG: ModelConfig = {
-  module: "deadwood_treecover_combined_v2",
-  checkpoint_name: "mitb3_seed200_ckpt_epoch_6_best_macro_f1.safetensors",
-};
-
 export const DEFAULT_MODEL_PREFERENCES: Record<
   ILabelData,
   ModelPreferenceConfig
@@ -38,8 +33,13 @@ export function selectPreferredModelLabel<
   if (activeLabels.length === 0) return null;
   if (activeLabels.length === 1) return activeLabels[0];
 
-  const preferredConfig =
-    preferences?.get(labelType) ?? DEFAULT_MODEL_PREFERENCES[labelType];
+  let preferredConfig = DEFAULT_MODEL_PREFERENCES[labelType];
+  if (preferences?.has(labelType)) {
+    const configuredPreference = preferences.get(labelType);
+    preferredConfig =
+      configuredPreference === undefined ? preferredConfig : configuredPreference;
+  }
+
   const preferred = activeLabels.find(
     (label) =>
       label.label_source === ILabelSource.MODEL_PREDICTION &&

--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -28,9 +28,9 @@ CLASS_TREECOVER = 1
 CLASS_DEADWOOD = 2
 
 MINIMUM_INFERENCE_RESOLUTION = 0.05  # metres — match deadwood_v1
-# Keep simplification below one 5 cm inference pixel so boundaries are reduced
-# without allowing a whole-pixel displacement.
-FOREST_COVER_SIMPLIFICATION_TOLERANCE_M = 0.04
+# Match the 5 cm combined-model inference grid when simplifying forest cover
+# polygons for storage.
+FOREST_COVER_SIMPLIFICATION_TOLERANCE_M = 0.05
 BATCH_SIZE = 2
 NUM_DATALOADER_WORKERS = 0
 MINIMUM_POLYGON_AREA = 0.1  # m²

--- a/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_simplification.py
+++ b/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_simplification.py
@@ -49,7 +49,7 @@ def test_forest_cover_simplification_runs_before_reproject(monkeypatch):
 		image_src=object(),
 		inference_crs=inference_crs,
 		orig_crs=orig_crs,
-		simplification_tolerance=0.04,
+		simplification_tolerance=0.05,
 		stats_key='forest_cover',
 	)
 
@@ -59,7 +59,7 @@ def test_forest_cover_simplification_runs_before_reproject(monkeypatch):
 	assert reproject_call['dst_crs'] == orig_crs
 	assert reproject_call['points'] < count_polygon_points([polygon])
 	assert inference.simplification_stats['forest_cover'] == {
-		'tolerance_m': 0.04,
+		'tolerance_m': 0.05,
 		'simplification_crs': 'EPSG:32634',
 		'polygons': 1,
 		'points_before': count_polygon_points([polygon]),

--- a/shared/labels.py
+++ b/shared/labels.py
@@ -245,18 +245,15 @@ def delete_model_prediction_labels(
 			raise Exception(f'Error deleting model prediction labels: {str(e)}')
 
 
-def get_model_preferences(token: Optional[str] = None) -> Dict[LabelDataEnum, Optional[Dict[str, Any]]]:
+def get_model_preferences(token: Optional[str] = None) -> Dict[LabelDataEnum, Dict[str, Any]]:
 	"""Return the preferred model_config per label_data type from v2_model_preferences.
 
-	Returns a dict mapping LabelDataEnum -> model_config dict, or None for legacy labels.
+	Returns a dict mapping LabelDataEnum -> model_config dict.
 	Label data types with no preference row use the legacy model defaults.
 	"""
 	with use_client(token) as client:
 		response = client.table(settings.model_preferences_table).select('label_data,model_config').execute()
 
-	preferences = {
-		label_data: dict(config) if config is not None else None
-		for label_data, config in DEFAULT_MODEL_PREFERENCES.items()
-	}
+	preferences = {label_data: dict(config) for label_data, config in DEFAULT_MODEL_PREFERENCES.items()}
 	preferences.update({LabelDataEnum(row['label_data']): row['model_config'] for row in (response.data or [])})
 	return preferences

--- a/shared/labels.py
+++ b/shared/labels.py
@@ -245,15 +245,18 @@ def delete_model_prediction_labels(
 			raise Exception(f'Error deleting model prediction labels: {str(e)}')
 
 
-def get_model_preferences(token: Optional[str] = None) -> Dict[LabelDataEnum, Dict[str, Any]]:
+def get_model_preferences(token: Optional[str] = None) -> Dict[LabelDataEnum, Optional[Dict[str, Any]]]:
 	"""Return the preferred model_config per label_data type from v2_model_preferences.
 
-	Returns a dict mapping LabelDataEnum -> model_config dict.
-	Label data types with no preference row use the combined model defaults.
+	Returns a dict mapping LabelDataEnum -> model_config dict, or None for legacy labels.
+	Label data types with no preference row use the legacy model defaults.
 	"""
 	with use_client(token) as client:
 		response = client.table(settings.model_preferences_table).select('label_data,model_config').execute()
 
-	preferences = {label_data: dict(config) for label_data, config in DEFAULT_MODEL_PREFERENCES.items()}
+	preferences = {
+		label_data: dict(config) if config is not None else None
+		for label_data, config in DEFAULT_MODEL_PREFERENCES.items()
+	}
 	preferences.update({LabelDataEnum(row['label_data']): row['model_config'] for row in (response.data or [])})
 	return preferences

--- a/shared/models.py
+++ b/shared/models.py
@@ -43,10 +43,20 @@ COMBINED_MODEL_CONFIG = {
 	'checkpoint_name': COMBINED_MODEL_CHECKPOINT_NAME,
 }
 
+DEADWOOD_V1_MODEL_CONFIG = {
+	'module': 'deadwood_segmentation_v1_moehring',
+	'checkpoint_name': 'segformer_b5_full_epoch_100.safetensors',
+}
+
+TREECOVER_V1_MODEL_CONFIG = {
+	'module': 'treecover_segmentation_oam_tcd',
+	'checkpoint_name': 'restor/tcd-segformer-mit-b5',
+}
+
 
 DEFAULT_MODEL_PREFERENCES = {
-	LabelDataEnum.deadwood: None,
-	LabelDataEnum.forest_cover: None,
+	LabelDataEnum.deadwood: dict(DEADWOOD_V1_MODEL_CONFIG),
+	LabelDataEnum.forest_cover: dict(TREECOVER_V1_MODEL_CONFIG),
 }
 
 

--- a/shared/models.py
+++ b/shared/models.py
@@ -45,8 +45,8 @@ COMBINED_MODEL_CONFIG = {
 
 
 DEFAULT_MODEL_PREFERENCES = {
-	LabelDataEnum.deadwood: dict(COMBINED_MODEL_CONFIG),
-	LabelDataEnum.forest_cover: dict(COMBINED_MODEL_CONFIG),
+	LabelDataEnum.deadwood: None,
+	LabelDataEnum.forest_cover: None,
 }
 
 

--- a/shared/tests/test_odm_models.py
+++ b/shared/tests/test_odm_models.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Dict, Any
 
 from shared.models import (
-	COMBINED_MODEL_CONFIG,
 	DEFAULT_MODEL_PREFERENCES,
 	Label,
 	LabelDataEnum,
@@ -85,9 +84,9 @@ def test_label_payload_model_config_input_alias_deserializes_to_model_metadata()
 	assert payload.model_dump(by_alias=True)['model_config'] == model_config
 
 
-def test_default_model_preferences_use_combined_model_for_both_label_types():
-	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.deadwood] == COMBINED_MODEL_CONFIG
-	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.forest_cover] == COMBINED_MODEL_CONFIG
+def test_default_model_preferences_use_legacy_model_for_both_label_types():
+	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.deadwood] is None
+	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.forest_cover] is None
 
 
 # ============================================================================

--- a/shared/tests/test_odm_models.py
+++ b/shared/tests/test_odm_models.py
@@ -4,12 +4,14 @@ from typing import Dict, Any
 
 from shared.models import (
 	DEFAULT_MODEL_PREFERENCES,
+	DEADWOOD_V1_MODEL_CONFIG,
 	Label,
 	LabelDataEnum,
 	LabelPayloadData,
 	LabelSourceEnum,
 	LabelTypeEnum,
 	RawImages,
+	TREECOVER_V1_MODEL_CONFIG,
 	TaskTypeEnum,
 	StatusEnum,
 	Status,
@@ -85,8 +87,8 @@ def test_label_payload_model_config_input_alias_deserializes_to_model_metadata()
 
 
 def test_default_model_preferences_use_legacy_model_for_both_label_types():
-	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.deadwood] is None
-	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.forest_cover] is None
+	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.deadwood] == DEADWOOD_V1_MODEL_CONFIG
+	assert DEFAULT_MODEL_PREFERENCES[LabelDataEnum.forest_cover] == TREECOVER_V1_MODEL_CONFIG
 
 
 # ============================================================================

--- a/supabase/migrations/20260506113000_restore_legacy_model_defaults_and_forest_mvt.sql
+++ b/supabase/migrations/20260506113000_restore_legacy_model_defaults_and_forest_mvt.sql
@@ -1,15 +1,37 @@
 -- Restore public defaults to legacy model predictions while the combined model
--- remains available as an auditor-selectable variant. Legacy labels are encoded
--- by a NULL model_config, so preferences and export matching must be null-safe.
+-- remains available as an auditor-selectable variant. Older legacy labels were
+-- written before model_config existed, so backfill those rows to the explicit
+-- legacy model configs used by the current legacy processors.
 
-alter table public.v2_model_preferences
-	alter column model_config drop not null;
+update public.v2_labels
+set
+	model_config = '{"module":"deadwood_segmentation_v1_moehring","checkpoint_name":"segformer_b5_full_epoch_100.safetensors"}'::jsonb,
+	updated_at = now()
+where
+	label_source = 'model_prediction'::"LabelSource"
+	and label_data = 'deadwood'
+	and model_config is null;
+
+update public.v2_labels
+set
+	model_config = '{"module":"treecover_segmentation_oam_tcd","checkpoint_name":"restor/tcd-segformer-mit-b5"}'::jsonb,
+	updated_at = now()
+where
+	label_source = 'model_prediction'::"LabelSource"
+	and label_data = 'forest_cover'
+	and model_config is null;
 
 update public.v2_model_preferences
 set
-	model_config = null,
+	model_config = case label_data
+		when 'deadwood' then '{"module":"deadwood_segmentation_v1_moehring","checkpoint_name":"segformer_b5_full_epoch_100.safetensors"}'::jsonb
+		when 'forest_cover' then '{"module":"treecover_segmentation_oam_tcd","checkpoint_name":"restor/tcd-segformer-mit-b5"}'::jsonb
+	end,
 	updated_at = now()
 where label_data in ('deadwood', 'forest_cover');
+
+alter table public.v2_model_preferences
+	alter column model_config set not null;
 
 create or replace view "public"."v_export_polygon_candidates" as
 with correction_flags as (
@@ -64,7 +86,7 @@ deadwood as (
 	join public.v2_labels l on l.id = dg.label_id
 	join public.v2_model_preferences mp
 		on mp.label_data = 'deadwood'
-		and l.model_config is not distinct from mp.model_config
+		and l.model_config = mp.model_config
 	left join correction_flags cf
 		on cf.layer_type = 'deadwood'
 		and cf.geometry_id = dg.id
@@ -98,7 +120,7 @@ forest_cover as (
 	join public.v2_labels l on l.id = fg.label_id
 	join public.v2_model_preferences mp
 		on mp.label_data = 'forest_cover'
-		and l.model_config is not distinct from mp.model_config
+		and l.model_config = mp.model_config
 	left join correction_flags cf
 		on cf.layer_type = 'forest_cover'
 		and cf.geometry_id = fg.id

--- a/supabase/migrations/20260506113000_restore_legacy_model_defaults_and_forest_mvt.sql
+++ b/supabase/migrations/20260506113000_restore_legacy_model_defaults_and_forest_mvt.sql
@@ -1,0 +1,311 @@
+-- Restore public defaults to legacy model predictions while the combined model
+-- remains available as an auditor-selectable variant. Legacy labels are encoded
+-- by a NULL model_config, so preferences and export matching must be null-safe.
+
+alter table public.v2_model_preferences
+	alter column model_config drop not null;
+
+update public.v2_model_preferences
+set
+	model_config = null,
+	updated_at = now()
+where label_data in ('deadwood', 'forest_cover');
+
+create or replace view "public"."v_export_polygon_candidates" as
+with correction_flags as (
+	select
+		c.layer_type,
+		c.geometry_id,
+		bool_or(c.operation = 'add' and c.review_status = 'approved') as has_approved_add,
+		bool_or(c.operation = 'modify' and c.review_status = 'approved') as has_approved_modify,
+		bool_or(c.operation = 'delete' and c.review_status = 'approved') as has_approved_delete,
+		bool_or(c.operation = 'add' and coalesce(c.review_status, '') not in ('approved', 'rejected')) as has_pending_add,
+		bool_or(c.operation = 'modify' and coalesce(c.review_status, '') not in ('approved', 'rejected')) as has_pending_modify,
+		bool_or(c.operation = 'delete' and coalesce(c.review_status, '') not in ('approved', 'rejected')) as has_pending_delete
+	from public.v2_geometry_corrections c
+	group by
+		c.layer_type,
+		c.geometry_id
+),
+approved_replacements as (
+	select
+		c.layer_type,
+		c.original_geometry_id as geometry_id,
+		true as replaced_by_approved_modify
+	from public.v2_geometry_corrections c
+	where
+		c.operation = 'modify'
+		and c.review_status = 'approved'
+		and c.original_geometry_id is not null
+	group by c.layer_type, c.original_geometry_id
+),
+deadwood as (
+	select
+		'deadwood'::text as layer_type,
+		dg.id as geometry_id,
+		dg.label_id,
+		l.dataset_id,
+		l.label_source::text as label_source,
+		l.is_active as label_is_active,
+		coalesce(dg.is_deleted, false) as is_deleted_in_table,
+		coalesce(cf.has_approved_add, false) as has_approved_add,
+		coalesce(cf.has_approved_modify, false) as has_approved_modify,
+		coalesce(cf.has_approved_delete, false) as has_approved_delete,
+		coalesce(cf.has_pending_add, false) as has_pending_add,
+		coalesce(cf.has_pending_modify, false) as has_pending_modify,
+		coalesce(cf.has_pending_delete, false) as has_pending_delete,
+		coalesce(ar.replaced_by_approved_modify, false) as replaced_by_approved_modify,
+		dg.geometry,
+		dg.area_m2,
+		dg.properties,
+		dg.created_at,
+		dg.updated_at
+	from public.v2_deadwood_geometries dg
+	join public.v2_labels l on l.id = dg.label_id
+	join public.v2_model_preferences mp
+		on mp.label_data = 'deadwood'
+		and l.model_config is not distinct from mp.model_config
+	left join correction_flags cf
+		on cf.layer_type = 'deadwood'
+		and cf.geometry_id = dg.id
+	left join approved_replacements ar
+		on ar.layer_type = 'deadwood'
+		and ar.geometry_id = dg.id
+	where l.label_source = 'model_prediction'::"LabelSource"
+),
+forest_cover as (
+	select
+		'forest_cover'::text as layer_type,
+		fg.id as geometry_id,
+		fg.label_id,
+		l.dataset_id,
+		l.label_source::text as label_source,
+		l.is_active as label_is_active,
+		coalesce(fg.is_deleted, false) as is_deleted_in_table,
+		coalesce(cf.has_approved_add, false) as has_approved_add,
+		coalesce(cf.has_approved_modify, false) as has_approved_modify,
+		coalesce(cf.has_approved_delete, false) as has_approved_delete,
+		coalesce(cf.has_pending_add, false) as has_pending_add,
+		coalesce(cf.has_pending_modify, false) as has_pending_modify,
+		coalesce(cf.has_pending_delete, false) as has_pending_delete,
+		coalesce(ar.replaced_by_approved_modify, false) as replaced_by_approved_modify,
+		fg.geometry,
+		fg.area_m2,
+		fg.properties,
+		fg.created_at,
+		fg.updated_at
+	from public.v2_forest_cover_geometries fg
+	join public.v2_labels l on l.id = fg.label_id
+	join public.v2_model_preferences mp
+		on mp.label_data = 'forest_cover'
+		and l.model_config is not distinct from mp.model_config
+	left join correction_flags cf
+		on cf.layer_type = 'forest_cover'
+		and cf.geometry_id = fg.id
+	left join approved_replacements ar
+		on ar.layer_type = 'forest_cover'
+		and ar.geometry_id = fg.id
+	where l.label_source = 'model_prediction'::"LabelSource"
+),
+resolved_polygons as (
+	select
+		p.layer_type,
+		p.geometry_id as id,
+		p.label_id,
+		p.dataset_id,
+		p.label_source,
+		case
+			when p.has_approved_delete then false
+			when p.replaced_by_approved_modify then false
+			when p.has_approved_add or p.has_approved_modify then true
+			when p.has_pending_add or p.has_pending_modify then false
+			when p.has_pending_delete then true
+			else not p.is_deleted_in_table
+		end as is_active,
+		p.is_deleted_in_table as is_deleted,
+		not (
+			p.has_approved_add
+			or p.has_approved_modify
+			or p.has_pending_add
+			or p.has_pending_modify
+		) as is_original_prediction_geometry,
+		false as has_pending_model_edits,
+		'approved_state'::text as recommended_export_mode,
+		p.label_is_active,
+		p.geometry,
+		p.area_m2,
+		p.properties,
+		p.created_at,
+		p.updated_at
+	from (
+		select * from deadwood
+		union all
+		select * from forest_cover
+	) p
+)
+select
+	p.layer_type,
+	p.id,
+	p.label_id,
+	p.dataset_id,
+	p.label_source,
+	p.is_active,
+	p.is_deleted,
+	p.is_original_prediction_geometry,
+	p.has_pending_model_edits,
+	p.recommended_export_mode,
+	da.final_assessment,
+	da.deadwood_quality::text as deadwood_quality,
+	da.forest_cover_quality::text as forest_cover_quality,
+	p.geometry,
+	p.area_m2,
+	p.properties,
+	p.created_at,
+	p.updated_at
+from resolved_polygons p
+left join public.dataset_audit da on da.dataset_id = p.dataset_id
+where p.is_active and p.label_is_active;
+
+CREATE OR REPLACE FUNCTION public.get_forest_cover_tiles_with_corrections(
+	z integer,
+	x integer,
+	y integer,
+	filter_label_id bigint,
+	resolution integer DEFAULT 4096,
+	filter_correction_status text DEFAULT NULL::text
+)
+ RETURNS text
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    mvt bytea;
+BEGIN
+    WITH
+    bbox AS (
+        SELECT ST_TileEnvelope(z, x, y) AS bbox_3857
+    ),
+    settings AS (
+        SELECT
+            CASE WHEN z < 6 THEN 1000000
+                 WHEN z < 8 THEN 500000
+                 WHEN z < 10 THEN 100000
+                 WHEN z < 12 THEN 50000
+                 WHEN z < 14 THEN 10000
+                 ELSE 0 END AS min_area
+    )
+    SELECT ST_AsMVT(tile_data, 'forest_cover', resolution)
+    INTO mvt
+    FROM (
+        SELECT
+            ST_AsMVTGeom(
+                ST_Transform(g.geometry, 3857),
+                b.bbox_3857,
+                resolution,
+                128,
+                true
+            ) AS geom,
+            g.id,
+            g.label_id,
+            g.properties,
+            g.is_deleted,
+            COALESCE(c.review_status, 'original') AS correction_status,
+            c.operation AS correction_operation,
+            c.id AS correction_id
+        FROM
+            public.v2_forest_cover_geometries g
+        CROSS JOIN bbox b
+        CROSS JOIN settings s
+        LEFT JOIN LATERAL (
+            SELECT id, review_status, operation
+            FROM v2_geometry_corrections
+            WHERE geometry_id = g.id AND layer_type = 'forest_cover'
+            ORDER BY created_at DESC
+            LIMIT 1
+        ) c ON true
+        WHERE
+            g.label_id = filter_label_id
+            AND g.area_m2 >= s.min_area
+            AND g.geometry && ST_Transform(b.bbox_3857, ST_SRID(g.geometry))
+            AND ST_Intersects(g.geometry, ST_Transform(b.bbox_3857, ST_SRID(g.geometry)))
+            AND (
+                CASE filter_correction_status
+                    WHEN 'all' THEN true
+                    WHEN 'pending' THEN c.review_status = 'pending'
+                    ELSE g.is_deleted = false
+                END
+            )
+        LIMIT 50000
+    ) AS tile_data
+    WHERE tile_data.geom IS NOT NULL;
+
+    RETURN encode(mvt, 'base64');
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_forest_cover_vector_tiles_perf(
+	z integer,
+	x integer,
+	y integer,
+	filter_label_id integer,
+	resolution integer DEFAULT 4096
+)
+ RETURNS text
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    mvt bytea;
+BEGIN
+    WITH
+    bbox AS (
+        SELECT ST_TileEnvelope(z, x, y) AS bbox_3857
+    ),
+    settings AS (
+        SELECT
+            CASE WHEN z < 6 THEN 1000000
+                 WHEN z < 8 THEN 500000
+                 WHEN z < 10 THEN 100000
+                 WHEN z < 12 THEN 50000
+                 WHEN z < 14 THEN 10000
+                 ELSE 0 END AS min_area
+    )
+    SELECT ST_AsMVT(tile_data, 'forest_cover', resolution)
+    INTO mvt
+    FROM (
+        SELECT
+            ST_AsMVTGeom(
+                ST_Transform(g.geometry, 3857),
+                b.bbox_3857,
+                resolution,
+                128,
+                true
+            ) AS geom,
+            g.id,
+            g.label_id,
+            g.properties,
+            COALESCE(c.review_status, 'original') AS correction_status,
+            c.operation AS correction_operation
+        FROM
+            public.v2_forest_cover_geometries g
+            CROSS JOIN bbox b
+            CROSS JOIN settings s
+            LEFT JOIN LATERAL (
+                SELECT review_status, operation
+                FROM v2_geometry_corrections
+                WHERE geometry_id = g.id AND layer_type = 'forest_cover'
+                ORDER BY created_at DESC LIMIT 1
+            ) c ON true
+        WHERE
+            g.label_id = filter_label_id
+            AND g.is_deleted = false
+            AND g.area_m2 >= s.min_area
+            AND g.geometry && ST_Transform(b.bbox_3857, ST_SRID(g.geometry))
+            AND ST_Intersects(g.geometry, ST_Transform(b.bbox_3857, ST_SRID(g.geometry)))
+        LIMIT 50000
+    ) AS tile_data
+    WHERE tile_data.geom IS NOT NULL;
+
+    RETURN encode(mvt, 'base64');
+END;
+$function$;


### PR DESCRIPTION
## What changed

- Restores public default model selection to the explicit legacy deadwood and forest-cover model configs.
- Backfills older legacy `model_prediction` labels that still had `model_config = NULL` to the current legacy pipeline configs.
- Updates `v2_model_preferences` to point at those explicit legacy configs and keeps `model_config` non-null.
- Recreates the forest-cover MVT functions using the previous corrections-aware strategy without request-time `ST_SimplifyPreserveTopology`.
- Sets combined-model forest-cover storage simplification to `0.05m`, matching the 5 cm inference grid.

## Legacy configs

- Deadwood: `{"module":"deadwood_segmentation_v1_moehring","checkpoint_name":"segformer_b5_full_epoch_100.safetensors"}`
- Forest cover: `{"module":"treecover_segmentation_oam_tcd","checkpoint_name":"restor/tcd-segformer-mit-b5"}`

## Why

The new combined forest-cover polygons are much denser than the legacy model output. Serving those geometries through request-time MVT simplification caused slow dataset loading and tile-generation failures. This PR moves the public default back to the legacy model predictions and keeps the combined predictions available as auditor-selectable variants, while ingestion continues to simplify new combined forest-cover polygons at storage time.

## Validation

- `npm --prefix frontend run test -- --run src/utils/modelPreferences.test.ts`
- `python3 -m py_compile api/src/download/downloads.py shared/labels.py shared/models.py api/tests/routers/test_download.py shared/tests/test_odm_models.py processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py`
- `git diff --check`
- Applied `supabase/migrations/20260506113000_restore_legacy_model_defaults_and_forest_mvt.sql` to the local Supabase Postgres container and verified both model preferences use explicit legacy configs, `v2_model_preferences.model_config` is `NOT NULL`, and the forest-cover tile functions no longer contain `ST_SimplifyPreserveTopology`.

## Known local validation gaps

- `python3 -m pytest api/tests/routers/test_download.py shared/tests/test_odm_models.py -q -k "filter_exportable_dataset_labels or default_model_preferences"` is blocked locally because the active Python environment does not have `pytest` installed.
