### PR TITLE
ci(api): add backend smoke suite

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -1,0 +1,67 @@
+name: API Smoke
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - "shared/**"
+      - "supabase/**"
+      - "deadtrees-cli/**"
+      - "docker-compose.test.yaml"
+      - "nginx/test-conf/**"
+      - "scripts/test-api-smoke.sh"
+      - ".github/workflows/api-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  api-smoke:
+    name: api-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      COMPOSE_PROJECT_NAME: deadtrees-api-smoke
+      DOCKER_BUILDKIT: "1"
+      COMPOSE_DOCKER_CLI_BUILD: "1"
+      CI: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            deadtrees-cli/setup.py
+            api/requirements.txt
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      - name: Prepare local env
+        run: |
+          cp .env.example .env
+          mkdir -p data/archive data/cogs data/thumbnails data/label_objects data/downloads data/raw_images data/trash
+
+      - name: Install DeadTrees CLI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e deadtrees-cli
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Run API smoke suite
+        run: scripts/test-api-smoke.sh
+
+      - name: Stop API test stack
+        if: always()
+        run: docker compose -f docker-compose.test.yaml down --remove-orphans
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop --no-backup

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -3,6 +3,7 @@ import subprocess
 import os
 import signal
 import shutil
+import sys
 import time
 from pathlib import Path
 from typing import Optional, List
@@ -46,6 +47,14 @@ class DevCommands:
 	def _compose_cmd(self, *args: str) -> List[str]:
 		"""Build a docker compose command for the test environment."""
 		return ['docker', 'compose', '-f', self.test_compose_file, *args]
+
+	def _compose_exec_args(self, service: str) -> List[str]:
+		"""Build docker compose exec args that work both locally and in CI."""
+		args = ['exec']
+		if os.environ.get('CI') or not sys.stdin.isatty():
+			args.append('-T')
+		args.append(service)
+		return args
 
 	def _normalize_services(self, services: Optional[List[str] | str]) -> Optional[List[str]]:
 		"""Allow Fire callers to pass either a list or a comma-separated string."""
@@ -595,8 +604,7 @@ class DevCommands:
 			'compose',
 			'-f',
 			self.test_compose_file,
-			'exec',
-			service,
+			*self._compose_exec_args(service),
 			'python',
 			'-m',
 			'pytest',

--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -52,11 +52,14 @@ sessions where a debugger client will attach.
 source venv/bin/activate
 deadtrees dev test api
 deadtrees dev test processor
+scripts/test-api-smoke.sh
 npm --prefix frontend test
 npm --prefix frontend run test:e2e
 ```
 
 Local work is good for API, shared-model, frontend, docs, and non-GPU checks.
+Use `scripts/test-api-smoke.sh` for API, shared, Supabase migration, RLS/RPC, or
+backend storage/download changes that need the same backend-lite coverage as CI.
 For targeted follow-up after the test stack is already running, direct
 container pytest is acceptable, for example
 `docker compose -f docker-compose.test.yaml exec api-test python -m pytest -v api/tests/routers/test_process.py`.

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -59,7 +59,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | Contributor write E2E  | `npm --prefix frontend run test:e2e:local:write`                        | local-only signup, password reset, upload start, download request side effects      |
 | Auditor local E2E      | `npm --prefix frontend run test:e2e:local:audit`                        | auditor-only queue triage, audit tabs, processing logs, and audit access guards     |
 | Auditor write E2E      | `npm --prefix frontend run test:e2e:local:audit:write`                  | local-only auditor flag, AOI, audit-lock, and audit-save side effects               |
-| API/router             | `deadtrees dev test api <path>`                                         | FastAPI routes, upload/download/process/auth behavior                               |
+| API/router             | `scripts/test-api-smoke.sh` or `deadtrees dev test api <path>`          | FastAPI routes, upload/download/process/auth behavior                               |
 | Database/RLS/migration | focused API DB tests plus migration review/reset where practical        | schema, policies, RPCs, views, generated contracts                                  |
 | Processor CPU          | `deadtrees dev test processor <path>`                                   | queue orchestration, GeoTIFF/COG/metadata, non-GPU utilities                        |
 | Processor GPU/model    | processing-server dev checkout                                          | model loading, CUDA/NVIDIA runtime, full combined-model execution, ODM-heavy checks |
@@ -93,6 +93,42 @@ should have at least one durable test or smoke check:
 - publication: selection, author/ORCID validation, submission state
 
 ## Local Contributor Smoke
+
+## API Smoke
+
+Use the API smoke suite when a change touches FastAPI routes, shared database
+models/helpers, Supabase migrations, RLS policies, RPC contracts, or local
+storage/download behavior:
+
+```bash
+supabase start
+scripts/test-api-smoke.sh
+```
+
+The same command is used by the path-filtered `api-smoke` GitHub Actions
+workflow. It starts only the backend-lite test surface: local Supabase, the API
+test container, nginx storage, and Mailpit. It intentionally excludes the
+processor, GPU/model inference, ODM, and full pipeline validation.
+
+The suite covers:
+
+- API settings/import sanity
+- contributor upload and process request contracts
+- upload type detection and unsupported ZIP compression rejection
+- processing task validation, priority, queue ordering, and rerun behavior
+- prepackaged download grant contracts
+- DTE stats route validation with synthetic fixtures
+- focused download route contracts and bundle helper behavior
+- auditor flag review RPC authorization and status history
+- private dataset RLS through tables and dataset views
+- privileged user visibility and privilege functions
+- dataset audit persistence and constraints
+- dataset edit history triggers and authorization
+- data publication tables and basic publication operations
+- notification email rendering and Mailpit delivery
+
+Keep this suite backend-lite. Add processor/GPU/ODM checks to the processing
+server validation lane instead of expanding API smoke into full-system testing.
 
 Keep authenticated contributor journeys out of the production-read Playwright
 suite. Use the local contributor smoke when a frontend change touches upload,

--- a/scripts/test-api-smoke.sh
+++ b/scripts/test-api-smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+if [[ ! -f .env ]]; then
+	cp .env.example .env
+fi
+
+mkdir -p \
+	data/archive \
+	data/cogs \
+	data/thumbnails \
+	data/label_objects \
+	data/downloads \
+	data/raw_images \
+	data/trash
+
+if command -v deadtrees >/dev/null 2>&1; then
+	DEADTREES_CLI=(deadtrees)
+elif [[ -x venv/bin/deadtrees ]]; then
+	DEADTREES_CLI=(venv/bin/deadtrees)
+else
+	echo "Could not find the deadtrees CLI. Install it or create the repo venv first." >&2
+	exit 1
+fi
+
+"${DEADTREES_CLI[@]}" dev test api api/tests/test_settings.py
+
+api_smoke_tests=(
+	api/tests/routers/test_contributor_contract_smoke.py
+	api/tests/routers/test_upload_odm_detection.py
+	api/tests/routers/test_process.py
+	api/tests/routers/test_prepackaged.py
+	api/tests/routers/test_dte_stats.py
+	api/tests/routers/test_download.py::test_download_status_invalid_dataset_id_returns_400
+	api/tests/routers/test_download.py::TestMultiBundleHelpers
+	api/tests/db/test_auditor_flag_review_contract.py
+	api/tests/db/test_dataset_rls_policy.py
+	api/tests/db/test_privileged_users.py
+	api/tests/db/test_dataset_audit.py
+	api/tests/db/test_dataset_edit_history.py
+	api/tests/db/test_data_publication.py
+	api/tests/test_notifications.py
+)
+
+docker compose -f docker-compose.test.yaml exec -T api-test \
+	python -m pytest -v "${api_smoke_tests[@]}"

--- a/scripts/test-api-smoke.sh
+++ b/scripts/test-api-smoke.sh
@@ -10,6 +10,17 @@ if [[ ! -f .env ]]; then
 	cp .env.example .env
 fi
 
+if [[ -z "${COMPOSE_PROJECT_NAME:-}" ]]; then
+	compose_project_name="$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' .env | tail -n 1)"
+	compose_project_name="${compose_project_name%\"}"
+	compose_project_name="${compose_project_name#\"}"
+	compose_project_name="${compose_project_name%\'}"
+	compose_project_name="${compose_project_name#\'}"
+	export COMPOSE_PROJECT_NAME="${compose_project_name:-deadtrees-test}"
+else
+	export COMPOSE_PROJECT_NAME
+fi
+
 mkdir -p \
 	data/archive \
 	data/cogs \


### PR DESCRIPTION
## Summary
- add a path-filtered API smoke workflow for backend, shared, Supabase, CLI, and test-stack changes
- add scripts/test-api-smoke.sh as the shared local/CI entrypoint for backend-lite API coverage
- run local Supabase plus api-test/nginx/Mailpit only; processor, GPU, ODM, and full pipeline validation stay out of PR CI
- make deadtrees dev test use non-TTY docker compose exec in CI
- document the API smoke lane in the testing strategy and agent rules

## Coverage
The smoke command covers API settings, contributor upload/process contracts, upload type validation, process queue/rerun behavior, prepackaged grants, synthetic DTE stats, focused download contracts, auditor flag RPC/RLS history, private dataset RLS, privileged user visibility, dataset audit persistence, dataset edit history, data publication, and notification email delivery through Mailpit.

## Validation
- bash -n scripts/test-api-smoke.sh
- python3 -m py_compile deadtrees-cli/deadtrees_cli/dev.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/api-smoke.yml")'
- scripts/test-api-smoke.sh (2 settings tests + 110 API smoke tests passed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated API smoke testing pipeline that runs on relevant pull requests to validate backend functionality.

* **Documentation**
  * Updated testing strategy and contribution guidelines with new API smoke test procedures and coverage details.

* **Chores**
  * Enhanced testing infrastructure and CI/CD configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate that boots Supabase and runs a curated backend test subset; failures will now block PRs touching backend/shared/db areas, and the new non-TTY `docker compose exec` behavior could affect local test invocation in edge cases.
> 
> **Overview**
> Introduces a path-filtered GitHub Actions workflow (`.github/workflows/api-smoke.yml`) that starts local Supabase and runs a new backend-lite API smoke suite on PRs that touch backend/shared/Supabase/CLI or test-stack files.
> 
> Adds `scripts/test-api-smoke.sh` as the shared local/CI entrypoint, which prepares `.env`/data directories, runs a settings sanity test, then executes a curated set of API router + DB/RLS/RPC contract tests inside the `api-test` container.
> 
> Updates `deadtrees-cli` to make `deadtrees dev test ...` use `docker compose exec -T` automatically in CI/non-TTY contexts, and documents the new API smoke lane in `docs/agents/rules.md` and `docs/agents/testing-strategy.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcca0fb59e9e53bc7d908f80a37d4ec0805566d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->