### PR TITLE
feat(releases): add prepackaged reproducibility metadata

### DIFF
--- a/api/src/routers/prepackaged.py
+++ b/api/src/routers/prepackaged.py
@@ -34,6 +34,8 @@ class PrepackagedDatasetVersion(BaseModel):
 	artifact_count: Optional[int] = None
 	built_at: Optional[datetime] = None
 	published_at: Optional[datetime] = None
+	source_commit: Optional[str] = None
+	source_package_version: Optional[str] = None
 	manifest: dict[str, Any] = Field(default_factory=dict)
 	known_issues: Optional[str] = None
 
@@ -46,6 +48,9 @@ class PrepackagedDatasetPackage(BaseModel):
 	title: str
 	summary: str
 	description: Optional[str] = None
+	technical_description: Optional[str] = None
+	source_repository_url: Optional[str] = None
+	source_file_path: Optional[str] = None
 	kind: str
 	sort_order: int
 	versions: list[PrepackagedDatasetVersion]
@@ -192,7 +197,10 @@ def list_prepackaged_packages():
 	with use_service_client() as db_client:
 		definition_response = (
 			db_client.table(DEFINITIONS_TABLE)
-			.select('id,slug,title,summary,description,kind,sort_order')
+			.select(
+				'id,slug,title,summary,description,technical_description,'
+				'source_repository_url,source_file_path,kind,sort_order'
+			)
 			.eq('is_active', True)
 			.order('sort_order')
 			.execute()
@@ -201,7 +209,8 @@ def list_prepackaged_packages():
 			db_client.table(VERSIONS_TABLE)
 			.select(
 				'id,definition_id,version,status,file_name,public_download_path,size_bytes,checksum_sha256,'
-				'dataset_count,artifact_count,built_at,published_at,manifest,known_issues'
+				'dataset_count,artifact_count,built_at,published_at,source_commit,source_package_version,'
+				'manifest,known_issues'
 			)
 			.eq('status', 'available')
 			.order('published_at', desc=True)

--- a/api/tests/routers/test_prepackaged.py
+++ b/api/tests/routers/test_prepackaged.py
@@ -124,6 +124,9 @@ class FakeCatalogClient:
 					'title': 'Tree cover aerial global',
 					'summary': 'Tree cover summary',
 					'description': None,
+					'technical_description': 'Exact package definition',
+					'source_repository_url': 'https://github.com/Deadwood-ai/prepackaged_datasets_dte',
+					'source_file_path': 'deadtrees_prepackaged/datasets/tree_cover_aerial_global.py',
 					'kind': 'vector',
 					'sort_order': 10,
 				}
@@ -142,6 +145,8 @@ class FakeCatalogClient:
 					'artifact_count': 1,
 					'built_at': None,
 					'published_at': None,
+					'source_commit': 'feffe7b73d2ec3159260a6d3fddf7e5ac9ae855a',
+					'source_package_version': '0.1.0',
 					'manifest': {},
 					'known_issues': None,
 				}
@@ -186,7 +191,12 @@ def test_list_prepackaged_packages_is_public_service_read(monkeypatch):
 
 	assert len(packages) == 1
 	assert packages[0].slug == 'tree-cover-aerial-global'
+	assert packages[0].technical_description == 'Exact package definition'
+	assert packages[0].source_repository_url == 'https://github.com/Deadwood-ai/prepackaged_datasets_dte'
+	assert packages[0].source_file_path == 'deadtrees_prepackaged/datasets/tree_cover_aerial_global.py'
 	assert packages[0].versions[0].file_name == 'tree-cover.zip'
+	assert packages[0].versions[0].source_commit == 'feffe7b73d2ec3159260a6d3fddf7e5ac9ae855a'
+	assert packages[0].versions[0].source_package_version == '0.1.0'
 	assert ('is_active', True) in client.queries[DEFINITIONS_TABLE].filters
 	assert ('status', 'available') in client.queries[VERSIONS_TABLE].filters
 

--- a/frontend/src/api/prepackaged.ts
+++ b/frontend/src/api/prepackaged.ts
@@ -12,6 +12,8 @@ export interface IPrepackagedDatasetVersion {
   artifact_count: number | null;
   built_at: string | null;
   published_at: string | null;
+  source_commit: string | null;
+  source_package_version: string | null;
   manifest: Record<string, unknown>;
   known_issues: string | null;
 }
@@ -22,6 +24,9 @@ export interface IPrepackagedDatasetPackage {
   title: string;
   summary: string;
   description: string | null;
+  technical_description: string | null;
+  source_repository_url: string | null;
+  source_file_path: string | null;
   kind: "vector" | "tiles" | "labels" | "satellite";
   sort_order: number;
   versions: IPrepackagedDatasetVersion[];

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -1,7 +1,10 @@
 import {
   ArrowLeftOutlined,
+  CodeOutlined,
   DatabaseOutlined,
+  ExportOutlined,
   FileOutlined,
+  LinkOutlined,
   LoginOutlined,
 } from "@ant-design/icons";
 import { Alert, Button, Empty, Skeleton, message } from "antd";
@@ -22,6 +25,36 @@ import {
   prepackagedKindLabel,
   prepackagedNumberFormatter,
 } from "../utils/prepackagedDatasets";
+
+function getSafeHttpUrl(url: string | null) {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function buildSourceCodeUrl(
+  repositoryUrl: string | null,
+  sourceFilePath: string | null,
+  sourceCommit: string | null,
+) {
+  const safeRepositoryUrl = getSafeHttpUrl(repositoryUrl);
+  if (!safeRepositoryUrl || !sourceFilePath || !sourceCommit) return null;
+
+  const encodedPath = sourceFilePath.split("/").map(encodeURIComponent).join("/");
+  return `${safeRepositoryUrl}/blob/${encodeURIComponent(sourceCommit)}/${encodedPath}`;
+}
+
+function getShortCommit(sourceCommit: string | null) {
+  return sourceCommit ? sourceCommit.slice(0, 7) : null;
+}
 
 export default function PrepackagedDatasetRelease() {
   const { slug } = useParams();
@@ -81,6 +114,27 @@ export default function PrepackagedDatasetRelease() {
     typeof manifest.license_filter === "string"
       ? manifest.license_filter
       : null;
+  const safeRepositoryUrl = datasetPackage
+    ? getSafeHttpUrl(datasetPackage.source_repository_url)
+    : null;
+  const sourceCodeUrl =
+    datasetPackage && latestVersion
+      ? buildSourceCodeUrl(
+          datasetPackage.source_repository_url,
+          datasetPackage.source_file_path,
+          latestVersion.source_commit,
+        )
+      : null;
+  const shortSourceCommit = latestVersion
+    ? getShortCommit(latestVersion.source_commit)
+    : null;
+  const hasReproducibilityMetadata = Boolean(
+    datasetPackage?.technical_description ||
+      sourceCodeUrl ||
+      safeRepositoryUrl ||
+      latestVersion?.source_package_version ||
+      shortSourceCommit,
+  );
 
   const handleDownload = async (versionId: number) => {
     if (!token) {
@@ -240,6 +294,94 @@ export default function PrepackagedDatasetRelease() {
               </div>
             </div>
           </section>
+
+          {hasReproducibilityMetadata && (
+            <section className="border-t border-gray-200 bg-[#f8faf9]">
+              <div className="mx-auto grid max-w-7xl gap-8 px-4 py-10 md:px-8 md:py-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+                <div>
+                  <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#1B5E35]">
+                    <CodeOutlined />
+                    Reproducibility
+                  </div>
+                  <h2 className="m-0 mt-3 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
+                    Technical definition
+                  </h2>
+                  {datasetPackage.technical_description && (
+                    <p className="mt-4 max-w-4xl text-base leading-8 text-gray-600">
+                      {datasetPackage.technical_description}
+                    </p>
+                  )}
+                </div>
+
+                <div className="self-start rounded-lg border border-gray-200 bg-white p-5 md:p-6">
+                  <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    <LinkOutlined />
+                    Generator code
+                  </div>
+                  <dl className="mt-5 grid gap-4 text-sm text-gray-600">
+                    {safeRepositoryUrl && (
+                      <div>
+                        <dt className="font-semibold text-gray-800">
+                          Repository
+                        </dt>
+                        <dd className="m-0 mt-2">
+                          <a
+                            href={safeRepositoryUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
+                          >
+                            <span className="truncate">
+                              Open repository
+                            </span>
+                            <ExportOutlined className="shrink-0 text-xs" />
+                          </a>
+                        </dd>
+                      </div>
+                    )}
+                    {sourceCodeUrl && (
+                      <div>
+                        <dt className="font-semibold text-gray-800">
+                          Source file
+                        </dt>
+                        <dd className="m-0 mt-2">
+                          <a
+                            href={sourceCodeUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
+                          >
+                            <span className="truncate">
+                              Open source file
+                            </span>
+                            <ExportOutlined className="shrink-0 text-xs" />
+                          </a>
+                        </dd>
+                      </div>
+                    )}
+                    {shortSourceCommit && (
+                      <div>
+                        <dt className="font-semibold text-gray-800">Commit</dt>
+                        <dd className="m-0 mt-1 font-mono text-gray-700">
+                          {shortSourceCommit}
+                        </dd>
+                      </div>
+                    )}
+                    {latestVersion.source_package_version && (
+                      <div>
+                        <dt className="font-semibold text-gray-800">
+                          Package version
+                        </dt>
+                        <dd className="m-0 mt-1">
+                          v{latestVersion.source_package_version}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+              </div>
+            </section>
+          )}
 
           <section
             className="border-t border-gray-200 bg-white"

--- a/supabase/migrations/20260511110000_add_prepackaged_reproducibility_metadata.sql
+++ b/supabase/migrations/20260511110000_add_prepackaged_reproducibility_metadata.sql
@@ -1,0 +1,44 @@
+alter table "public"."prepackaged_dataset_definitions"
+add column if not exists "technical_description" text,
+add column if not exists "source_repository_url" text,
+add column if not exists "source_file_path" text;
+
+alter table "public"."prepackaged_dataset_versions"
+add column if not exists "source_commit" text,
+add column if not exists "source_package_version" text;
+
+update public.prepackaged_dataset_definitions
+set
+    technical_description = 'Dataset-level eligibility starts from audited deadtrees.earth records that are public, CC BY licensed, not archived, and have a complete acquisition date. Tree-cover polygon eligibility is then restricted to outputs that passed the export quality checks for forest cover. For each eligible dataset, tree-cover polygons are loaded, clipped to the dataset AOI, reduced to polygonal geometries only, and appended incrementally to a single GeoPackage tree_cover layer. Datasets that yield no remaining polygons after loading or AOI clipping are excluded from the final package. The output ZIP contains the GeoPackage, dataset-level metadata tables, a package manifest, and attribution/license text.',
+    source_repository_url = 'https://github.com/Deadwood-ai/prepackaged_datasets_dte',
+    source_file_path = 'deadtrees_prepackaged/datasets/tree_cover_aerial_global.py'
+where slug = 'tree-cover-aerial-global';
+
+update public.prepackaged_dataset_definitions
+set
+    technical_description = 'Dataset-level eligibility starts from audited deadtrees.earth records that are public, CC BY licensed, not archived, and have a complete acquisition date. Standing-deadwood polygon eligibility is restricted to outputs that passed the export quality checks for deadwood. A conservative phenology filter is applied in Python using the exported phenology curve, requiring the acquisition-day indicator to be greater than 128. For each eligible dataset, AOI geometry is always retained in the package, while deadwood polygons are clipped to the AOI and reduced to polygonal geometries only. Datasets that end up with zero deadwood polygons after loading or clipping are still preserved in AOI and metadata outputs. The final ZIP contains one GeoPackage, dataset-level metadata tables, a package manifest, and attribution/license text.',
+    source_repository_url = 'https://github.com/Deadwood-ai/prepackaged_datasets_dte',
+    source_file_path = 'deadtrees_prepackaged/datasets/standing_deadwood_aerial_global_conservative.py'
+where slug = 'standing-deadwood-aerial-global-conservative';
+
+update public.prepackaged_dataset_definitions
+set
+    technical_description = 'Dataset eligibility starts from audited deadtrees.earth records that are public, CC BY licensed, not archived, have a complete acquisition date, include an orthophoto file, and have at least one AOI. For each eligible orthophoto, the raster is partitioned into non-overlapping 1024x1024 source windows, and only tiles whose full bounds are covered by the AOI are retained. A deterministic random sample seeded by dataset ID selects at most 20 tiles per dataset from those AOI-covered candidates. Selected tiles are written as GeoTIFF files under tiles/ in the original orthophoto CRS and native source resolution, and only the first three source bands (RGB) are read and saved. The package also includes dataset-level metadata tables, a per-tile index table, a package manifest, and attribution/license text inside the final ZIP archive.',
+    source_repository_url = 'https://github.com/Deadwood-ai/prepackaged_datasets_dte',
+    source_file_path = 'deadtrees_prepackaged/datasets/image_tiles_1024_global_aerial_sampled_20_random.py'
+where slug = 'image-tiles-1024-global-aerial-sampled-20-random';
+
+update public.prepackaged_dataset_versions
+set
+    source_commit = 'feffe7b73d2ec3159260a6d3fddf7e5ac9ae855a',
+    source_package_version = '0.1.0'
+where version = '2026.04.17'
+  and definition_id in (
+    select id
+    from public.prepackaged_dataset_definitions
+    where slug in (
+        'tree-cover-aerial-global',
+        'standing-deadwood-aerial-global-conservative',
+        'image-tiles-1024-global-aerial-sampled-20-random'
+    )
+  );


### PR DESCRIPTION
## Summary

- add reproducibility metadata fields for prepackaged dataset definitions and versions
- expose technical descriptions, generator repository, source file, commit, and package version through the prepackaged packages API
- render a public technical definition and explicit generator-code link buttons on release detail pages

## Validation

- `deadtrees dev test api api/tests/routers/test_prepackaged.py`
- `npm exec -- eslint src/api/prepackaged.ts src/pages/PrepackagedDatasetRelease.tsx --max-warnings 0`
- `git diff --check` plus migration trailing-whitespace check
- local API smoke for `/api/v1/prepackaged/packages` after applying the migration locally
- Browser smoke on `http://127.0.0.1:5179/releases/image-tiles-1024-global-aerial-sampled-20-random`: repository/source buttons visible, raw URL/file text removed, hrefs correct

## Known limitation

- `npm --prefix frontend run build` still fails on existing unrelated TypeScript baseline errors in map/editor/test files (`UIEvent` generic constraints, nullable extents, and Buffer/BlobPart typing). This PR does not touch those files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `/prepackaged/packages` API response shape and requires a Supabase schema migration; issues would mainly be missing/NULL metadata or downstream client assumptions.
> 
> **Overview**
> Adds **reproducibility metadata** to prepackaged dataset definitions and versions (technical definition text, generator repo/file path, source commit, and generator package version) via a Supabase migration that also seeds initial values for a few slugs.
> 
> Extends the backend `/prepackaged/packages` response and frontend TS types to expose these fields, and updates the release detail page to render a new *Reproducibility* section with repository/source-file links plus commit/package version when available. Also expands the API router test coverage to assert the new fields are returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2062b9fc838dd6a1ad2262fc0aac409325fa72b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prepackaged datasets now display reproducibility metadata including technical descriptions, source code repository links, commit hashes, and package versions in a new "Reproducibility" section on dataset release pages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->