### PR TITLE
test(frontend): add contributor local smoke

### DIFF
--- a/.github/workflows/frontend-hosting-pull-request.yml
+++ b/.github/workflows/frontend-hosting-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
         timeout-minutes: 8
         run: npx playwright install --with-deps chromium
-      - name: Run customer factory smoke
+      - name: Run data factory smoke
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
         timeout-minutes: 8
         env:

--- a/api/tests/routers/test_contributor_contract_smoke.py
+++ b/api/tests/routers/test_contributor_contract_smoke.py
@@ -1,0 +1,161 @@
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.src.server import app
+from api.src.utils.file_utils import UploadType
+from shared.db import use_client
+from shared.models import DatasetAccessEnum, LicenseEnum, PlatformEnum, StatusEnum
+from shared.settings import settings
+
+client = TestClient(app)
+
+GEOTIFF_PROCESSING_STEPS = [
+	'geotiff',
+	'cog',
+	'thumbnail',
+	'metadata',
+	'deadwood_v1',
+	'treecover_v1',
+	'deadwood_treecover_combined_v2',
+]
+
+RAW_IMAGES_PROCESSING_STEPS = [
+	'odm_processing',
+	*GEOTIFF_PROCESSING_STEPS,
+]
+
+
+@pytest.fixture(scope='function')
+def contributor_dataset(auth_token, test_user):
+	dataset_id = None
+
+	try:
+		with use_client(auth_token) as supabase_client:
+			dataset_response = (
+				supabase_client.table(settings.datasets_table)
+				.insert(
+					{
+						'file_name': 'contributor-contract-smoke.tif',
+						'user_id': test_user,
+						'license': LicenseEnum.cc_by.value,
+						'platform': PlatformEnum.drone.value,
+						'authors': ['Contract Smoke Contributor'],
+						'data_access': DatasetAccessEnum.public.value,
+						'aquisition_year': 2024,
+						'aquisition_month': 5,
+						'aquisition_day': 6,
+					}
+				)
+				.execute()
+			)
+			dataset_id = dataset_response.data[0]['id']
+			supabase_client.table(settings.statuses_table).insert(
+				{
+					'dataset_id': dataset_id,
+					'is_upload_done': True,
+					'current_status': StatusEnum.idle.value,
+				}
+			).execute()
+
+		yield dataset_id
+
+	finally:
+		if dataset_id:
+			with use_client(auth_token) as supabase_client:
+				supabase_client.table(settings.queue_table).delete().eq('dataset_id', dataset_id).execute()
+				supabase_client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+				supabase_client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+@pytest.mark.parametrize(
+	('upload_type', 'filename', 'expected_tmp_parent'),
+	[
+		(UploadType.GEOTIFF.value, 'contributor-smoke.tif', 'archive_path'),
+		(UploadType.RAW_IMAGES_ZIP.value, 'contributor-smoke.zip', 'raw_images_path'),
+	],
+)
+def test_contributor_chunk_upload_contract_targets_expected_storage(
+	auth_token,
+	data_directory,
+	upload_type,
+	filename,
+	expected_tmp_parent,
+):
+	upload_id = f'contributor-contract-{uuid4()}'
+	expected_tmp_path = getattr(settings, expected_tmp_parent) / f'{upload_id}.tmp'
+
+	try:
+		response = client.post(
+			'/datasets/chunk',
+			files={'file': (filename, b'partial upload bytes', 'application/octet-stream')},
+			data={
+				'chunk_index': '0',
+				'chunks_total': '2',
+				'upload_id': upload_id,
+				'license': LicenseEnum.cc_by.value,
+				'platform': PlatformEnum.drone.value,
+				'authors': ['Contract Smoke Contributor', 'Second Contributor'],
+				'data_access': DatasetAccessEnum.public.value,
+				'upload_type': upload_type,
+				'aquisition_year': '2024',
+				'aquisition_month': '5',
+				'aquisition_day': '6',
+				'additional_information': 'Contributor contract smoke',
+				'citation_doi': 'https://doi.org/10.1234/deadtrees.contract-smoke',
+			},
+			headers={'Authorization': f'Bearer {auth_token}'},
+		)
+
+		assert response.status_code == 200
+		assert response.json() == {'message': 'Chunk 0 of 2 received'}
+		assert expected_tmp_path.exists()
+		assert expected_tmp_path.read_bytes() == b'partial upload bytes'
+
+	finally:
+		expected_tmp_path.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+	('processing_steps', 'expected_steps'),
+	[
+		(GEOTIFF_PROCESSING_STEPS, GEOTIFF_PROCESSING_STEPS),
+		(RAW_IMAGES_PROCESSING_STEPS, RAW_IMAGES_PROCESSING_STEPS),
+	],
+)
+def test_contributor_processing_contract_enqueues_frontend_steps(
+	contributor_dataset,
+	auth_token,
+	processing_steps,
+	expected_steps,
+):
+	response = client.put(
+		f'/datasets/{contributor_dataset}/process',
+		headers={'Authorization': f'Bearer {auth_token}'},
+		json={'task_types': processing_steps, 'priority': 4},
+	)
+
+	assert response.status_code == 200
+	body = response.json()
+	assert body['dataset_id'] == contributor_dataset
+	assert body['task_types'] == expected_steps
+	assert body['priority'] == 4
+	assert body['is_processing'] is False
+
+	with use_client(auth_token) as supabase_client:
+		queue_response = (
+			supabase_client.table(settings.queue_table)
+			.select('dataset_id,task_types,priority,is_processing')
+			.eq('dataset_id', contributor_dataset)
+			.execute()
+		)
+
+	assert queue_response.data == [
+		{
+			'dataset_id': contributor_dataset,
+			'task_types': expected_steps,
+			'priority': 4,
+			'is_processing': False,
+		}
+	]

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -55,6 +55,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | ---------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | Frontend utility       | `npm --prefix frontend test`                                            | pure data, validation, analytics, routing helpers                                   |
 | Frontend browser       | `npm --prefix frontend run test:e2e` or the browser regression playbook | user-facing routes, maps, auth shell, archive/detail/release flows                  |
+| Contributor local E2E  | `npm --prefix frontend run test:e2e:local`                              | authenticated upload shell, metadata submission contract, process request contract  |
 | API/router             | `deadtrees dev test api <path>`                                         | FastAPI routes, upload/download/process/auth behavior                               |
 | Database/RLS/migration | focused API DB tests plus migration review/reset where practical        | schema, policies, RPCs, views, generated contracts                                  |
 | Processor CPU          | `deadtrees dev test processor <path>`                                   | queue orchestration, GeoTIFF/COG/metadata, non-GPU utilities                        |
@@ -87,3 +88,20 @@ should have at least one durable test or smoke check:
 - improvement: issue reporting, correction save, approval/revert
 - trust: audit filters, locks, saves, reference patch readiness
 - publication: selection, author/ORCID validation, submission state
+
+## Local Contributor Smoke
+
+Keep authenticated contributor journeys out of the production-read Playwright
+suite. Use the local contributor smoke when a frontend change touches upload,
+auth restoration, upload metadata, or process enqueue behavior:
+
+```bash
+npm --prefix frontend run test:e2e:local
+deadtrees dev test api api/tests/routers/test_contributor_contract_smoke.py
+```
+
+The browser smoke uses local/development frontend settings and mocked local
+service responses to prove the UI contract without mutating production. The API
+contract smoke runs against the repo test stack and proves the same upload and
+processing payloads are accepted by FastAPI and persisted to the expected local
+test tables/storage paths.

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -56,6 +56,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | Frontend utility       | `npm --prefix frontend test`                                            | pure data, validation, analytics, routing helpers                                   |
 | Frontend browser       | `npm --prefix frontend run test:e2e` or the browser regression playbook | user-facing routes, maps, auth shell, archive/detail/release flows                  |
 | Contributor local E2E  | `npm --prefix frontend run test:e2e:local`                              | authenticated upload shell, metadata submission contract, process request contract  |
+| Contributor write E2E  | `npm --prefix frontend run test:e2e:local:write`                        | local-only signup, password reset, upload start, download request side effects      |
 | API/router             | `deadtrees dev test api <path>`                                         | FastAPI routes, upload/download/process/auth behavior                               |
 | Database/RLS/migration | focused API DB tests plus migration review/reset where practical        | schema, policies, RPCs, views, generated contracts                                  |
 | Processor CPU          | `deadtrees dev test processor <path>`                                   | queue orchestration, GeoTIFF/COG/metadata, non-GPU utilities                        |
@@ -105,3 +106,18 @@ service responses to prove the UI contract without mutating production. The API
 contract smoke runs against the repo test stack and proves the same upload and
 processing payloads are accepted by FastAPI and persisted to the expected local
 test tables/storage paths.
+
+Use the local write-flow suite when auth, upload start, download start, or
+local storage side effects are part of the risk:
+
+```bash
+supabase start
+deadtrees dev start
+npm --prefix frontend run test:e2e:local:write
+```
+
+This suite is intentionally opt-in and local-only. It signs up a unique local
+contributor, requests a password reset through local Supabase Auth, verifies the
+reset email through Supabase Mailpit, uploads a small GeoTIFF through the real
+local API, asserts dataset/status/ortho/queue rows and archive storage, starts a
+download request, and asserts the local download bundle plus download audit log.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -74,6 +74,10 @@ npm --prefix frontend test
 npm --prefix frontend run test:e2e
 ```
 
+Use `npm --prefix frontend run test:e2e:local` for authenticated contributor
+upload-shell changes. It is intentionally separate from the production-read
+smoke suite.
+
 For user-facing UI changes, start the relevant Vite profile and validate with the
 Codex in-app browser or Playwright. Use `docs/playbooks/frontend-browser-regression.md`
 for production-connected smoke checks.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -78,6 +78,11 @@ Use `npm --prefix frontend run test:e2e:local` for authenticated contributor
 upload-shell changes. It is intentionally separate from the production-read
 smoke suite.
 
+Use `npm --prefix frontend run test:e2e:local:write` only when the local
+Supabase/API/Mailpit stack is running and the change needs real local
+signup/password-reset/upload/download side-effect coverage. This suite mutates
+local auth, database, mail, and storage state and cleans up after itself.
+
 For user-facing UI changes, start the relevant Vite profile and validate with the
 Codex in-app browser or Playwright. Use `docs/playbooks/frontend-browser-regression.md`
 for production-connected smoke checks.

--- a/frontend/e2e-local/contributor-local.spec.ts
+++ b/frontend/e2e-local/contributor-local.spec.ts
@@ -1,0 +1,218 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rgbGeoTiffFixture = path.resolve(
+  __dirname,
+  "../test/fixtures/geotiff/upload-validation/rgb-real-crop.tif",
+);
+
+const localSupabaseUrl = "http://127.0.0.1:54321";
+const localApiUrl = "http://localhost:8080/api/v1";
+const contributor = {
+  id: "00000000-0000-4000-8000-000000000001",
+  email: "contributor-local-e2e@example.com",
+};
+
+const createUnsignedJwt = (payload: Record<string, unknown>) => {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+
+  return [
+    encode({ alg: "none", typ: "JWT" }),
+    encode({
+      aud: "authenticated",
+      role: "authenticated",
+      sub: contributor.id,
+      email: contributor.email,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+      ...payload,
+    }),
+    "local-e2e",
+  ].join(".");
+};
+
+const createLocalSession = () => {
+  const accessToken = createUnsignedJwt({});
+  const now = new Date().toISOString();
+
+  return {
+    access_token: accessToken,
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: "local-e2e-refresh-token",
+    user: {
+      id: contributor.id,
+      aud: "authenticated",
+      role: "authenticated",
+      email: contributor.email,
+      email_confirmed_at: now,
+      app_metadata: { provider: "email", providers: ["email"] },
+      user_metadata: {},
+      created_at: now,
+      updated_at: now,
+    },
+  };
+};
+
+const installAuthenticatedContributor = async (page: Page) => {
+  const session = createLocalSession();
+
+  await page.addInitScript((localSession) => {
+    window.localStorage.setItem("sb-127-auth-token", JSON.stringify(localSession));
+  }, session);
+
+  await page.route(`${localSupabaseUrl}/auth/v1/user`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: session.user,
+    });
+  });
+
+  await page.route(`${localSupabaseUrl}/rest/v1/**`, async (route) => {
+    const url = new URL(route.request().url());
+    const table = url.pathname.split("/").pop();
+
+    if (table === "privileged_users") {
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          id: 1,
+          user_id: contributor.id,
+          can_upload_private: false,
+          can_audit: false,
+          can_view_all_private: false,
+          created_at: new Date().toISOString(),
+        },
+      });
+      return;
+    }
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: { "content-range": "0-0/0" },
+      json: [],
+    });
+  });
+};
+
+const extractMultipartText = (route: Route) =>
+  route.request().postDataBuffer()?.toString("latin1") ?? "";
+
+test.describe("contributor local e2e", () => {
+  test("authenticated contributor can open the upload workflow", async ({
+    page,
+  }) => {
+    await installAuthenticatedContributor(page);
+
+    await page.goto("/profile");
+
+    await expect(page.getByRole("heading", { name: "My Account" })).toBeVisible();
+    await expect(page.getByText(contributor.email)).toBeVisible();
+
+    await page.getByRole("button", { name: "Upload Data" }).click();
+
+    const modal = page.getByTestId("contributor-upload-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText("Orthophoto Upload")).toBeVisible();
+    await expect(page.getByTestId("contributor-upload-dropzone")).toBeAttached();
+    await expect(page.getByText("Click or drag file to this area")).toBeVisible();
+    await expect(page.getByTestId("contributor-upload-author-select")).toBeVisible();
+    await expect(page.getByTestId("contributor-upload-submit")).toBeDisabled();
+  });
+
+  test("GeoTIFF contribution sends upload and processing contracts", async ({
+    page,
+  }) => {
+    await installAuthenticatedContributor(page);
+
+    let uploadMultipartBody = "";
+    let processRequestBody: Record<string, unknown> | undefined;
+
+    await page.route(`${localApiUrl}/datasets/chunk`, async (route) => {
+      uploadMultipartBody = extractMultipartText(route);
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          id: 4242,
+          file_name: "rgb-real-crop.tif",
+          user_id: contributor.id,
+          license: "CC BY",
+          platform: "drone",
+          authors: ["Local E2E Contributor"],
+          data_access: "public",
+        },
+      });
+    });
+
+    await page.route(`${localApiUrl}/datasets/4242/process`, async (route) => {
+      processRequestBody = route.request().postDataJSON();
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          id: 99,
+          dataset_id: 4242,
+          task_types: processRequestBody?.task_types,
+          priority: processRequestBody?.priority,
+          is_processing: false,
+        },
+      });
+    });
+
+    await page.goto("/profile");
+    await page.getByRole("button", { name: "Upload Data" }).click();
+
+    await page.getByTestId("contributor-upload-dropzone").setInputFiles(rgbGeoTiffFixture);
+
+    await page.getByTestId("contributor-upload-author-select").click();
+    await page.keyboard.type("Local E2E Contributor");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Escape");
+
+    const dateInput = page.getByPlaceholder("Select date");
+    await dateInput.fill("2024-05-06");
+    await dateInput.press("Enter");
+
+    await page.getByLabel("DOI").fill("https://doi.org/10.1234/deadtrees.local-e2e");
+    await page
+      .getByLabel("Additional Information")
+      .fill("Local contributor smoke metadata");
+    await page.getByRole("checkbox", { name: /I agree to the/i }).check();
+
+    await expect(page.getByTestId("contributor-upload-submit")).toBeEnabled();
+    await page.getByTestId("contributor-upload-submit").click();
+
+    await expect.poll(() => uploadMultipartBody).toContain('name="upload_type"');
+    expect(uploadMultipartBody).toContain("\r\n\r\ngeotiff\r\n");
+    expect(uploadMultipartBody).toContain('name="platform"');
+    expect(uploadMultipartBody).toContain("\r\n\r\ndrone\r\n");
+    expect(uploadMultipartBody).toContain('name="authors"');
+    expect(uploadMultipartBody).toContain("\r\n\r\nLocal E2E Contributor\r\n");
+    expect(uploadMultipartBody).toContain('name="aquisition_year"');
+    expect(uploadMultipartBody).toContain("\r\n\r\n2024\r\n");
+    expect(uploadMultipartBody).toContain('name="aquisition_month"');
+    expect(uploadMultipartBody).toContain("\r\n\r\n5\r\n");
+    expect(uploadMultipartBody).toContain('name="aquisition_day"');
+    expect(uploadMultipartBody).toContain("\r\n\r\n6\r\n");
+    expect(uploadMultipartBody).toContain('name="data_access"');
+    expect(uploadMultipartBody).toContain("\r\n\r\npublic\r\n");
+    expect(uploadMultipartBody).toContain('name="citation_doi"');
+    expect(uploadMultipartBody).toContain("https://doi.org/10.1234/deadtrees.local-e2e");
+
+    await expect.poll(() => processRequestBody).toEqual({
+      task_types: [
+        "geotiff",
+        "cog",
+        "thumbnail",
+        "metadata",
+        "deadwood_v1",
+        "treecover_v1",
+        "deadwood_treecover_combined_v2",
+      ],
+      priority: 4,
+    });
+  });
+});

--- a/frontend/e2e-local/contributor-local.spec.ts
+++ b/frontend/e2e-local/contributor-local.spec.ts
@@ -62,7 +62,10 @@ const installAuthenticatedContributor = async (page: Page) => {
   const session = createLocalSession();
 
   await page.addInitScript((localSession) => {
-    window.localStorage.setItem("sb-127-auth-token", JSON.stringify(localSession));
+    window.localStorage.setItem(
+      "sb-127-auth-token",
+      JSON.stringify(localSession),
+    );
   }, session);
 
   await page.route(`${localSupabaseUrl}/auth/v1/user`, async (route) => {
@@ -110,7 +113,9 @@ test.describe("contributor local e2e", () => {
 
     await page.goto("/profile");
 
-    await expect(page.getByRole("heading", { name: "My Account" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "My Account" }),
+    ).toBeVisible();
     await expect(page.getByText(contributor.email)).toBeVisible();
 
     await page.getByRole("button", { name: "Upload Data" }).click();
@@ -118,9 +123,15 @@ test.describe("contributor local e2e", () => {
     const modal = page.getByTestId("contributor-upload-modal");
     await expect(modal).toBeVisible();
     await expect(modal.getByText("Orthophoto Upload")).toBeVisible();
-    await expect(page.getByTestId("contributor-upload-dropzone")).toBeAttached();
-    await expect(page.getByText("Click or drag file to this area")).toBeVisible();
-    await expect(page.getByTestId("contributor-upload-author-select")).toBeVisible();
+    await expect(
+      page.getByTestId("contributor-upload-dropzone"),
+    ).toBeAttached();
+    await expect(
+      page.getByText("Click or drag file to this area"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("contributor-upload-author-select"),
+    ).toBeVisible();
     await expect(page.getByTestId("contributor-upload-submit")).toBeDisabled();
   });
 
@@ -165,18 +176,19 @@ test.describe("contributor local e2e", () => {
     await page.goto("/profile");
     await page.getByRole("button", { name: "Upload Data" }).click();
 
-    await page.getByTestId("contributor-upload-dropzone").setInputFiles(rgbGeoTiffFixture);
+    await page
+      .getByTestId("contributor-upload-dropzone")
+      .setInputFiles(rgbGeoTiffFixture);
 
-    await page.getByTestId("contributor-upload-author-select").click();
-    await page.keyboard.type("Local E2E Contributor");
-    await page.keyboard.press("Enter");
-    await page.keyboard.press("Escape");
+    await addUploadAuthor(page, "Local E2E Contributor");
 
     const dateInput = page.getByPlaceholder("Select date");
     await dateInput.fill("2024-05-06");
     await dateInput.press("Enter");
 
-    await page.getByLabel("DOI").fill("https://doi.org/10.1234/deadtrees.local-e2e");
+    await page
+      .getByLabel("DOI")
+      .fill("https://doi.org/10.1234/deadtrees.local-e2e");
     await page
       .getByLabel("Additional Information")
       .fill("Local contributor smoke metadata");
@@ -185,7 +197,9 @@ test.describe("contributor local e2e", () => {
     await expect(page.getByTestId("contributor-upload-submit")).toBeEnabled();
     await page.getByTestId("contributor-upload-submit").click();
 
-    await expect.poll(() => uploadMultipartBody).toContain('name="upload_type"');
+    await expect
+      .poll(() => uploadMultipartBody)
+      .toContain('name="upload_type"');
     expect(uploadMultipartBody).toContain("\r\n\r\ngeotiff\r\n");
     expect(uploadMultipartBody).toContain('name="platform"');
     expect(uploadMultipartBody).toContain("\r\n\r\ndrone\r\n");
@@ -200,19 +214,30 @@ test.describe("contributor local e2e", () => {
     expect(uploadMultipartBody).toContain('name="data_access"');
     expect(uploadMultipartBody).toContain("\r\n\r\npublic\r\n");
     expect(uploadMultipartBody).toContain('name="citation_doi"');
-    expect(uploadMultipartBody).toContain("https://doi.org/10.1234/deadtrees.local-e2e");
+    expect(uploadMultipartBody).toContain(
+      "https://doi.org/10.1234/deadtrees.local-e2e",
+    );
 
-    await expect.poll(() => processRequestBody).toEqual({
-      task_types: [
-        "geotiff",
-        "cog",
-        "thumbnail",
-        "metadata",
-        "deadwood_v1",
-        "treecover_v1",
-        "deadwood_treecover_combined_v2",
-      ],
-      priority: 4,
-    });
+    await expect
+      .poll(() => processRequestBody)
+      .toEqual({
+        task_types: [
+          "geotiff",
+          "cog",
+          "thumbnail",
+          "metadata",
+          "deadwood_v1",
+          "treecover_v1",
+          "deadwood_treecover_combined_v2",
+        ],
+        priority: 4,
+      });
   });
 });
+
+async function addUploadAuthor(page: Page, author: string) {
+  const authorSelect = page.getByTestId("contributor-upload-author-select");
+  await authorSelect.locator("input").fill(author);
+  await authorSelect.locator("input").press("Enter");
+  await expect(authorSelect).toContainText(author);
+}

--- a/frontend/e2e-local/contributor-write-flows.spec.ts
+++ b/frontend/e2e-local/contributor-write-flows.spec.ts
@@ -1,0 +1,571 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const rgbGeoTiffFixture = path.resolve(
+  __dirname,
+  "../test/fixtures/geotiff/upload-validation/rgb-real-crop.tif",
+);
+
+const localSupabaseUrl = "http://127.0.0.1:54321";
+const localApiUrl = "http://localhost:8080/api/v1";
+const localMailpitUrl = "http://127.0.0.1:54324";
+
+type MailpitMessageSummary = {
+  ID: string;
+  Subject?: string;
+  To?: Array<{ Address?: string }>;
+};
+
+type LocalSession = {
+  access_token: string;
+  user: {
+    id: string;
+    email?: string;
+  };
+};
+
+const uniqueRunId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const contributorEmail = `local-write-${uniqueRunId}@example.com`;
+const initialPassword = `Initial-${uniqueRunId}!`;
+const resetPassword = `Reset-${uniqueRunId}!`;
+const contributorName = "Local Write Contributor";
+const uploadDoi = `https://doi.org/10.1234/deadtrees.local-write-${uniqueRunId}`;
+
+let adminClient: SupabaseClient;
+let anonClient: SupabaseClient;
+const uploadedDatasetIds: number[] = [];
+let contributorAccessToken = "";
+
+test.describe("contributor local write flows", () => {
+  test.skip(
+    process.env.E2E_LOCAL_WRITE !== "1",
+    "Set E2E_LOCAL_WRITE=1 and start local Supabase/API/Mailpit before running this write suite.",
+  );
+
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async () => {
+    adminClient = createLocalSupabaseClient(
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    );
+    anonClient = createLocalSupabaseClient(
+      process.env.VITE_SUPABASE_ANON_KEY || requireEnv("SUPABASE_ANON_KEY"),
+    );
+
+    await expectLocalService(
+      `${localSupabaseUrl}/auth/v1/settings`,
+      "local Supabase",
+    );
+    await expectLocalService(`${localApiUrl}/`, "local API");
+    await expectLocalService(
+      `${localMailpitUrl}/api/v1/info`,
+      "local Supabase Mailpit",
+    );
+    await purgeMailpit();
+    await deleteAuthUsersByEmail(adminClient, contributorEmail);
+  });
+
+  test.afterAll(async () => {
+    await cleanupDatasets(adminClient, uploadedDatasetIds);
+    await deleteAuthUsersByEmail(adminClient, contributorEmail);
+    await purgeMailpit();
+  });
+
+  test("signup creates a local authenticated contributor", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page.getByPlaceholder(/email/i).fill(contributorEmail);
+    await page.getByPlaceholder(/password/i).fill(initialPassword);
+    await page.getByRole("button", { name: /sign up/i }).click();
+
+    await expect(page).toHaveURL(/\/profile$/, { timeout: 20_000 });
+    await expect(
+      page.getByRole("heading", { name: "My Account" }),
+    ).toBeVisible();
+    await expect(page.getByText(contributorEmail)).toBeVisible();
+
+    const user = await waitForAuthUser(contributorEmail);
+    expect(user.email).toBe(contributorEmail);
+    expect(user.email_confirmed_at).toBeTruthy();
+  });
+
+  test("password reset sends local email and updates the credential", async ({
+    page,
+  }) => {
+    await clearBrowserSession(page);
+    await purgeMailpit();
+
+    await page.goto("/forgot-password");
+    await page.getByPlaceholder(/email/i).fill(contributorEmail);
+    await page.getByRole("button", { name: /reset|send/i }).click();
+
+    const recoveryLink = await waitForRecoveryLink(contributorEmail);
+    expect(recoveryLink).toContain("/auth/v1/verify");
+    expect(recoveryLink).toContain("type=recovery");
+
+    await page.goto(recoveryLink);
+    await expect(page).toHaveURL(/\/reset-password/, { timeout: 20_000 });
+    await expect(
+      page.getByRole("heading", { name: "Reset Password" }),
+    ).toBeVisible();
+
+    await page.getByLabel(/^New Password$/i).fill(resetPassword);
+    await page.getByLabel(/^Confirm New Password$/i).fill(resetPassword);
+    await page.getByRole("button", { name: /^Reset Password$/i }).click();
+
+    await expect(page).toHaveURL(/\/profile$/, { timeout: 20_000 });
+    await expect(page.getByText(contributorEmail)).toBeVisible();
+
+    const oldLogin = await anonClient.auth.signInWithPassword({
+      email: contributorEmail,
+      password: initialPassword,
+    });
+    expect(oldLogin.error?.message).toMatch(/invalid login credentials/i);
+
+    const newLogin = await anonClient.auth.signInWithPassword({
+      email: contributorEmail,
+      password: resetPassword,
+    });
+    expect(newLogin.error).toBeNull();
+    expect(newLogin.data.user?.email).toBe(contributorEmail);
+    await anonClient.auth.signOut();
+  });
+
+  test("upload start writes dataset, storage object, and processing queue", async ({
+    page,
+  }) => {
+    await signInContributor(page);
+    await expect(
+      page.getByRole("heading", { name: "My Account" }),
+    ).toBeVisible();
+    contributorAccessToken = await getBrowserAccessToken(page);
+
+    const uploadResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url() === `${localApiUrl}/datasets/chunk` &&
+        response.request().method() === "POST",
+    );
+    const processResponsePromise = page.waitForResponse(
+      (response) =>
+        /\/datasets\/\d+\/process$/.test(response.url()) &&
+        response.request().method() === "PUT",
+    );
+
+    await page.getByRole("button", { name: "Upload Data" }).click();
+    await page
+      .getByTestId("contributor-upload-dropzone")
+      .setInputFiles(rgbGeoTiffFixture);
+
+    await addUploadAuthor(page, contributorName);
+
+    const dateInput = page.getByPlaceholder("Select date");
+    await dateInput.fill("2024-05-06");
+    await dateInput.press("Enter");
+
+    await page.getByLabel("DOI").fill(uploadDoi);
+    await page
+      .getByLabel("Additional Information")
+      .fill("Local write-flow upload start");
+    await page.getByRole("checkbox", { name: /I agree to the/i }).check();
+
+    await expect(page.getByTestId("contributor-upload-submit")).toBeEnabled();
+    await page.getByTestId("contributor-upload-submit").click();
+
+    const uploadResponse = await uploadResponsePromise;
+    expect(uploadResponse.status()).toBe(200);
+    const uploadedDataset = await uploadResponse.json();
+    const datasetId = Number(uploadedDataset.id);
+    expect(datasetId).toBeGreaterThan(0);
+    uploadedDatasetIds.push(datasetId);
+
+    const processResponse = await processResponsePromise;
+    expect(processResponse.status()).toBe(200);
+
+    await expectDatasetSideEffects(datasetId);
+  });
+
+  test("download request creates a local bundle and download audit log", async ({
+    request,
+  }) => {
+    const datasetId = uploadedDatasetIds.at(-1);
+    expect(datasetId).toBeTruthy();
+    expect(contributorAccessToken).toBeTruthy();
+
+    await markUploadedDatasetDownloadable(datasetId!);
+
+    const status = await startAndWaitForDatasetDownload(
+      request,
+      datasetId!,
+      contributorAccessToken,
+    );
+
+    expect(status.download_path).toBe(
+      `/downloads/v1/${datasetId}/${datasetId}.zip`,
+    );
+
+    const downloadFile = path.join(
+      repoRoot,
+      "data",
+      "downloads",
+      String(datasetId),
+      `${datasetId}.zip`,
+    );
+    expect(fs.existsSync(downloadFile)).toBe(true);
+
+    const { data: logs, error } = await adminClient
+      .from("v2_logs")
+      .select("id, category, dataset_id, extra")
+      .eq("dataset_id", datasetId)
+      .eq("category", "download");
+
+    expect(error).toBeNull();
+    expect(logs?.some((log) => log.extra?.event === "allowed")).toBe(true);
+  });
+});
+
+async function expectLocalService(url: string, name: string) {
+  const response = await fetch(url).catch((error) => {
+    throw new Error(`${name} is not reachable at ${url}: ${String(error)}`);
+  });
+
+  if (!response.ok) {
+    throw new Error(`${name} returned ${response.status} for ${url}`);
+  }
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set for the local write E2E suite.`);
+  }
+  return value;
+}
+
+function createLocalSupabaseClient(key: string) {
+  return createClient(localSupabaseUrl, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+async function clearBrowserSession(page: Page) {
+  await page.goto("/");
+  await page.evaluate(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+}
+
+async function signInContributor(page: Page) {
+  await page.goto("/sign-in");
+  await page.getByPlaceholder(/email/i).fill(contributorEmail);
+  await page.getByPlaceholder(/password/i).fill(resetPassword);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expect(page).toHaveURL(/\/profile$/, { timeout: 20_000 });
+}
+
+async function addUploadAuthor(page: Page, author: string) {
+  const authorSelect = page.getByTestId("contributor-upload-author-select");
+  await authorSelect.locator("input").fill(author);
+  await authorSelect.locator("input").press("Enter");
+  await expect(authorSelect).toContainText(author);
+}
+
+async function purgeMailpit() {
+  await fetch(`${localMailpitUrl}/api/v1/messages`, { method: "DELETE" });
+}
+
+async function waitForAuthUser(email: string) {
+  const deadline = Date.now() + 10_000;
+
+  while (Date.now() < deadline) {
+    const user = await findAuthUserByEmail(adminClient, email);
+    if (user) {
+      return user;
+    }
+    await delay(250);
+  }
+
+  throw new Error(`Timed out waiting for local auth user ${email}`);
+}
+
+async function findAuthUserByEmail(client: SupabaseClient, email: string) {
+  for (let page = 1; page <= 10; page += 1) {
+    const { data, error } = await client.auth.admin.listUsers({
+      page,
+      perPage: 100,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const user = data.users.find((candidate) => candidate.email === email);
+    if (user) {
+      return user;
+    }
+
+    if (data.users.length < 100) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+async function deleteAuthUsersByEmail(client: SupabaseClient, email: string) {
+  let user = await findAuthUserByEmail(client, email);
+
+  while (user) {
+    const { error } = await client.auth.admin.deleteUser(user.id);
+    if (error) {
+      throw error;
+    }
+    user = await findAuthUserByEmail(client, email);
+  }
+}
+
+async function waitForRecoveryLink(email: string) {
+  const deadline = Date.now() + 15_000;
+
+  while (Date.now() < deadline) {
+    const summariesResponse = await fetch(`${localMailpitUrl}/api/v1/messages`);
+    const summaries = await summariesResponse.json();
+    const message = (summaries.messages as MailpitMessageSummary[]).find(
+      (candidate) =>
+        candidate.To?.some((recipient) => recipient.Address === email) &&
+        /reset|recover|password/i.test(candidate.Subject ?? ""),
+    );
+
+    if (message) {
+      const detailResponse = await fetch(
+        `${localMailpitUrl}/api/v1/message/${message.ID}`,
+      );
+      const detail = await detailResponse.json();
+      const body = [detail.HTML, detail.Text, detail.Snippet]
+        .filter(Boolean)
+        .join("\n")
+        .replaceAll("&amp;", "&");
+      const match = body.match(
+        /https?:\/\/[^"'<>\s]+\/auth\/v1\/verify\?[^"'<>\s]+/,
+      );
+
+      if (match?.[0]) {
+        return match[0];
+      }
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(`Timed out waiting for password recovery email to ${email}`);
+}
+
+async function expectDatasetSideEffects(datasetId: number) {
+  const { data: datasetRows, error: datasetError } = await adminClient
+    .from("v2_datasets")
+    .select(
+      "id, file_name, authors, data_access, citation_doi, aquisition_year, aquisition_month, aquisition_day",
+    )
+    .eq("id", datasetId);
+
+  expect(datasetError).toBeNull();
+  expect(datasetRows).toEqual([
+    expect.objectContaining({
+      id: datasetId,
+      file_name: "rgb-real-crop.tif",
+      authors: [contributorName],
+      data_access: "public",
+      citation_doi: uploadDoi,
+      aquisition_year: 2024,
+      aquisition_month: 5,
+      aquisition_day: 6,
+    }),
+  ]);
+
+  const { data: orthoRows, error: orthoError } = await adminClient
+    .from("v2_orthos")
+    .select("dataset_id, ortho_file_name")
+    .eq("dataset_id", datasetId);
+
+  expect(orthoError).toBeNull();
+  expect(orthoRows).toEqual([]);
+
+  const archiveFile = path.join(
+    repoRoot,
+    "data",
+    "archive",
+    `${datasetId}_ortho.tif`,
+  );
+  expect(fs.existsSync(archiveFile)).toBe(true);
+  expect(fs.statSync(archiveFile).size).toBeGreaterThan(0);
+
+  const { data: statusRows, error: statusError } = await adminClient
+    .from("v2_statuses")
+    .select("dataset_id, current_status, is_upload_done, has_error")
+    .eq("dataset_id", datasetId);
+
+  expect(statusError).toBeNull();
+  expect(statusRows).toEqual([
+    expect.objectContaining({
+      dataset_id: datasetId,
+      current_status: "idle",
+      is_upload_done: true,
+      has_error: false,
+    }),
+  ]);
+
+  const { data: queueRows, error: queueError } = await adminClient
+    .from("v2_queue")
+    .select("dataset_id, task_types, priority, is_processing")
+    .eq("dataset_id", datasetId);
+
+  expect(queueError).toBeNull();
+  expect(queueRows).toEqual([
+    {
+      dataset_id: datasetId,
+      task_types: [
+        "geotiff",
+        "cog",
+        "thumbnail",
+        "metadata",
+        "deadwood_v1",
+        "treecover_v1",
+        "deadwood_treecover_combined_v2",
+      ],
+      priority: 4,
+      is_processing: false,
+    },
+  ]);
+}
+
+async function markUploadedDatasetDownloadable(datasetId: number) {
+  const archiveFile = path.join(
+    repoRoot,
+    "data",
+    "archive",
+    `${datasetId}_ortho.tif`,
+  );
+  const fileSizeMb = Math.max(
+    1,
+    Math.ceil(fs.statSync(archiveFile).size / 1024 / 1024),
+  );
+
+  const { error: orthoError } = await adminClient.from("v2_orthos").insert({
+    dataset_id: datasetId,
+    ortho_file_name: `${datasetId}_ortho.tif`,
+    version: 1,
+    ortho_file_size: fileSizeMb,
+    ortho_upload_runtime: 0.1,
+  });
+  expect(orthoError).toBeNull();
+
+  const { error: statusError } = await adminClient
+    .from("v2_statuses")
+    .update({ is_ortho_done: true })
+    .eq("dataset_id", datasetId);
+  expect(statusError).toBeNull();
+}
+
+async function getBrowserAccessToken(page: Page) {
+  const session = await page.evaluate(() => {
+    const storageKey = Object.keys(window.localStorage).find(
+      (key) => key.startsWith("sb-") && key.endsWith("-auth-token"),
+    );
+
+    if (!storageKey) {
+      return null;
+    }
+
+    return JSON.parse(window.localStorage.getItem(storageKey) || "null");
+  });
+
+  expect(session).toBeTruthy();
+  return (session as LocalSession).access_token;
+}
+
+async function startAndWaitForDatasetDownload(
+  request: APIRequestContext,
+  datasetId: number,
+  accessToken: string,
+) {
+  const startResponse = await request.get(
+    `${localApiUrl}/download/datasets/${datasetId}/dataset.zip`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+
+  expect(startResponse.status()).toBe(200);
+  const started = await startResponse.json();
+  expect(started.job_id).toBe(String(datasetId));
+
+  const deadline = Date.now() + 20_000;
+  let lastStatus = started;
+
+  while (Date.now() < deadline) {
+    const statusResponse = await request.get(
+      `${localApiUrl}/download/datasets/${datasetId}/status`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+    expect(statusResponse.status()).toBe(200);
+    lastStatus = await statusResponse.json();
+
+    if (lastStatus.status === "completed") {
+      return lastStatus;
+    }
+
+    if (lastStatus.status === "failed") {
+      throw new Error(`Download failed: ${lastStatus.message}`);
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for dataset ${datasetId} download; last status: ${JSON.stringify(lastStatus)}`,
+  );
+}
+
+async function cleanupDatasets(client: SupabaseClient, datasetIds: number[]) {
+  for (const datasetId of datasetIds) {
+    await client.from("v2_logs").delete().eq("dataset_id", datasetId);
+    await client.from("v2_queue").delete().eq("dataset_id", datasetId);
+    await client.from("v2_statuses").delete().eq("dataset_id", datasetId);
+    await client.from("v2_orthos").delete().eq("dataset_id", datasetId);
+    await client.from("v2_metadata").delete().eq("dataset_id", datasetId);
+    await client.from("v2_datasets").delete().eq("id", datasetId);
+
+    fs.rmSync(
+      path.join(repoRoot, "data", "archive", `${datasetId}_ortho.tif`),
+      {
+        force: true,
+      },
+    );
+    fs.rmSync(path.join(repoRoot, "data", "downloads", String(datasetId)), {
+      force: true,
+      recursive: true,
+    });
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/frontend/e2e-local/contributor-write-flows.spec.ts
+++ b/frontend/e2e-local/contributor-write-flows.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,7 +36,7 @@ type LocalSession = {
   };
 };
 
-const uniqueRunId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const uniqueRunId = `${Date.now()}-${randomUUID()}`;
 const contributorEmail = `local-write-${uniqueRunId}@example.com`;
 const initialPassword = `Initial-${uniqueRunId}!`;
 const resetPassword = `Reset-${uniqueRunId}!`;

--- a/frontend/e2e-local/contributor-write-flows.spec.ts
+++ b/frontend/e2e-local/contributor-write-flows.spec.ts
@@ -286,7 +286,15 @@ async function addUploadAuthor(page: Page, author: string) {
 }
 
 async function purgeMailpit() {
-  await fetch(`${localMailpitUrl}/api/v1/messages`, { method: "DELETE" });
+  const response = await fetch(`${localMailpitUrl}/api/v1/messages`, {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to purge Mailpit: ${response.status} ${await response.text()}`,
+    );
+  }
 }
 
 async function waitForAuthUser(email: string) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:readonly": "playwright test",
+    "test:e2e:local": "playwright test --config playwright.local.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "test:e2e": "playwright test",
     "test:e2e:readonly": "playwright test",
     "test:e2e:local": "playwright test --config playwright.local.config.ts",
+    "test:e2e:local:write": "bash ./scripts/run-local-write-e2e.sh",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/frontend/playwright.local.config.ts
+++ b/frontend/playwright.local.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT || 5173);
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e-local",
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    browserName: "chromium",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  webServer: {
+    command:
+      "bash -lc 'if [ -f .env.dev.local ]; then set -a; source .env.dev.local; set +a; fi; export VITE_MODE=development; npm run dev -- --host 127.0.0.1 --port " +
+      PORT +
+      "'",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/frontend/scripts/run-local-write-e2e.sh
+++ b/frontend/scripts/run-local-write-e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+
+ENV_FILE="$REPO_ROOT/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  ENV_FILE="$REPO_ROOT/.env.example"
+fi
+
+for key in SUPABASE_SERVICE_ROLE_KEY SUPABASE_ANON_KEY; do
+  value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "$value" ]]; then
+    echo "Missing $key in $ENV_FILE; local write E2E needs local Supabase keys." >&2
+    exit 1
+  fi
+  export "$key=$value"
+done
+
+export E2E_LOCAL_WRITE=1
+
+cd "$FRONTEND_DIR"
+exec ./node_modules/.bin/playwright test --config playwright.local.config.ts e2e-local/contributor-write-flows.spec.ts

--- a/frontend/src/components/Upload/PickerWithType.tsx
+++ b/frontend/src/components/Upload/PickerWithType.tsx
@@ -7,6 +7,8 @@ interface PickerWithTypeProps {
   pickerTypeOptions: string[];
   pickerType: string;
   setPickerType: (type: string) => void;
+  datePickerTestId?: string;
+  pickerTypeTestId?: string;
 }
 
 const pickerTypeToAntdPicker: Record<string, "date" | "month" | "year"> = {
@@ -15,7 +17,15 @@ const pickerTypeToAntdPicker: Record<string, "date" | "month" | "year"> = {
   Year: "year",
 } as const;
 
-const PickerWithType = ({ value, onChange, pickerTypeOptions, pickerType, setPickerType }: PickerWithTypeProps) => {
+const PickerWithType = ({
+  value,
+  onChange,
+  pickerTypeOptions,
+  pickerType,
+  setPickerType,
+  datePickerTestId,
+  pickerTypeTestId,
+}: PickerWithTypeProps) => {
   const handleDateChange = (date: Dayjs | null) => {
     if (date) {
       // Normalize the date based on picker type
@@ -44,6 +54,7 @@ const PickerWithType = ({ value, onChange, pickerTypeOptions, pickerType, setPic
   return (
     <div className="flex w-full space-x-4">
       <Select
+        data-testid={pickerTypeTestId}
         style={{ width: "100%" }}
         value={pickerType}
         onChange={(newType) => {
@@ -59,6 +70,7 @@ const PickerWithType = ({ value, onChange, pickerTypeOptions, pickerType, setPic
         ))}
       </Select>
       <DatePicker
+        data-testid={datePickerTestId}
         className="w-full"
         picker={pickerTypeToAntdPicker[pickerType]}
         onChange={handleDateChange}

--- a/frontend/src/components/Upload/UploadModal.tsx
+++ b/frontend/src/components/Upload/UploadModal.tsx
@@ -345,7 +345,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
       maskClosable={false}
       width={720}
     >
-      <div className="m-0 px-4 py-0">
+      <div className="m-0 px-4 py-0" data-testid="contributor-upload-modal">
         <Typography.Title style={{ margin: 0, paddingBottom: 16 }} level={4}>
           Orthophoto Upload
         </Typography.Title>
@@ -359,6 +359,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
           <div className="flex flex-col w-full gap-1">
             <Form.Item label="Orthophoto" rules={[{ required: true, message: "Please upload a GeoTIFF file" }]}>
               <Upload.Dragger
+                data-testid="contributor-upload-dropzone"
                 fileList={fileList}
                 onChange={onFileChange}
                 beforeUpload={handleBeforeUpload}
@@ -420,13 +421,19 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
             >
               {authors?.at(0)?.label ? (
                 <Select
+                  data-testid="contributor-upload-author-select"
                   mode="tags"
                   style={{ width: "100%" }}
                   options={authors}
                   placeholder="Enter author names separately (e.g. 'John Smith')"
                 />
               ) : (
-                <Select mode="tags" style={{ width: "100%" }} placeholder="Enter authors (one author per entry)" />
+                <Select
+                  data-testid="contributor-upload-author-select"
+                  mode="tags"
+                  style={{ width: "100%" }}
+                  placeholder="Enter authors (one author per entry)"
+                />
               )}
             </Form.Item>
 
@@ -449,6 +456,8 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
                 pickerType={pickerType}
                 setPickerType={setPickerType}
                 onChange={(date) => form.setFieldsValue({ aquisition_date: date })}
+                datePickerTestId="contributor-upload-acquisition-date"
+                pickerTypeTestId="contributor-upload-acquisition-date-type"
               />
             </Form.Item>
 
@@ -592,7 +601,12 @@ const UploadModal: React.FC<UploadModalProps> = ({ isVisible, onClose, uploadKey
                   </Checkbox>
                 </Form.Item>
                 <Space className="pt-2">
-                  <Button type="primary" htmlType="submit" disabled={fileList.length === 0 || !agreementAccepted}>
+                  <Button
+                    data-testid="contributor-upload-submit"
+                    type="primary"
+                    htmlType="submit"
+                    disabled={fileList.length === 0 || !agreementAccepted}
+                  >
                     Upload
                   </Button>
                   <Button type="default" onClick={onClose}>


### PR DESCRIPTION
## Summary
- Add a DeadTrees local contributor smoke layer for authenticated upload workflows.
- Add an opt-in local write-flow suite for signup, password reset, upload start, and download request side effects.
- Document when future agents should run read-only, local mocked, local write, and API contract tests.
- Keep production-read CI safe and separate from mutating local-only validation.

## Why
Fast read-only CI catches public integration regressions, but contributor flows also need controlled local tests that prove real auth, mail, database, storage, and API side effects without touching production.

## Coverage
- Local mocked contributor browser smoke: upload modal and frontend upload/process contracts.
- API contract smoke: GeoTIFF/RAW ZIP upload chunk storage routing and process queue payload persistence.
- Local write E2E: real local Supabase signup, password reset through Mailpit, password update verification, GeoTIFF upload start through the local API, dataset/status/queue/archive assertions, download bundle creation, and download audit log assertion.

## Validation
- `npm --prefix frontend test -- --run`
- `npm --prefix frontend run test:e2e:local`
- `npm --prefix frontend run test:e2e:local:write`
- Headed local write run with Chromium visible
- `venv/bin/deadtrees dev test api api/tests/routers/test_contributor_contract_smoke.py`
- `git diff --check`

## Risk
Local write tests are intentionally opt-in and mutate only the local Supabase/API/Mailpit/storage stack. They are not added to production-read PR CI in this pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local end-to-end testing capabilities for contributor workflows, including signup, upload, and download flows.
  * New test commands available for developers to validate contributor functionality locally.

* **Documentation**
  * Updated testing strategy with detailed guidance on local contributor testing procedures and write-flow validation.

* **Tests**
  * Added comprehensive smoke and integration tests for contributor contract validation.
  * Added contributor workflow E2E test suites for local development.

* **Chores**
  * Updated GitHub Actions workflow and Playwright configuration for local testing support.
  * Enhanced UI components with testing identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test- and docs-focused, with only non-functional `data-testid` additions to upload UI components.
> 
> **Overview**
> Adds a new **local contributor testing layer**: Playwright specs for authenticated upload-shell contract validation (mocked local services) plus an opt-in local *write-flow* suite that exercises real local Supabase/Auth/Mailpit, upload start, and download side effects.
> 
> Introduces an API router smoke (`test_contributor_contract_smoke.py`) to assert chunk uploads land in the correct temp storage paths for GeoTIFF vs raw ZIP and that `/process` enqueues the expected task list/priority in the queue table.
> 
> Wires in supporting tooling: new Playwright local config + runner script, new `npm` scripts (`test:e2e:local`, `test:e2e:local:write`), documentation updates for when to run each suite, and `data-testid` hooks on upload modal controls to make the new E2E tests stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a69910cc6cf07a53ffb5e3fac2ef078802001e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->