### PR TITLE
test(frontend): cover detail and release smoke paths

### DIFF
--- a/frontend/e2e/customer-factory-smoke.spec.ts
+++ b/frontend/e2e/customer-factory-smoke.spec.ts
@@ -1,4 +1,43 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+const openFirstPublicDataset = async (page: Page) => {
+  await page.goto("/dataset");
+
+  await expect(page.getByTestId("dataset-archive-page")).toBeVisible();
+  const firstDataset = page.getByTestId("dataset-list-item").first();
+  await expect(firstDataset).toBeVisible({ timeout: 45_000 });
+
+  await firstDataset.click({ position: { x: 12, y: 12 } });
+  await expect(page).toHaveURL(/\/dataset\/\d+$/);
+  await expect(page.getByTestId("dataset-detail-page")).toBeVisible({
+    timeout: 45_000,
+  });
+};
+
+const openFirstAvailableRelease = async (page: Page) => {
+  await page.goto("/releases");
+
+  await expect(page.getByTestId("releases-page")).toBeVisible();
+  await expect(page.getByTestId("release-card").first()).toBeVisible();
+
+  const releaseActions = page.getByRole("button", { name: "Open release" });
+  const releaseActionCount = await releaseActions.count();
+
+  for (let index = 0; index < releaseActionCount; index += 1) {
+    const releaseAction = releaseActions.nth(index);
+
+    if (await releaseAction.isEnabled()) {
+      await releaseAction.click();
+      await expect(page).toHaveURL(/\/releases\/[^/]+$/);
+      await expect(page.getByTestId("release-detail-page")).toBeVisible({
+        timeout: 30_000,
+      });
+      return;
+    }
+  }
+
+  throw new Error("No available release action found.");
+};
 
 test.describe("customer factory public smoke", () => {
   test("home loads and primary navigation reaches core public routes", async ({
@@ -23,43 +62,77 @@ test.describe("customer factory public smoke", () => {
   test("dataset archive loads production data and opens a public dataset", async ({
     page,
   }) => {
+    await openFirstPublicDataset(page);
+  });
+
+  test("dataset detail exposes result map metadata and layer controls", async ({
+    page,
+  }) => {
+    await openFirstPublicDataset(page);
+
+    await expect(page.getByTestId("dataset-detail-map")).toBeVisible();
+    await expect(
+      page.locator('[data-testid="dataset-detail-map"] .ol-viewport'),
+    ).toBeVisible({ timeout: 45_000 });
+    await expect(page.getByTestId("dataset-layer-controls")).toBeVisible();
+    await expect(page.getByText("Author").first()).toBeVisible();
+    await expect(page.getByText("Platform").first()).toBeVisible();
+    await expect(page.getByText("License").first()).toBeVisible();
+
+    const droneImageryLayer = page.getByRole("checkbox", {
+      name: "Drone Imagery",
+    });
+    await expect(droneImageryLayer).toBeChecked();
+    await droneImageryLayer.click();
+    await expect(droneImageryLayer).not.toBeChecked();
+    await droneImageryLayer.click();
+    await expect(droneImageryLayer).toBeChecked();
+  });
+
+  test("dataset archive search handles empty results and recovers", async ({
+    page,
+  }) => {
     await page.goto("/dataset");
 
     await expect(page.getByTestId("dataset-archive-page")).toBeVisible();
-    const firstDataset = page.getByTestId("dataset-list-item").first();
-    await expect(firstDataset).toBeVisible({ timeout: 45_000 });
-
-    await firstDataset.click({ position: { x: 12, y: 12 } });
-    await expect(page).toHaveURL(/\/dataset\/\d+$/);
-    await expect(page.getByTestId("dataset-detail-page")).toBeVisible({
+    await expect(page.getByTestId("dataset-list-item").first()).toBeVisible({
       timeout: 45_000,
+    });
+
+    const searchInput = page.getByPlaceholder(
+      "Search by Authors or Location (Region, Province, City)",
+    );
+    await searchInput.fill("no-matching-public-dataset-smoke-query");
+    await expect(page.getByText("No results found").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await searchInput.clear();
+    await expect(page.getByTestId("dataset-list-item").first()).toBeVisible({
+      timeout: 10_000,
     });
   });
 
   test("releases index opens an available public release", async ({ page }) => {
-    await page.goto("/releases");
+    await openFirstAvailableRelease(page);
+  });
 
-    await expect(page.getByTestId("releases-page")).toBeVisible();
-    await expect(page.getByTestId("release-card").first()).toBeVisible();
+  test("release detail exposes reusable public artifact metadata", async ({
+    page,
+  }) => {
+    await openFirstAvailableRelease(page);
 
-    const releaseActions = page.getByRole("button", { name: "Open release" });
-    const releaseActionCount = await releaseActions.count();
-    let openedAvailableRelease = false;
-
-    for (let index = 0; index < releaseActionCount; index += 1) {
-      const releaseAction = releaseActions.nth(index);
-
-      if (await releaseAction.isEnabled()) {
-        await releaseAction.click();
-        openedAvailableRelease = true;
-        break;
-      }
-    }
-
-    expect(openedAvailableRelease).toBe(true);
-    await expect(page).toHaveURL(/\/releases\/[^/]+$/);
-    await expect(page.getByTestId("release-detail-page")).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(page.getByTestId("release-artifacts")).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: /Dataset package|Get the current package/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("release-artifacts")
+        .getByRole("button", { name: /Download dataset|Download ZIP/ })
+        .first(),
+    ).toBeVisible();
   });
 });

--- a/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
+++ b/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
@@ -266,6 +266,7 @@ export default function BaseMap({
 			<div
 				ref={mapContainerRef}
 				style={{ width: "100%", height: "100%", position: "relative" }}
+				data-testid="dataset-detail-map"
 				data-rr-ignore
 			>
 				{/* Tooltip overlay */}

--- a/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
@@ -116,6 +116,7 @@ const DatasetLayerControlPanel = ({
   return (
     <div
       className="flex w-full max-w-sm sm:w-56 flex-col rounded-2xl border border-gray-200/60 bg-white/95 p-4 shadow-xl backdrop-blur-sm pointer-events-auto overflow-hidden"
+      data-testid="dataset-layer-controls"
       onMouseDown={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       onTouchStart={(e) => e.stopPropagation()}

--- a/frontend/src/pages/DteAerialRelease.tsx
+++ b/frontend/src/pages/DteAerialRelease.tsx
@@ -150,6 +150,7 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
 
       <section
         id="dataset-download-placeholder"
+        data-testid="release-artifacts"
         className="border-t border-gray-200 bg-white"
       >
         <div className="mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-20">

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -241,7 +241,10 @@ export default function PrepackagedDatasetRelease() {
             </div>
           </section>
 
-          <section className="border-t border-gray-200 bg-white">
+          <section
+            className="border-t border-gray-200 bg-white"
+            data-testid="release-artifacts"
+          >
             <div className="mx-auto max-w-7xl px-4 py-12 md:px-8 md:py-14">
               <div className="flex max-w-4xl flex-col gap-6 md:flex-row md:items-center md:justify-between">
                 <div>


### PR DESCRIPTION
## Summary
- expand the customer factory Playwright smoke from 3 to 6 read-only checks
- cover dataset detail result inspection, map/layer controls, archive empty-search recovery, and release artifact metadata
- add stable non-user-visible test hooks for the dataset map, layer controls, and release artifacts

## Validation
- `npm --prefix frontend run test:e2e`
- `npm --prefix frontend test`
- `git diff --check`

## Notes
- the new checks remain production-read and do not require auth or mutate data
- build/lint are still intentionally outside this gate because of existing baseline debt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright E2E assertions and adding `data-testid` hooks on existing UI containers, with no business logic or data handling changes.
> 
> **Overview**
> Expands the Playwright public smoke suite from basic navigation into **dataset detail** and **release detail** checks, including map render/layer toggle assertions, empty-search recovery in the dataset archive, and validation that release artifact metadata/download CTAs are visible.
> 
> Adds stable, non-user-visible test hooks (`data-testid`) for the dataset detail map container, layer control panel, and release artifact sections to make these new E2E checks reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40600a034f313bc627159bdcd04856e72f0c8a78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->