### PR TITLE
test(frontend): add auditor write e2e coverage

### DIFF
--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -58,6 +58,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | Contributor local E2E  | `npm --prefix frontend run test:e2e:local`                              | authenticated upload shell, metadata submission contract, process request contract  |
 | Contributor write E2E  | `npm --prefix frontend run test:e2e:local:write`                        | local-only signup, password reset, upload start, download request side effects      |
 | Auditor local E2E      | `npm --prefix frontend run test:e2e:local:audit`                        | auditor-only queue triage, audit tabs, processing logs, and audit access guards     |
+| Auditor write E2E      | `npm --prefix frontend run test:e2e:local:audit:write`                  | local-only auditor flag, AOI, audit-lock, and audit-save side effects               |
 | API/router             | `deadtrees dev test api <path>`                                         | FastAPI routes, upload/download/process/auth behavior                               |
 | Database/RLS/migration | focused API DB tests plus migration review/reset where practical        | schema, policies, RPCs, views, generated contracts                                  |
 | Processor CPU          | `deadtrees dev test processor <path>`                                   | queue orchestration, GeoTIFF/COG/metadata, non-GPU utilities                        |
@@ -141,3 +142,19 @@ contract without writing to production. The DB contract smoke covers the real
 `update_flag_status` RPC with local Supabase side effects: non-auditors are
 rejected, auditors can acknowledge and resolve a flag, and status history is
 recorded with the acting auditor.
+
+Use the local auditor write-flow suite when the frontend change touches real
+auditor write behavior:
+
+```bash
+supabase start
+deadtrees dev start --services api-test,nginx
+npm --prefix frontend run test:e2e:local:audit:write
+```
+
+This suite is intentionally opt-in and local-only. It creates unique local
+auditor and reporter Auth users, grants the auditor `can_audit`, seeds an
+auditable dataset with a local COG, opens the real audit page, acknowledges a
+user-reported flag through the `update_flag_status` RPC, draws an AOI, saves the
+audit, and asserts real local side effects in `dataset_audit`, `v2_aois`,
+`v2_statuses`, `dataset_flags`, and `dataset_flag_status_history`.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -87,6 +87,11 @@ Use `npm --prefix frontend run test:e2e:local:audit` for auditor-only queue,
 audit-tab, processing-log, and audit access guard changes. It uses mocked local
 Supabase responses and must stay production-write safe.
 
+Use `npm --prefix frontend run test:e2e:local:audit:write` only when the local
+Supabase/API/nginx stack is running and the change needs real auditor write
+side-effect coverage for flag acknowledgement, AOI save, audit lock release, or
+`dataset_audit` persistence.
+
 For user-facing UI changes, start the relevant Vite profile and validate with the
 Codex in-app browser or Playwright. Use `docs/playbooks/frontend-browser-regression.md`
 for production-connected smoke checks.

--- a/frontend/e2e-local/auditor-write-flows.spec.ts
+++ b/frontend/e2e-local/auditor-write-flows.spec.ts
@@ -1,0 +1,490 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createClient, type SupabaseClient, type User } from "@supabase/supabase-js";
+import { expect, test, type Page } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const rgbGeoTiffFixture = path.resolve(
+  __dirname,
+  "../test/fixtures/geotiff/upload-validation/rgb-real-crop.tif",
+);
+
+const localSupabaseUrl = "http://127.0.0.1:54321";
+const localApiUrl = "http://localhost:8080/api/v1";
+
+const uniqueRunId = randomUUID().replaceAll("-", "").slice(0, 12);
+const auditorEmail = `auditor-write-${uniqueRunId}@example.com`;
+const reporterEmail = `auditor-write-reporter-${uniqueRunId}@example.com`;
+const auditorPassword = `Auditor-${uniqueRunId}!`;
+const reporterPassword = `Reporter-${uniqueRunId}!`;
+const cogPath = `auditor-write/${uniqueRunId}.tif`;
+const cogFileName = `${uniqueRunId}.tif`;
+
+let adminClient: SupabaseClient;
+let anonClient: SupabaseClient;
+let auditorUser: User;
+let reporterUser: User;
+let datasetId = 0;
+let flagId = 0;
+let privilegedUserId = 0;
+
+test.describe("auditor local write flows", () => {
+  test.skip(
+    process.env.E2E_LOCAL_AUDITOR_WRITE !== "1",
+    "Set E2E_LOCAL_AUDITOR_WRITE=1 and start local Supabase/API/nginx before running this write suite.",
+  );
+
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async () => {
+    adminClient = createLocalSupabaseClient(
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    );
+    anonClient = createLocalSupabaseClient(
+      process.env.VITE_SUPABASE_ANON_KEY || requireEnv("SUPABASE_ANON_KEY"),
+    );
+
+    await expectLocalService(
+      `${localSupabaseUrl}/auth/v1/settings`,
+      "local Supabase",
+    );
+    await expectLocalService(`${localApiUrl}/`, "local API");
+
+    await deleteAuthUsersByEmail(adminClient, auditorEmail);
+    await deleteAuthUsersByEmail(adminClient, reporterEmail);
+
+    auditorUser = await createConfirmedUser(auditorEmail, auditorPassword);
+    reporterUser = await createConfirmedUser(reporterEmail, reporterPassword);
+    privilegedUserId = await grantAuditPrivilege(auditorUser.id);
+    datasetId = await createAuditableDataset();
+    flagId = await createOpenFlag();
+  });
+
+  test.afterAll(async () => {
+    await cleanupDataset();
+    await cleanupAuditPrivilege();
+    await deleteAuthUsersByEmail(adminClient, auditorEmail);
+    await deleteAuthUsersByEmail(adminClient, reporterEmail);
+    fs.rmSync(path.join(repoRoot, "data", "cogs", cogPath), { force: true });
+  });
+
+  test("auditor acknowledges a user flag, draws AOI, and persists audit side effects", async ({
+    page,
+  }) => {
+    await installAuditorSession(page);
+    await page.goto(`/dataset-audit/${datasetId}`);
+    await dismissCookieBanner(page);
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Audit: ${datasetId}`) }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("Securing audit lock...")).toBeHidden({
+      timeout: 20_000,
+    });
+    await expectAuditLock(true);
+
+    await expect(page.getByText("User-reported issues")).toBeVisible();
+    await expect(page.getByText("Local auditor write issue")).toBeVisible();
+    await page.getByRole("button", { name: "Acknowledge" }).click();
+    await expectFlagStatus("acknowledged");
+
+    await card(page, "1. Georeferencing Accuracy")
+      .getByText(/Good/)
+      .click();
+    await card(page, "2. Acquisition Date")
+      .getByText(/Valid/)
+      .click();
+
+    const phenologyCard = card(page, "3. Phenology / Season");
+    await phenologyCard.getByText(/In Season/).click();
+    await phenologyCard
+      .getByPlaceholder("Seasonal observations...")
+      .fill("Local write suite confirms phenology.");
+
+    const predictionCard = card(page, "4. Prediction Quality");
+    await predictionCard.getByText(/Great/).nth(0).click();
+    await predictionCard
+      .getByPlaceholder("Deadwood cover notes...")
+      .fill("Deadwood prediction is fit for audit.");
+    await predictionCard.getByText(/OK/).nth(1).click();
+    await predictionCard
+      .getByPlaceholder("Forest cover notes...")
+      .fill("Tree cover is usable.");
+
+    const cogCard = card(page, "5. Cloud-Optimized GeoTIFF");
+    await cogCard.getByText(/Good/).click();
+    await cogCard
+      .getByPlaceholder(/COG issue details/)
+      .fill("COG loads from local nginx.");
+
+    const thumbnailCard = card(page, "6. Thumbnail");
+    await thumbnailCard.getByText(/Good/).click();
+    await thumbnailCard
+      .getByPlaceholder(/Thumbnail issue details/)
+      .fill("Thumbnail state accepted.");
+
+    await drawAuditAoi(page);
+    await expect(page.getByText(/AOI defined/)).toBeVisible();
+
+    const finalAssessmentCard = card(page, "8. Final Assessment");
+    await finalAssessmentCard.getByText(/Ready/).click();
+    await finalAssessmentCard
+      .getByPlaceholder("Additional observations...")
+      .fill("Auditor local write integration completed.");
+
+    await page.getByRole("button", { name: /^save Save$/i }).click();
+    await expect(page).toHaveURL(/\/dataset-audit(?:\?tab=pending)?$/, {
+      timeout: 20_000,
+    });
+
+    await expectAuditSideEffects();
+  });
+});
+
+async function expectLocalService(url: string, name: string) {
+  const response = await fetch(url).catch((error) => {
+    throw new Error(`${name} is not reachable at ${url}: ${String(error)}`);
+  });
+
+  if (!response.ok) {
+    throw new Error(`${name} returned ${response.status} for ${url}`);
+  }
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set for the local auditor write suite.`);
+  }
+  return value;
+}
+
+function createLocalSupabaseClient(key: string) {
+  return createClient(localSupabaseUrl, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+async function createConfirmedUser(email: string, password: string) {
+  const { data, error } = await adminClient.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+
+  if (error || !data.user) {
+    throw error ?? new Error(`Failed to create local user ${email}`);
+  }
+
+  return data.user;
+}
+
+async function findAuthUserByEmail(client: SupabaseClient, email: string) {
+  for (let page = 1; page <= 10; page += 1) {
+    const { data, error } = await client.auth.admin.listUsers({
+      page,
+      perPage: 100,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const user = data.users.find((candidate) => candidate.email === email);
+    if (user) {
+      return user;
+    }
+
+    if (data.users.length < 100) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+async function deleteAuthUsersByEmail(client: SupabaseClient, email: string) {
+  let user = await findAuthUserByEmail(client, email);
+
+  while (user) {
+    const { error } = await client.auth.admin.deleteUser(user.id);
+    if (error) {
+      throw error;
+    }
+    user = await findAuthUserByEmail(client, email);
+  }
+}
+
+async function grantAuditPrivilege(userId: string) {
+  const { data, error } = await adminClient
+    .from("privileged_users")
+    .insert({
+      user_id: userId,
+      can_upload_private: false,
+      can_view_all_private: false,
+      can_audit: true,
+    })
+    .select("id")
+    .single();
+
+  expect(error).toBeNull();
+  return data.id as number;
+}
+
+async function createAuditableDataset() {
+  const { data: dataset, error: datasetError } = await adminClient
+    .from("v2_datasets")
+    .insert({
+      file_name: `auditor-write-${uniqueRunId}.tif`,
+      user_id: reporterUser.id,
+      license: "CC BY",
+      platform: "drone",
+      authors: ["Local Auditor Write Reporter"],
+      data_access: "public",
+      aquisition_year: 2024,
+      aquisition_month: 5,
+      aquisition_day: 6,
+      additional_information: "Local auditor write integration fixture",
+    })
+    .select("id")
+    .single();
+
+  expect(datasetError).toBeNull();
+  const createdDatasetId = dataset.id as number;
+
+  const { error: statusError } = await adminClient.from("v2_statuses").insert({
+    dataset_id: createdDatasetId,
+    current_status: "idle",
+    is_upload_done: true,
+    is_ortho_done: true,
+    is_cog_done: true,
+    is_thumbnail_done: true,
+    is_deadwood_done: true,
+    is_forest_cover_done: true,
+    is_metadata_done: true,
+    is_combined_model_done: true,
+    has_error: false,
+    is_in_audit: false,
+  });
+  expect(statusError).toBeNull();
+
+  const localCogFile = path.join(repoRoot, "data", "cogs", cogPath);
+  fs.mkdirSync(path.dirname(localCogFile), { recursive: true });
+  fs.copyFileSync(rgbGeoTiffFixture, localCogFile);
+
+  const { error: cogError } = await adminClient.from("v2_cogs").insert({
+    dataset_id: createdDatasetId,
+    cog_file_name: cogFileName,
+    version: 1,
+    cog_file_size: fs.statSync(localCogFile).size,
+    cog_info: {},
+    cog_processing_runtime: 0.1,
+    cog_path: cogPath,
+  });
+  expect(cogError).toBeNull();
+
+  return createdDatasetId;
+}
+
+async function createOpenFlag() {
+  const { data, error } = await adminClient
+    .from("dataset_flags")
+    .insert({
+      dataset_id: datasetId,
+      created_by: reporterUser.id,
+      is_ortho_mosaic_issue: true,
+      is_prediction_issue: false,
+      description: "Local auditor write issue",
+      status: "open",
+    })
+    .select("id")
+    .single();
+
+  expect(error).toBeNull();
+  return data.id as number;
+}
+
+async function installAuditorSession(page: Page) {
+  const login = await anonClient.auth.signInWithPassword({
+    email: auditorEmail,
+    password: auditorPassword,
+  });
+  expect(login.error).toBeNull();
+  expect(login.data.user?.id).toBe(auditorUser.id);
+  expect(login.data.session).toBeTruthy();
+
+  await page.addInitScript((session) => {
+    const storageKey = "sb-127-auth-token";
+    const { user, ...sessionWithoutUser } = session;
+    window.localStorage.setItem(storageKey, JSON.stringify(sessionWithoutUser));
+    window.localStorage.setItem(`${storageKey}-user`, JSON.stringify({ user }));
+  }, login.data.session);
+}
+
+const card = (page: Page, title: string) =>
+  page.locator(".ant-card").filter({ hasText: title });
+
+async function dismissCookieBanner(page: Page) {
+  await page
+    .getByRole("button", { name: "Accept" })
+    .click({ timeout: 2_000 })
+    .catch(() => undefined);
+}
+
+async function drawAuditAoi(page: Page) {
+  await expect(page.getByTestId("dataset-audit-map")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(
+    page.locator('[data-testid="dataset-audit-map"] .ol-viewport').first(),
+  ).toBeVisible({ timeout: 20_000 });
+
+  await card(page, "7. Area of Interest (AOI)")
+    .getByRole("button", { name: "Draw AOI Polygon" })
+    .click();
+
+  const map = page.getByTestId("dataset-audit-map");
+  const box = await map.boundingBox();
+  if (!box) {
+    throw new Error("Audit map is not visible for AOI drawing.");
+  }
+
+  const points = [
+    { x: box.x + box.width * 0.45, y: box.y + box.height * 0.45 },
+    { x: box.x + box.width * 0.56, y: box.y + box.height * 0.45 },
+    { x: box.x + box.width * 0.56, y: box.y + box.height * 0.56 },
+    { x: box.x + box.width * 0.45, y: box.y + box.height * 0.56 },
+  ];
+
+  await page.mouse.click(points[0].x, points[0].y);
+  await page.mouse.click(points[1].x, points[1].y);
+  await page.mouse.click(points[2].x, points[2].y);
+  await page.mouse.dblclick(points[3].x, points[3].y);
+}
+
+async function expectAuditLock(expected: boolean) {
+  await expect
+    .poll(async () => {
+      const { data, error } = await adminClient
+        .from("v2_statuses")
+        .select("is_in_audit")
+        .eq("dataset_id", datasetId)
+        .single();
+      expect(error).toBeNull();
+      return data.is_in_audit;
+    })
+    .toBe(expected);
+}
+
+async function expectFlagStatus(status: string) {
+  await expect
+    .poll(async () => {
+      const { data, error } = await adminClient
+        .from("dataset_flags")
+        .select("status")
+        .eq("id", flagId)
+        .single();
+      expect(error).toBeNull();
+      return data.status;
+    })
+    .toBe(status);
+}
+
+async function expectAuditSideEffects() {
+  const { data: audit, error: auditError } = await adminClient
+    .from("dataset_audit")
+    .select(
+      "dataset_id,is_georeferenced,has_valid_acquisition_date,has_valid_phenology,deadwood_quality,deadwood_notes,forest_cover_quality,forest_cover_notes,aoi_done,has_cog_issue,cog_issue_notes,has_thumbnail_issue,thumbnail_issue_notes,audited_by,notes,final_assessment",
+    )
+    .eq("dataset_id", datasetId)
+    .single();
+  expect(auditError).toBeNull();
+  expect(audit).toMatchObject({
+    dataset_id: datasetId,
+    is_georeferenced: true,
+    has_valid_acquisition_date: true,
+    has_valid_phenology: true,
+    deadwood_quality: "great",
+    deadwood_notes: "Deadwood prediction is fit for audit.",
+    forest_cover_quality: "sentinel_ok",
+    forest_cover_notes: "Tree cover is usable.",
+    aoi_done: true,
+    has_cog_issue: false,
+    cog_issue_notes: "COG loads from local nginx.",
+    has_thumbnail_issue: false,
+    thumbnail_issue_notes: "Thumbnail state accepted.",
+    audited_by: auditorUser.id,
+    notes: "Auditor local write integration completed.",
+    final_assessment: "no_issues",
+  });
+
+  const { data: aois, error: aoiError } = await adminClient
+    .from("v2_aois")
+    .select("dataset_id,user_id,is_whole_image,geometry")
+    .eq("dataset_id", datasetId);
+  expect(aoiError).toBeNull();
+  expect(aois).toHaveLength(1);
+  expect(aois?.[0]).toMatchObject({
+    dataset_id: datasetId,
+    user_id: auditorUser.id,
+    is_whole_image: false,
+  });
+  expect(aois?.[0].geometry).toMatchObject({ type: "MultiPolygon" });
+
+  await expectAuditLock(false);
+
+  const { data: flag, error: flagError } = await adminClient
+    .from("dataset_flags")
+    .select("status,resolved_by")
+    .eq("id", flagId)
+    .single();
+  expect(flagError).toBeNull();
+  expect(flag).toEqual({ status: "acknowledged", resolved_by: null });
+
+  const { data: history, error: historyError } = await adminClient
+    .from("dataset_flag_status_history")
+    .select("old_status,new_status,changed_by")
+    .eq("flag_id", flagId)
+    .order("changed_at");
+  expect(historyError).toBeNull();
+  expect(history).toEqual([
+    {
+      old_status: "open",
+      new_status: "acknowledged",
+      changed_by: auditorUser.id,
+    },
+  ]);
+}
+
+async function cleanupAuditPrivilege() {
+  if (!privilegedUserId) return;
+  await adminClient.from("privileged_users").delete().eq("id", privilegedUserId);
+  privilegedUserId = 0;
+}
+
+async function cleanupDataset() {
+  if (!datasetId) return;
+
+  await adminClient
+    .from("dataset_flag_status_history")
+    .delete()
+    .eq("flag_id", flagId);
+  await adminClient.from("dataset_flags").delete().eq("dataset_id", datasetId);
+  await adminClient.from("dataset_audit").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_aois").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_cogs").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_thumbnails").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_orthos").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_statuses").delete().eq("dataset_id", datasetId);
+  await adminClient.from("v2_datasets").delete().eq("id", datasetId);
+
+  datasetId = 0;
+  flagId = 0;
+}

--- a/frontend/e2e-local/auditor-write-flows.spec.ts
+++ b/frontend/e2e-local/auditor-write-flows.spec.ts
@@ -67,8 +67,10 @@ test.describe("auditor local write flows", () => {
   test.afterAll(async () => {
     await cleanupDataset();
     await cleanupAuditPrivilege();
-    await deleteAuthUsersByEmail(adminClient, auditorEmail);
-    await deleteAuthUsersByEmail(adminClient, reporterEmail);
+    if (adminClient) {
+      await deleteAuthUsersByEmail(adminClient, auditorEmail);
+      await deleteAuthUsersByEmail(adminClient, reporterEmail);
+    }
     fs.rmSync(path.join(repoRoot, "data", "cogs", cogPath), { force: true });
   });
 
@@ -465,26 +467,38 @@ async function expectAuditSideEffects() {
 
 async function cleanupAuditPrivilege() {
   if (!privilegedUserId) return;
-  await adminClient.from("privileged_users").delete().eq("id", privilegedUserId);
+  await deleteRows("privileged_users", "id", privilegedUserId);
   privilegedUserId = 0;
 }
 
 async function cleanupDataset() {
   if (!datasetId) return;
 
-  await adminClient
-    .from("dataset_flag_status_history")
-    .delete()
-    .eq("flag_id", flagId);
-  await adminClient.from("dataset_flags").delete().eq("dataset_id", datasetId);
-  await adminClient.from("dataset_audit").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_aois").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_cogs").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_thumbnails").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_orthos").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_statuses").delete().eq("dataset_id", datasetId);
-  await adminClient.from("v2_datasets").delete().eq("id", datasetId);
+  if (flagId) {
+    await deleteRows("dataset_flag_status_history", "flag_id", flagId);
+  }
+  await deleteRows("dataset_flags", "dataset_id", datasetId);
+  await deleteRows("dataset_audit", "dataset_id", datasetId);
+  await deleteRows("v2_aois", "dataset_id", datasetId);
+  await deleteRows("v2_cogs", "dataset_id", datasetId);
+  await deleteRows("v2_thumbnails", "dataset_id", datasetId);
+  await deleteRows("v2_orthos", "dataset_id", datasetId);
+  await deleteRows("v2_statuses", "dataset_id", datasetId);
+  await deleteRows("v2_datasets", "id", datasetId);
 
   datasetId = 0;
   flagId = 0;
+}
+
+async function deleteRows(
+  table: string,
+  column: string,
+  value: number | string,
+) {
+  const { error } = await adminClient.from(table).delete().eq(column, value);
+  if (error) {
+    throw new Error(
+      `Failed to clean ${table}.${column}=${String(value)}: ${error.message}`,
+    );
+  }
 }

--- a/frontend/e2e-local/auditor-write-flows.spec.ts
+++ b/frontend/e2e-local/auditor-write-flows.spec.ts
@@ -323,10 +323,7 @@ async function installAuditorSession(page: Page) {
   expect(login.data.session).toBeTruthy();
 
   await page.addInitScript((session) => {
-    const storageKey = "sb-127-auth-token";
-    const { user, ...sessionWithoutUser } = session;
-    window.localStorage.setItem(storageKey, JSON.stringify(sessionWithoutUser));
-    window.localStorage.setItem(`${storageKey}-user`, JSON.stringify({ user }));
+    window.localStorage.setItem("sb-127-auth-token", JSON.stringify(session));
   }, login.data.session);
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "test:e2e": "playwright test",
     "test:e2e:readonly": "playwright test",
     "test:e2e:local:audit": "playwright test --config playwright.local.config.ts auditor-local.spec.ts",
+    "test:e2e:local:audit:write": "bash ./scripts/run-local-auditor-write-e2e.sh",
     "test:e2e:local": "playwright test --config playwright.local.config.ts",
     "test:e2e:local:write": "bash ./scripts/run-local-write-e2e.sh",
     "test:watch": "vitest"

--- a/frontend/scripts/run-local-auditor-write-e2e.sh
+++ b/frontend/scripts/run-local-auditor-write-e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+
+ENV_FILE="$REPO_ROOT/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  ENV_FILE="$REPO_ROOT/.env.example"
+fi
+
+for key in SUPABASE_SERVICE_ROLE_KEY SUPABASE_ANON_KEY; do
+  value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "$value" ]]; then
+    echo "Missing $key in $ENV_FILE; local auditor write E2E needs local Supabase keys." >&2
+    exit 1
+  fi
+  export "$key=$value"
+done
+
+export E2E_LOCAL_AUDITOR_WRITE=1
+export PLAYWRIGHT_PORT="${PLAYWRIGHT_PORT:-5174}"
+
+cd "$FRONTEND_DIR"
+exec ./node_modules/.bin/playwright test --config playwright.local.config.ts e2e-local/auditor-write-flows.spec.ts


### PR DESCRIPTION
## Summary
- add an opt-in local Playwright suite for the auditor write workflow
- seed local Supabase with auditor/reporter users, an auditable dataset, local COG metadata, and an open dataset flag
- verify real local side effects for flag acknowledgement, audit lock release, AOI persistence, and dataset_audit save
- document when future agents should run the suite and add a package script wrapper

## Validation
- npm --prefix frontend run test:e2e:local:audit:write
- npx eslint e2e-local/auditor-write-flows.spec.ts --ext ts,tsx --max-warnings 0
- npm --prefix frontend run test:e2e:local -- --list
- npm --prefix frontend test
- git diff --check

## Notes
- this is intentionally local-only and requires local Supabase plus api-test/nginx; it does not run against production or same-repo read-only CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new local test harness/docs and do not alter production runtime behavior. Main risk is test flakiness or local environment/key handling assumptions when running the suite.
> 
> **Overview**
> Adds a new **opt-in, local-only** Playwright suite (`e2e-local/auditor-write-flows.spec.ts`) that seeds local Supabase (auditor/reporter users, dataset/COG, open flag) and verifies real write side effects: flag acknowledgement via `update_flag_status`, audit lock acquisition/release, AOI persistence, and `dataset_audit` save.
> 
> Wires the suite into `frontend/package.json` via `test:e2e:local:audit:write`, adds a wrapper script (`run-local-auditor-write-e2e.sh`) to load local Supabase keys and set gating env vars/port, and updates agent/testing docs to describe when to run this new auditor write flow suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23fc39e21e734f8fa2b1d10bb2da26247d91a5b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing strategy documentation with new auditor workflow test procedures and local setup instructions.

* **Tests**
  * Added comprehensive end-to-end test suite for auditor workflows with local database validation and side-effect verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->