### PR TITLE
test(frontend): cover auditor local workflows

### DIFF
--- a/api/tests/db/test_auditor_flag_review_contract.py
+++ b/api/tests/db/test_auditor_flag_review_contract.py
@@ -1,0 +1,234 @@
+import pytest
+
+from shared.db import login, use_client
+from shared.models import DatasetAccessEnum, LicenseEnum, PlatformEnum
+from shared.settings import settings
+
+
+@pytest.fixture(scope='function')
+def audit_privileged_user(test_user):
+	processor_token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)
+	privileged_user_id = None
+	previous_privilege = None
+
+	try:
+		with use_client(processor_token) as client:
+			existing = client.table('privileged_users').select('*').eq('user_id', test_user).limit(1).execute()
+
+			if existing.data:
+				previous_privilege = existing.data[0]
+				client.table('privileged_users').update(
+					{
+						'can_upload_private': previous_privilege.get('can_upload_private', False),
+						'can_view_all_private': previous_privilege.get('can_view_all_private', False),
+						'can_audit': True,
+					}
+				).eq('id', previous_privilege['id']).execute()
+			else:
+				response = client.table('privileged_users').insert(
+					{
+						'user_id': test_user,
+						'can_upload_private': False,
+						'can_view_all_private': False,
+						'can_audit': True,
+					}
+				).execute()
+				privileged_user_id = response.data[0]['id']
+
+		yield test_user
+
+	finally:
+		with use_client(processor_token) as client:
+			if previous_privilege:
+				client.table('privileged_users').update(
+					{
+						'can_upload_private': previous_privilege.get('can_upload_private', False),
+						'can_view_all_private': previous_privilege.get('can_view_all_private', False),
+						'can_audit': previous_privilege.get('can_audit', False),
+					}
+				).eq('id', previous_privilege['id']).execute()
+			elif privileged_user_id:
+				client.table('privileged_users').delete().eq('id', privileged_user_id).execute()
+
+
+@pytest.fixture(scope='function')
+def flagged_dataset(test_user2):
+	reporter_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+	dataset_id = None
+	flag_id = None
+
+	try:
+		with use_client(reporter_token) as client:
+			dataset_response = client.table(settings.datasets_table).insert(
+				{
+					'file_name': 'auditor-flag-review-contract.tif',
+					'user_id': test_user2,
+					'license': LicenseEnum.cc_by.value,
+					'platform': PlatformEnum.drone.value,
+					'authors': ['Flag Review Contract Reporter'],
+					'data_access': DatasetAccessEnum.public.value,
+					'aquisition_year': 2024,
+					'aquisition_month': 5,
+					'aquisition_day': 6,
+				}
+			).execute()
+			dataset_id = dataset_response.data[0]['id']
+
+			flag_response = client.table('dataset_flags').insert(
+				{
+					'dataset_id': dataset_id,
+					'created_by': test_user2,
+					'is_ortho_mosaic_issue': True,
+					'is_prediction_issue': False,
+					'description': 'Local contract smoke issue',
+					'status': 'open',
+				}
+			).execute()
+			flag_id = flag_response.data[0]['id']
+
+		yield {'dataset_id': dataset_id, 'flag_id': flag_id}
+
+	finally:
+		processor_token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)
+		with use_client(processor_token) as client:
+			if flag_id:
+				client.table('dataset_flag_status_history').delete().eq('flag_id', flag_id).execute()
+				client.table('dataset_flags').delete().eq('id', flag_id).execute()
+			if dataset_id:
+				client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+@pytest.fixture(scope='function')
+def non_audit_user(test_user2):
+	processor_token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)
+	created_privilege_id = None
+	previous_privileges = []
+
+	try:
+		with use_client(processor_token) as client:
+			existing = client.table('privileged_users').select('*').eq('user_id', test_user2).execute()
+			previous_privileges = existing.data or []
+
+			if previous_privileges:
+				client.table('privileged_users').update(
+					{
+						'can_upload_private': False,
+						'can_view_all_private': False,
+						'can_audit': False,
+					}
+				).eq('user_id', test_user2).execute()
+			else:
+				response = client.table('privileged_users').insert(
+					{
+						'user_id': test_user2,
+						'can_upload_private': False,
+						'can_view_all_private': False,
+						'can_audit': False,
+					}
+				).execute()
+				created_privilege_id = response.data[0]['id']
+
+		yield test_user2
+
+	finally:
+		with use_client(processor_token) as client:
+			if previous_privileges:
+				for privilege in previous_privileges:
+					client.table('privileged_users').update(
+						{
+							'can_upload_private': privilege.get('can_upload_private', False),
+							'can_view_all_private': privilege.get('can_view_all_private', False),
+							'can_audit': privilege.get('can_audit', False),
+						}
+					).eq('id', privilege['id']).execute()
+			elif created_privilege_id:
+				client.table('privileged_users').delete().eq('id', created_privilege_id).execute()
+
+
+def test_auditor_flag_review_rpc_requires_auditor_and_records_history(
+	audit_privileged_user,
+	auth_token,
+	flagged_dataset,
+	non_audit_user,
+	test_user,
+):
+	reporter_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_client(reporter_token) as reporter_client:
+		with pytest.raises(Exception, match='not_authorized'):
+			reporter_client.rpc(
+				'update_flag_status',
+				{
+					'p_flag_id': flagged_dataset['flag_id'],
+					'p_new_status': 'acknowledged',
+					'p_note': 'Reporter cannot acknowledge audit flags',
+				},
+			).execute()
+
+	with use_client(auth_token) as auditor_client:
+		auditor_client.rpc(
+			'update_flag_status',
+			{
+				'p_flag_id': flagged_dataset['flag_id'],
+				'p_new_status': 'acknowledged',
+				'p_note': 'Auditor acknowledged local smoke issue',
+			},
+		).execute()
+
+		flag_response = (
+			auditor_client.table('dataset_flags')
+			.select('status,auditor_comment,resolved_by')
+			.eq('id', flagged_dataset['flag_id'])
+			.single()
+			.execute()
+		)
+		assert flag_response.data == {
+			'status': 'acknowledged',
+			'auditor_comment': 'Auditor acknowledged local smoke issue',
+			'resolved_by': None,
+		}
+
+		auditor_client.rpc(
+			'update_flag_status',
+			{
+				'p_flag_id': flagged_dataset['flag_id'],
+				'p_new_status': 'resolved',
+				'p_note': 'Auditor resolved local smoke issue',
+			},
+		).execute()
+
+		resolved_response = (
+			auditor_client.table('dataset_flags')
+			.select('status,auditor_comment,resolved_by')
+			.eq('id', flagged_dataset['flag_id'])
+			.single()
+			.execute()
+		)
+		assert resolved_response.data == {
+			'status': 'resolved',
+			'auditor_comment': 'Auditor resolved local smoke issue',
+			'resolved_by': test_user,
+		}
+
+		history_response = (
+			auditor_client.table('dataset_flag_status_history')
+			.select('old_status,new_status,changed_by,note')
+			.eq('flag_id', flagged_dataset['flag_id'])
+			.order('changed_at')
+			.execute()
+		)
+		assert history_response.data == [
+			{
+				'old_status': 'open',
+				'new_status': 'acknowledged',
+				'changed_by': test_user,
+				'note': 'Auditor acknowledged local smoke issue',
+			},
+			{
+				'old_status': 'acknowledged',
+				'new_status': 'resolved',
+				'changed_by': test_user,
+				'note': 'Auditor resolved local smoke issue',
+			},
+		]

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -57,6 +57,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | Frontend browser       | `npm --prefix frontend run test:e2e` or the browser regression playbook | user-facing routes, maps, auth shell, archive/detail/release flows                  |
 | Contributor local E2E  | `npm --prefix frontend run test:e2e:local`                              | authenticated upload shell, metadata submission contract, process request contract  |
 | Contributor write E2E  | `npm --prefix frontend run test:e2e:local:write`                        | local-only signup, password reset, upload start, download request side effects      |
+| Auditor local E2E      | `npm --prefix frontend run test:e2e:local:audit`                        | auditor-only queue triage, audit tabs, processing logs, and audit access guards     |
 | API/router             | `deadtrees dev test api <path>`                                         | FastAPI routes, upload/download/process/auth behavior                               |
 | Database/RLS/migration | focused API DB tests plus migration review/reset where practical        | schema, policies, RPCs, views, generated contracts                                  |
 | Processor CPU          | `deadtrees dev test processor <path>`                                   | queue orchestration, GeoTIFF/COG/metadata, non-GPU utilities                        |
@@ -121,3 +122,22 @@ contributor, requests a password reset through local Supabase Auth, verifies the
 reset email through Supabase Mailpit, uploads a small GeoTIFF through the real
 local API, asserts dataset/status/ortho/queue rows and archive storage, starts a
 download request, and asserts the local download bundle plus download audit log.
+
+## Local Auditor Smoke
+
+Use the local auditor smoke when a frontend change touches audit access,
+auditor-only queue triage, completed/reference/edit-review tabs, or processing
+visibility:
+
+```bash
+npm --prefix frontend run test:e2e:local:audit
+deadtrees dev test api api/tests/db/test_auditor_flag_review_contract.py
+```
+
+The browser smoke runs against local/development frontend settings and mocked
+local Supabase responses. It verifies the auditor access guard, the dashboard's
+main queue tabs, processing-log inspection, and the audit-lock navigation
+contract without writing to production. The DB contract smoke covers the real
+`update_flag_status` RPC with local Supabase side effects: non-auditors are
+rejected, auditors can acknowledge and resolve a flag, and status history is
+recorded with the acting auditor.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -83,6 +83,10 @@ Supabase/API/Mailpit stack is running and the change needs real local
 signup/password-reset/upload/download side-effect coverage. This suite mutates
 local auth, database, mail, and storage state and cleans up after itself.
 
+Use `npm --prefix frontend run test:e2e:local:audit` for auditor-only queue,
+audit-tab, processing-log, and audit access guard changes. It uses mocked local
+Supabase responses and must stay production-write safe.
+
 For user-facing UI changes, start the relevant Vite profile and validate with the
 Codex in-app browser or Playwright. Use `docs/playbooks/frontend-browser-regression.md`
 for production-connected smoke checks.

--- a/frontend/e2e-local/auditor-local.spec.ts
+++ b/frontend/e2e-local/auditor-local.spec.ts
@@ -1,0 +1,716 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rgbGeoTiffFixture = path.resolve(
+  __dirname,
+  "../test/fixtures/geotiff/upload-validation/rgb-real-crop.tif",
+);
+
+const localSupabaseUrl = "http://127.0.0.1:54321";
+const auditor = {
+  id: "00000000-0000-4000-8000-0000000000a1",
+  email: "auditor-local-e2e@example.com",
+};
+const reporter = {
+  id: "00000000-0000-4000-8000-0000000000b2",
+  email: "reporter-local-e2e@example.com",
+};
+
+const completeDataset = {
+  id: 3001,
+  user_id: reporter.id,
+  created_at: "2026-01-02T03:04:05Z",
+  file_name: "audit-pending-local.tif",
+  license: "CC BY",
+  platform: "drone",
+  project_id: null,
+  authors: ["Audit Local Contributor"],
+  aquisition_year: "2024",
+  aquisition_month: "5",
+  aquisition_day: "6",
+  additional_information: "Audit local smoke dataset",
+  data_access: "public",
+  citation_doi: null,
+  archived: false,
+  ortho_file_name: "audit-pending-local.tif",
+  ortho_file_size: 12345,
+  bbox: null,
+  sha256: "local-audit-sha",
+  current_status: "idle",
+  is_upload_done: true,
+  is_odm_done: true,
+  is_ortho_done: true,
+  is_cog_done: true,
+  is_thumbnail_done: true,
+  is_deadwood_done: true,
+  is_forest_cover_done: true,
+  is_combined_model_done: true,
+  is_metadata_done: true,
+  is_audited: false,
+  has_error: false,
+  error_message: null,
+  cog_file_name: "audit-pending-local_cog.tif",
+  cog_path: "/cog/audit-pending-local.tif",
+  cog_file_size: 23456,
+  thumbnail_file_name: "audit-pending-local.png",
+  thumbnail_path: "/thumbnails/audit-pending-local.png",
+  admin_level_1: "Germany",
+  admin_level_2: "Bavaria",
+  admin_level_3: "Local Forest",
+  biome_name: "Temperate Broadleaf and Mixed Forests",
+  has_labels: true,
+  has_deadwood_prediction: true,
+  freidata_doi: null,
+  has_ml_tiles: false,
+  final_assessment: null,
+  deadwood_quality: null,
+  forest_cover_quality: null,
+  has_major_issue: null,
+  audit_date: null,
+  has_valid_acquisition_date: null,
+  has_valid_phenology: null,
+  audited_by: null,
+  audited_by_email: null,
+  show_deadwood_predictions: true,
+  show_forest_cover_predictions: true,
+};
+
+const auditedDataset = {
+  ...completeDataset,
+  id: 3002,
+  file_name: "audit-completed-local.tif",
+  is_audited: true,
+  final_assessment: "fixable_issues",
+  deadwood_quality: "sentinel_ok",
+  forest_cover_quality: "great",
+  has_valid_acquisition_date: true,
+  has_valid_phenology: false,
+  audited_by: auditor.id,
+  audited_by_email: auditor.email,
+};
+
+const incompleteDataset = {
+  ...completeDataset,
+  id: 3003,
+  file_name: "audit-processing-local.tif",
+  is_cog_done: false,
+  is_thumbnail_done: false,
+  is_deadwood_done: false,
+  is_forest_cover_done: false,
+  is_combined_model_done: false,
+  is_metadata_done: false,
+  current_status: "cog",
+};
+
+const datasets = [completeDataset, auditedDataset, incompleteDataset];
+
+const audits = [
+  {
+    dataset_id: auditedDataset.id,
+    audit_date: "2026-01-03T03:04:05Z",
+    is_georeferenced: true,
+    has_valid_acquisition_date: true,
+    acquisition_date_notes: "Date is plausible",
+    has_valid_phenology: false,
+    phenology_notes: "Outside expected season",
+    deadwood_quality: "sentinel_ok",
+    deadwood_notes: "Some model noise",
+    forest_cover_quality: "great",
+    forest_cover_notes: "Tree cover looks good",
+    aoi_done: false,
+    has_cog_issue: false,
+    cog_issue_notes: null,
+    has_thumbnail_issue: false,
+    thumbnail_issue_notes: null,
+    audited_by: auditor.id,
+    notes: "Needs minor cleanup",
+    has_major_issue: null,
+    final_assessment: "fixable_issues",
+    reviewed_at: null,
+    reviewed_by: null,
+    audited_by_email: auditor.email,
+    uploaded_by_email: reporter.email,
+    reviewed_by_email: null,
+  },
+];
+
+const flags = [
+  {
+    id: 81,
+    dataset_id: completeDataset.id,
+    created_by: reporter.id,
+    is_ortho_mosaic_issue: true,
+    is_prediction_issue: false,
+    description: "Mosaic seam is visible in the north-east corner.",
+    status: "acknowledged",
+    created_at: "2026-01-04T03:04:05Z",
+    updated_at: "2026-01-04T03:04:05Z",
+  },
+];
+
+let savedAuditPayloads: Array<Record<string, unknown>> = [];
+let savedAoiPayloads: Array<Record<string, unknown>> = [];
+
+const createUnsignedJwt = (payload: Record<string, unknown>) => {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+
+  return [
+    encode({ alg: "none", typ: "JWT" }),
+    encode({
+      aud: "authenticated",
+      role: "authenticated",
+      sub: auditor.id,
+      email: auditor.email,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+      ...payload,
+    }),
+    "local-e2e",
+  ].join(".");
+};
+
+const createLocalSession = () => {
+  const now = new Date().toISOString();
+
+  return {
+    access_token: createUnsignedJwt({}),
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: "local-auditor-e2e-refresh-token",
+    user: {
+      id: auditor.id,
+      aud: "authenticated",
+      role: "authenticated",
+      email: auditor.email,
+      email_confirmed_at: now,
+      app_metadata: { provider: "email", providers: ["email"] },
+      user_metadata: {},
+      created_at: now,
+      updated_at: now,
+    },
+  };
+};
+
+const installAuthenticatedUser = async (
+  page: Page,
+  options: { canAudit: boolean },
+) => {
+  const session = createLocalSession();
+
+  await page.addInitScript((localSession) => {
+    window.localStorage.setItem(
+      "sb-127-auth-token",
+      JSON.stringify(localSession),
+    );
+  }, session);
+
+  await page.route(`${localSupabaseUrl}/auth/v1/user`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: session.user,
+    });
+  });
+
+  await page.route(`${localSupabaseUrl}/rest/v1/**`, async (route) => {
+    await fulfillSupabaseRequest(route, options);
+  });
+
+  await page.route("**/cogs/v1/**", async (route) => {
+    const buffer = fs.readFileSync(rgbGeoTiffFixture);
+    const range = route.request().headers().range;
+
+    if (range) {
+      const match = /^bytes=(\d+)-(\d*)$/.exec(range);
+      if (match) {
+        const start = Number(match[1]);
+        const requestedEnd = match[2] ? Number(match[2]) : buffer.length - 1;
+        const end = Math.min(requestedEnd, buffer.length - 1);
+        const chunk = buffer.subarray(start, end + 1);
+
+        await route.fulfill({
+          status: 206,
+          headers: {
+            "accept-ranges": "bytes",
+            "content-length": String(chunk.length),
+            "content-range": `bytes ${start}-${end}/${buffer.length}`,
+            "content-type": "image/tiff",
+          },
+          body: chunk,
+        });
+        return;
+      }
+    }
+
+    await route.fulfill({
+      headers: {
+        "accept-ranges": "bytes",
+        "content-length": String(buffer.length),
+        "content-type": "image/tiff",
+      },
+      body: buffer,
+    });
+  });
+};
+
+const fulfillSupabaseRequest = async (
+  route: Route,
+  options: { canAudit: boolean },
+) => {
+  const request = route.request();
+  const url = new URL(request.url());
+  const segments = url.pathname.split("/").filter(Boolean);
+  const resource = segments.at(-1);
+  const method = request.method();
+  const wantsObject =
+    request.headers()["accept"]?.includes("vnd.pgrst.object") ?? false;
+
+  if (segments.at(-2) === "rpc") {
+    await fulfillRpc(route, resource);
+    return;
+  }
+
+  if (resource === "privileged_users") {
+    await fulfillJson(route, {
+      id: 1,
+      user_id: auditor.id,
+      can_upload_private: false,
+      can_audit: options.canAudit,
+      can_view_all_private: false,
+      created_at: "2026-01-01T00:00:00Z",
+    });
+    return;
+  }
+
+  if (resource === "v2_full_dataset_view") {
+    const idFilter = url.searchParams.get("id");
+    if (idFilter?.startsWith("eq.")) {
+      const dataset = datasets.find((row) => row.id === Number(idFilter.slice(3)));
+      await fulfillJson(route, wantsObject ? dataset ?? null : dataset ? [dataset] : []);
+      return;
+    }
+
+    const pendingCorrectionFilter = url.searchParams.get(
+      "pending_corrections_count",
+    );
+    if (pendingCorrectionFilter?.startsWith("gt.")) {
+      await fulfillJson(route, [
+        {
+          id: completeDataset.id,
+          pending_corrections_count: 2,
+        },
+      ]);
+      return;
+    }
+
+    await fulfillJson(route, datasets);
+    return;
+  }
+
+  if (resource === "dataset_flags") {
+    await fulfillJson(route, flags);
+    return;
+  }
+
+  if (resource === "reference_datasets") {
+    await fulfillJson(route, [{ dataset_id: auditedDataset.id }]);
+    return;
+  }
+
+  if (resource === "v2_processing_overview") {
+    await fulfillJson(route, [
+      {
+        dataset_id: incompleteDataset.id,
+        file_name: incompleteDataset.file_name,
+        processing_status: "FAILED",
+        current_status: "cog",
+        has_error: true,
+        error_message: "COG conversion failed in local smoke fixture",
+        hours_in_current_status: 7.25,
+        status_last_updated: "2026-01-05T03:04:05Z",
+        user_email: reporter.email,
+        queue_priority: 4,
+        queued_at: "2026-01-05T01:04:05Z",
+        is_upload_done: true,
+        is_odm_done: true,
+        is_ortho_done: true,
+        is_cog_done: false,
+        is_thumbnail_done: false,
+        is_metadata_done: false,
+        is_deadwood_done: false,
+        is_forest_cover_done: false,
+        is_combined_model_done: false,
+        last_20_logs: "ERROR COG conversion failed\nINFO retry pending",
+      },
+    ]);
+    return;
+  }
+
+  if (resource === "v2_logs") {
+    await fulfillJson(route, [
+      {
+        id: 101,
+        created_at: "2026-01-05T03:04:05Z",
+        level: "ERROR",
+        category: "processing",
+        message: "COG conversion failed in local smoke fixture",
+        origin: "processor",
+        origin_line: 42,
+      },
+    ]);
+    return;
+  }
+
+  if (resource === "v2_metadata") {
+    await fulfillJson(route, []);
+    return;
+  }
+
+  if (resource === "v2_statuses") {
+    if (method === "PATCH") {
+      await fulfillJson(route, {
+        id: completeDataset.id,
+        dataset_id: completeDataset.id,
+        is_in_audit: false,
+      });
+      return;
+    }
+
+    await fulfillJson(route, wantsObject ? { is_in_audit: false } : []);
+    return;
+  }
+
+  if (resource === "v2_aois" || resource === "v2_orthos") {
+    if (resource === "v2_aois" && method === "POST") {
+      const payload = request.postDataJSON();
+      const rows = Array.isArray(payload) ? payload : [payload];
+      savedAoiPayloads.push(...(rows as Array<Record<string, unknown>>));
+      await fulfillJson(route, rows);
+      return;
+    }
+
+    await fulfillJson(route, wantsObject ? null : []);
+    return;
+  }
+
+  if (resource === "dataset_audit") {
+    if (method === "HEAD") {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-range": "0-0/1" },
+      });
+      return;
+    }
+
+    if (method === "POST" || method === "PATCH") {
+      const payload = request.postDataJSON() ?? {};
+      const rows = Array.isArray(payload) ? payload : [payload];
+      savedAuditPayloads.push(...(rows as Array<Record<string, unknown>>));
+      await fulfillJson(route, rows.map((row) => ({ ...row, id: 1 })));
+      return;
+    }
+
+    await fulfillJson(route, []);
+    return;
+  }
+
+  await fulfillJson(route, wantsObject ? null : []);
+};
+
+const fulfillRpc = async (route: Route, rpcName: string | undefined) => {
+  if (rpcName === "get_dataset_audits_with_emails") {
+    await fulfillJson(route, audits);
+    return;
+  }
+
+  if (rpcName === "get_dataset_audit_with_emails") {
+    const body = route.request().postDataJSON() as
+      | { p_dataset_id?: number }
+      | undefined;
+    await fulfillJson(
+      route,
+      audits.filter((audit) => audit.dataset_id === body?.p_dataset_id),
+    );
+    return;
+  }
+
+  if (rpcName === "get_dataset_contributors_with_emails") {
+    await fulfillJson(route, [
+      {
+        dataset_id: completeDataset.id,
+        contributor_email: reporter.email,
+      },
+      {
+        dataset_id: auditedDataset.id,
+        contributor_email: reporter.email,
+      },
+    ]);
+    return;
+  }
+
+  if (rpcName === "get_user_emails") {
+    await fulfillJson(route, [{ user_id: reporter.id, email: reporter.email }]);
+    return;
+  }
+
+  if (
+    rpcName === "get_correction_contributors" ||
+    rpcName === "get_pending_correction_locations" ||
+    rpcName === "update_flag_status"
+  ) {
+    await fulfillJson(route, []);
+    return;
+  }
+
+  await fulfillJson(route, []);
+};
+
+const fulfillJson = async (route: Route, json: unknown) => {
+  await route.fulfill({
+    contentType: "application/json",
+    headers: { "content-range": "0-0/1" },
+    json,
+  });
+};
+
+test.describe("auditor local e2e", () => {
+  test.beforeEach(() => {
+    savedAuditPayloads = [];
+    savedAoiPayloads = [];
+  });
+
+  test("non-auditor cannot open the audit workspace", async ({ page }) => {
+    await installAuthenticatedUser(page, { canAudit: false });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+
+    await expect(page.getByText("Forbidden")).toBeVisible();
+    await expect(
+      page.getByText("Auditor access is required to view this page."),
+    ).toBeVisible();
+  });
+
+  test("auditor can triage audit queues and inspect processing logs", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Dataset Audits" }),
+    ).toBeVisible();
+    await expect(page.getByText("Local Forest")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Start Audit" }),
+    ).toBeVisible();
+
+    await page.getByText("Completed").click();
+    await expect(page.getByText("Fixable")).toBeVisible();
+    await expect(page.getByText(auditor.email)).toBeVisible();
+    await page.getByPlaceholder("Filter by ID").fill(String(auditedDataset.id));
+    await expect(
+      page.locator("tr").filter({ hasText: String(auditedDataset.id) }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Clear all filters" }).click();
+
+    await page.getByText("Edits & Flags").click();
+    await expect(page.getByText("Pending Edits").first()).toBeVisible();
+    await expect(page.getByText("Flags").first()).toBeVisible();
+
+    await page.getByText("Reference").click();
+    await expect(
+      page.getByRole("button", { name: "Generate Patches" }),
+    ).toBeVisible();
+
+    await page.getByText("Processing").click();
+    const processingRow = page.locator("tr").filter({
+      hasText: incompleteDataset.file_name,
+    });
+    await expect(processingRow).toBeVisible();
+    await expect(processingRow.getByText("FAILED", { exact: true })).toBeVisible();
+    await expect(
+      processingRow.getByText("COG conversion failed in local smoke fixture"),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "View Logs" }).click();
+    await expect(
+      page.getByText(`Dataset ${incompleteDataset.id} Logs`),
+    ).toBeVisible();
+    const logsDrawer = page.getByLabel(`Dataset ${incompleteDataset.id} Logs`);
+    await expect(
+      logsDrawer.getByText("COG conversion failed in local smoke fixture"),
+    ).toBeVisible();
+  });
+
+  test("auditor start action checks the lock before opening detail", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+    await page.getByRole("button", { name: "Start Audit" }).click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/dataset-audit/${completeDataset.id}(?:\\?.*)?$`),
+    );
+    await expect(
+      page.getByRole("heading", {
+        name: new RegExp(`Audit: ${completeDataset.id}`),
+      }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(reporter.email)).toBeVisible();
+    await expect(page.getByText("1. Georeferencing Accuracy")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^save Save$/i }),
+    ).toBeVisible();
+  });
+
+  test("auditor can complete the audit form with AOI and save the review", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+    await page.getByRole("button", { name: "Start Audit" }).click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/dataset-audit/${completeDataset.id}(?:\\?.*)?$`),
+    );
+    await expect(page.getByTestId("dataset-audit-map")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="dataset-audit-map"] .ol-viewport'),
+    ).toBeVisible({ timeout: 20_000 });
+
+    await card(page, "1. Georeferencing Accuracy")
+      .getByText(/Good/)
+      .click();
+    await card(page, "2. Acquisition Date")
+      .getByText(/Valid/)
+      .click();
+
+    const phenologyCard = card(page, "3. Phenology / Season");
+    await phenologyCard.getByText(/In Season/).click();
+    await phenologyCard
+      .getByPlaceholder("Seasonal observations...")
+      .fill("Leaf-on season confirmed in local workflow smoke.");
+
+    const predictionCard = card(page, "4. Prediction Quality");
+    await predictionCard.getByText("🟡 OK").nth(0).click();
+    await predictionCard
+      .getByPlaceholder("Deadwood cover notes...")
+      .fill("Deadwood cover is usable with minor noise.");
+    await predictionCard.getByText("🟢 Great").nth(1).click();
+    await predictionCard
+      .getByPlaceholder("Forest cover notes...")
+      .fill("Tree cover looks consistent.");
+
+    const cogCard = card(page, "5. Cloud-Optimized GeoTIFF");
+    await cogCard.getByText(/Good/).click();
+    await cogCard
+      .getByPlaceholder(/COG issue details/)
+      .fill("COG renders correctly in the audit map.");
+
+    const thumbnailCard = card(page, "6. Thumbnail");
+    await thumbnailCard.getByText(/Good/).click();
+    await thumbnailCard
+      .getByPlaceholder(/Thumbnail issue details/)
+      .fill("Thumbnail represents the dataset.");
+
+    await drawAuditAoi(page);
+    await expect(page.getByText(/AOI defined/)).toBeVisible();
+
+    const finalAssessmentCard = card(page, "8. Final Assessment");
+    await finalAssessmentCard.getByText(/Ready/).click();
+    await finalAssessmentCard
+      .getByPlaceholder("Additional observations...")
+      .fill("Audit workflow local smoke completed.");
+
+    await page.getByRole("button", { name: /^save Save$/i }).click();
+
+    await expect
+      .poll(() => savedAoiPayloads.length, { timeout: 10_000 })
+      .toBe(1);
+    await expect
+      .poll(() => savedAuditPayloads.length, { timeout: 10_000 })
+      .toBe(1);
+
+    expect(savedAoiPayloads[0]).toMatchObject({
+      dataset_id: completeDataset.id,
+      user_id: auditor.id,
+      is_whole_image: false,
+    });
+    expect(savedAoiPayloads[0].geometry).toMatchObject({
+      type: "MultiPolygon",
+    });
+
+    expect(savedAuditPayloads[0]).toMatchObject({
+      dataset_id: completeDataset.id,
+      is_georeferenced: true,
+      has_valid_acquisition_date: true,
+      has_valid_phenology: true,
+      deadwood_quality: "sentinel_ok",
+      deadwood_notes: "Deadwood cover is usable with minor noise.",
+      forest_cover_quality: "great",
+      forest_cover_notes: "Tree cover looks consistent.",
+      has_cog_issue: false,
+      cog_issue_notes: "COG renders correctly in the audit map.",
+      has_thumbnail_issue: false,
+      thumbnail_issue_notes: "Thumbnail represents the dataset.",
+      final_assessment: "no_issues",
+      notes: "Audit workflow local smoke completed.",
+      aoi_done: true,
+      audited_by: auditor.id,
+    });
+  });
+});
+
+const card = (page: Page, title: string) =>
+  page.locator(".ant-card").filter({ hasText: title });
+
+const dismissCookieBanner = async (page: Page) => {
+  await page
+    .getByRole("button", { name: "Accept" })
+    .click({ timeout: 2_000 })
+    .catch(() => undefined);
+};
+
+const drawAuditAoi = async (page: Page) => {
+  await card(page, "7. Area of Interest (AOI)")
+    .getByRole("button", { name: "Draw AOI Polygon" })
+    .click();
+
+  const map = page.getByTestId("dataset-audit-map");
+  await expect(
+    card(page, "7. Area of Interest (AOI)").getByRole("button", {
+      name: "Cancel Drawing",
+    }),
+  ).toBeVisible();
+
+  const box = await map.boundingBox();
+  if (!box) {
+    throw new Error("Audit map is not visible for AOI drawing.");
+  }
+
+  const points = [
+    { x: box.x + box.width * 0.45, y: box.y + box.height * 0.45 },
+    { x: box.x + box.width * 0.56, y: box.y + box.height * 0.45 },
+    { x: box.x + box.width * 0.56, y: box.y + box.height * 0.56 },
+    { x: box.x + box.width * 0.45, y: box.y + box.height * 0.56 },
+  ];
+
+  await page.mouse.click(points[0].x, points[0].y);
+  await page.mouse.click(points[1].x, points[1].y);
+  await page.mouse.click(points[2].x, points[2].y);
+  await page.mouse.dblclick(points[3].x, points[3].y);
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:readonly": "playwright test",
+    "test:e2e:local:audit": "playwright test --config playwright.local.config.ts auditor-local.spec.ts",
     "test:e2e:local": "playwright test --config playwright.local.config.ts",
     "test:e2e:local:write": "bash ./scripts/run-local-write-e2e.sh",
     "test:watch": "vitest"

--- a/frontend/playwright.local.config.ts
+++ b/frontend/playwright.local.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 const PORT = Number(process.env.PLAYWRIGHT_PORT || 5173);
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${PORT}`;
+const SLOW_MO = Number(process.env.PLAYWRIGHT_SLOW_MO || 0);
 
 export default defineConfig({
   testDir: "./e2e-local",
@@ -14,6 +15,9 @@ export default defineConfig({
   use: {
     baseURL: BASE_URL,
     browserName: "chromium",
+    launchOptions: {
+      slowMo: SLOW_MO,
+    },
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "off",

--- a/frontend/src/components/DatasetAudit/DatasetAuditMap.tsx
+++ b/frontend/src/components/DatasetAudit/DatasetAuditMap.tsx
@@ -82,7 +82,6 @@ const DatasetAuditMap = forwardRef<DatasetAuditMapHandle, DatasetAuditMapProps>(
 	onMapReady,
 	onOrthoLayerReady,
 	isEditing = false,
-	editingLayerType: _editingLayerType = null,
 	enableAOIEditing = false,
 	onAOIChange,
 	onToolbarStateChange,
@@ -109,7 +108,7 @@ const DatasetAuditMap = forwardRef<DatasetAuditMapHandle, DatasetAuditMapProps>(
 
 	// Fetch AOI data
 	const { data: aoiData, isLoading: isAOILoading } = useDatasetAOI(data?.id);
-	const aoiGeometry = useMemo(() => aoiData?.geometry, [aoiData?.id]);
+	const aoiGeometry = aoiData?.geometry;
 
 	// Compute effective visibility - HIDE MVT LAYERS WHEN EDITING
 	const effectiveDeadwoodVisible = useMemo(() => {
@@ -302,6 +301,7 @@ const DatasetAuditMap = forwardRef<DatasetAuditMapHandle, DatasetAuditMapProps>(
 				ref={mapContainerRef}
 				style={{ width: "100%", height: "100%", position: "relative" }}
 				data-rr-ignore
+				data-testid="dataset-audit-map"
 			>
 				{/* Tooltip overlay */}
 				<FeatureTooltip


### PR DESCRIPTION
## Summary
- add a local Playwright auditor smoke suite for access guard, queue tabs, processing logs, audit locking, AOI drawing, and audit save payloads
- add a local API/DB contract test for update_flag_status auditor authorization and history side effects
- document when to run the auditor local smoke and add slow-motion support for headed Playwright runs

## Validation
- local review: codex review --uncommitted
- npx eslint e2e-local/auditor-local.spec.ts playwright.local.config.ts src/components/DatasetAudit/DatasetAuditMap.tsx --ext ts,tsx --max-warnings 0
- ruff check api/tests/db/test_auditor_flag_review_contract.py
- git diff --check
- npm --prefix frontend run test:e2e:local:audit
- npm --prefix frontend test -- --run
- venv/bin/deadtrees dev test api api/tests/db/test_auditor_flag_review_contract.py

## Notes
- The auditor browser smoke is local/mocked and production-safe.
- The DB contract test runs against the controlled local Supabase test stack.
- Full frontend build/lint remain known baseline debt and are not added as gates here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are primarily new local test coverage and documentation; the only production code tweak is a small React memo dependency/test-id change in `DatasetAuditMap`.
> 
> **Overview**
> Adds a new local Playwright *auditor smoke* suite that stubs Supabase responses to cover audit access guarding, queue tab triage (completed/edits/flags/reference/processing), processing log inspection, audit lock navigation, AOI drawing, and asserting audit/AOI save payloads.
> 
> Adds a DB contract test for the `update_flag_status` RPC to ensure **non-auditors are rejected**, auditors can acknowledge/resolve a flag, and `dataset_flag_status_history` is recorded with the acting user.
> 
> Updates docs and frontend tooling to support this workflow (`test:e2e:local:audit` script, testing-strategy/agent guidance, Playwright local `slowMo` env support), and makes a small `DatasetAuditMap` tweak (stable AOI memoization + `data-testid` for test targeting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907e2fddd815c86f0e8297b3ea39bba698365bad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive auditor flag review contract tests with fixtures for authorization and status history validation.
  * Introduced local auditor E2E test suite covering authorization guards, audit queue triage, processing log inspection, and audit form completion with AOI mapping.
  * Added new `test:e2e:local:audit` npm script for running auditor-specific smoke tests.

* **Chores**
  * Updated testing documentation with local auditor smoke testing workflow.
  * Added slow motion support to test browser configuration for debugging.
  * Optimized AOI geometry memoization performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->