### PR TITLE
test(quality): add ast-grep guardrails

### DIFF
--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -1,0 +1,38 @@
+name: AST Grep
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**/*.ts"
+      - "frontend/**/*.tsx"
+      - "api/**/*.py"
+      - "shared/**/*.py"
+      - "processor/**/*.py"
+      - "deadtrees-cli/**/*.py"
+      - "scripts/**/*.py"
+      - "scripts/**/*.ts"
+      - "scripts/lint-ast-grep.sh"
+      - "ast-grep/**"
+      - "sgconfig.yml"
+      - ".github/workflows/ast-grep.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ast-grep:
+    name: ast-grep
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Test ast-grep rules
+        run: scripts/test-ast-grep-rules.sh
+
+      - name: Run repo-specific AST guardrails
+        run: scripts/lint-ast-grep.sh --format github

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/**/*.py"
       - "scripts/**/*.ts"
       - "scripts/lint-ast-grep.sh"
+      - "scripts/test-ast-grep-rules.sh"
       - "ast-grep/**"
       - "sgconfig.yml"
       - ".github/workflows/ast-grep.yml"

--- a/ast-grep/rule-tests/no-browser-dump-in-tests-test.yml
+++ b/ast-grep/rule-tests/no-browser-dump-in-tests-test.yml
@@ -1,0 +1,8 @@
+id: no-browser-dump-in-tests
+valid:
+  - 'await expect(page.getByTestId("dataset-archive-page")).toBeVisible()'
+  - 'await page.getByRole("button", { name: "Explore Map" }).click()'
+invalid:
+  - 'await page.locator("body").innerText()'
+  - 'await page.content()'
+  - 'await page.locator(".items").allTextContents()'

--- a/ast-grep/rule-tests/no-env-value-logging-python-test.yml
+++ b/ast-grep/rule-tests/no-env-value-logging-python-test.yml
@@ -4,5 +4,6 @@ valid:
   - logger.info('processor started')
 invalid:
   - print(os.environ['SUPABASE_SERVICE_ROLE_KEY'])
+  - print(os.environ.get('DATABASE_URL'))
   - logger.error(os.getenv('DATABASE_URL'))
-
+  - logger.info('db url', os.environ.get('DATABASE_URL'))

--- a/ast-grep/rule-tests/no-env-value-logging-python-test.yml
+++ b/ast-grep/rule-tests/no-env-value-logging-python-test.yml
@@ -1,0 +1,8 @@
+id: no-env-value-logging-python
+valid:
+  - settings_value = os.environ.get('GDAL_DISABLE_READDIR_ON_OPEN')
+  - logger.info('processor started')
+invalid:
+  - print(os.environ['SUPABASE_SERVICE_ROLE_KEY'])
+  - logger.error(os.getenv('DATABASE_URL'))
+

--- a/ast-grep/rule-tests/no-env-value-logging-ts-test.yml
+++ b/ast-grep/rule-tests/no-env-value-logging-ts-test.yml
@@ -1,0 +1,8 @@
+id: no-env-value-logging-ts
+valid:
+  - console.log("startup complete")
+  - const apiUrl = import.meta.env.VITE_SAM_API_URL
+invalid:
+  - console.log(process.env.SUPABASE_SERVICE_ROLE_KEY)
+  - logger.warn(import.meta.env.VITE_SUPABASE_ANON_KEY)
+

--- a/ast-grep/rule-tests/no-env-value-logging-ts-test.yml
+++ b/ast-grep/rule-tests/no-env-value-logging-ts-test.yml
@@ -5,4 +5,5 @@ valid:
 invalid:
   - console.log(process.env.SUPABASE_SERVICE_ROLE_KEY)
   - logger.warn(import.meta.env.VITE_SUPABASE_ANON_KEY)
-
+  - console.error("db", process.env.DATABASE_URL)
+  - logger.warn("cfg", import.meta.env.VITE_SUPABASE_ANON_KEY)

--- a/ast-grep/rule-tests/no-frontend-service-role-env-test.yml
+++ b/ast-grep/rule-tests/no-frontend-service-role-env-test.yml
@@ -5,4 +5,7 @@ valid:
 invalid:
   - const serviceRole = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY
   - const databaseUrl = process.env.DATABASE_URL
-
+  - const serviceRole = import.meta.env["VITE_SUPABASE_SERVICE_ROLE_KEY"]
+  - const databaseUrl = process.env["DATABASE_URL"]
+  - const { VITE_SUPABASE_SERVICE_ROLE_KEY } = import.meta.env
+  - const { DATABASE_URL, OTHER } = process.env

--- a/ast-grep/rule-tests/no-frontend-service-role-env-test.yml
+++ b/ast-grep/rule-tests/no-frontend-service-role-env-test.yml
@@ -1,0 +1,8 @@
+id: no-frontend-service-role-env
+valid:
+  - const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+  - const mode = import.meta.env.VITE_MODE
+invalid:
+  - const serviceRole = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY
+  - const databaseUrl = process.env.DATABASE_URL
+

--- a/ast-grep/rule-tests/no-http-mutation-in-readonly-e2e-test.yml
+++ b/ast-grep/rule-tests/no-http-mutation-in-readonly-e2e-test.yml
@@ -1,0 +1,7 @@
+id: no-http-mutation-in-readonly-e2e
+valid:
+  - 'await request.get("/api/v1/openapi.json")'
+  - 'await page.goto("/dataset")'
+invalid:
+  - 'await request.post("/api/v1/datasets")'
+  - 'await api.patch("/api/v1/datasets/1")'

--- a/ast-grep/rule-tests/no-mutating-submit-in-readonly-e2e-test.yml
+++ b/ast-grep/rule-tests/no-mutating-submit-in-readonly-e2e-test.yml
@@ -4,5 +4,6 @@ valid:
   - 'await page.getByRole("menuitem", { name: "Drone Archive" }).click()'
 invalid:
   - 'await page.getByRole("button", { name: "Upload Data" }).click()'
+  - 'await page.getByRole("button", { name: "upload data" }).click()'
   - 'await page.getByRole("button", { name: /Reset Password/i }).click()'
   - 'await page.getByText("Save").click()'

--- a/ast-grep/rule-tests/no-mutating-submit-in-readonly-e2e-test.yml
+++ b/ast-grep/rule-tests/no-mutating-submit-in-readonly-e2e-test.yml
@@ -1,0 +1,8 @@
+id: no-mutating-submit-in-readonly-e2e
+valid:
+  - 'await page.getByRole("button", { name: "Explore Map" }).click()'
+  - 'await page.getByRole("menuitem", { name: "Drone Archive" }).click()'
+invalid:
+  - 'await page.getByRole("button", { name: "Upload Data" }).click()'
+  - 'await page.getByRole("button", { name: /Reset Password/i }).click()'
+  - 'await page.getByText("Save").click()'

--- a/ast-grep/rules/no-browser-dump-in-tests.yml
+++ b/ast-grep/rules/no-browser-dump-in-tests.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-browser-dump-in-tests
+message: Use scoped locators/assertions instead of broad browser text or DOM dumps.
+severity: error
+language: TypeScript
+files:
+  - "frontend/e2e/**/*.ts"
+  - "frontend/scripts/**/*.ts"
+rule:
+  any:
+    - pattern: $PAGE.locator("body").innerText()
+    - pattern: $PAGE.locator('body').innerText()
+    - pattern: $LOCATOR.allTextContents()
+    - pattern: $PAGE.content()
+note: Browser checks should stay output-light and focused on URLs, locator state, console errors, and small artifacts.
+

--- a/ast-grep/rules/no-env-value-logging-python.yml
+++ b/ast-grep/rules/no-env-value-logging-python.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-env-value-logging-python
+message: Do not log environment values.
+severity: error
+language: Python
+rule:
+  any:
+    - pattern: print(os.environ)
+    - pattern: print(os.environ[$KEY])
+    - pattern: print(os.getenv($KEY))
+    - pattern: $LOGGER.$METHOD(os.environ)
+    - pattern: $LOGGER.$METHOD(os.environ[$KEY])
+    - pattern: $LOGGER.$METHOD(os.getenv($KEY))
+note: Secrets and local access settings must not be printed into CI, runtime, or support logs.
+

--- a/ast-grep/rules/no-env-value-logging-python.yml
+++ b/ast-grep/rules/no-env-value-logging-python.yml
@@ -8,9 +8,16 @@ rule:
   any:
     - pattern: print(os.environ)
     - pattern: print(os.environ[$KEY])
+    - pattern: print(os.environ.get($KEY))
     - pattern: print(os.getenv($KEY))
+    - pattern: print($A, os.environ[$KEY])
+    - pattern: print($A, os.environ.get($KEY))
+    - pattern: print($A, os.getenv($KEY))
     - pattern: $LOGGER.$METHOD(os.environ)
     - pattern: $LOGGER.$METHOD(os.environ[$KEY])
+    - pattern: $LOGGER.$METHOD(os.environ.get($KEY))
     - pattern: $LOGGER.$METHOD(os.getenv($KEY))
+    - pattern: $LOGGER.$METHOD($A, os.environ[$KEY])
+    - pattern: $LOGGER.$METHOD($A, os.environ.get($KEY))
+    - pattern: $LOGGER.$METHOD($A, os.getenv($KEY))
 note: Secrets and local access settings must not be printed into CI, runtime, or support logs.
-

--- a/ast-grep/rules/no-env-value-logging-ts.yml
+++ b/ast-grep/rules/no-env-value-logging-ts.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-env-value-logging-ts
+message: Do not log environment values or frontend runtime env values.
+severity: error
+language: TypeScript
+rule:
+  any:
+    - pattern: console.$METHOD(process.env.$KEY)
+    - pattern: console.$METHOD(import.meta.env.$KEY)
+    - pattern: logger.$METHOD(process.env.$KEY)
+    - pattern: logger.$METHOD(import.meta.env.$KEY)
+note: Secrets and runtime configuration must not be printed into browser, CI, or server logs.
+

--- a/ast-grep/rules/no-env-value-logging-ts.yml
+++ b/ast-grep/rules/no-env-value-logging-ts.yml
@@ -10,5 +10,12 @@ rule:
     - pattern: console.$METHOD(import.meta.env.$KEY)
     - pattern: logger.$METHOD(process.env.$KEY)
     - pattern: logger.$METHOD(import.meta.env.$KEY)
+    - pattern: console.$METHOD($A, process.env.$KEY)
+    - pattern: console.$METHOD($A, import.meta.env.$KEY)
+    - pattern: logger.$METHOD($A, process.env.$KEY)
+    - pattern: logger.$METHOD($A, import.meta.env.$KEY)
+    - pattern: console.$METHOD($A, $B, process.env.$KEY)
+    - pattern: console.$METHOD($A, $B, import.meta.env.$KEY)
+    - pattern: logger.$METHOD($A, $B, process.env.$KEY)
+    - pattern: logger.$METHOD($A, $B, import.meta.env.$KEY)
 note: Secrets and runtime configuration must not be printed into browser, CI, or server logs.
-

--- a/ast-grep/rules/no-frontend-service-role-env.yml
+++ b/ast-grep/rules/no-frontend-service-role-env.yml
@@ -11,8 +11,13 @@ rule:
   any:
     - pattern: import.meta.env.$KEY
     - pattern: process.env.$KEY
+    - pattern: import.meta.env[$KEY]
+    - pattern: process.env[$KEY]
+    - pattern: const { $KEY } = import.meta.env
+    - pattern: const { $KEY } = process.env
+    - pattern: const { $$$, $KEY, $$$ } = import.meta.env
+    - pattern: const { $$$, $KEY, $$$ } = process.env
 constraints:
   KEY:
-    regex: "(SERVICE_ROLE|SERVICE_KEY|PRIVATE_KEY|DATABASE_URL|JWT_SECRET|SUPABASE_SERVICE_ROLE_KEY)"
+    regex: "(?i)(SERVICE_ROLE|SERVICE_KEY|PRIVATE_KEY|DATABASE_URL|JWT_SECRET|SUPABASE_SERVICE_ROLE_KEY)"
 note: Browser code may use public VITE_* anon keys only; service-role and private credentials belong behind API/server boundaries.
-

--- a/ast-grep/rules/no-frontend-service-role-env.yml
+++ b/ast-grep/rules/no-frontend-service-role-env.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-frontend-service-role-env
+message: Do not reference privileged service-role or private env values from frontend code.
+severity: error
+language: TypeScript
+files:
+  - "frontend/**/*.ts"
+  - "frontend/**/*.tsx"
+rule:
+  any:
+    - pattern: import.meta.env.$KEY
+    - pattern: process.env.$KEY
+constraints:
+  KEY:
+    regex: "(SERVICE_ROLE|SERVICE_KEY|PRIVATE_KEY|DATABASE_URL|JWT_SECRET|SUPABASE_SERVICE_ROLE_KEY)"
+note: Browser code may use public VITE_* anon keys only; service-role and private credentials belong behind API/server boundaries.
+

--- a/ast-grep/rules/no-http-mutation-in-readonly-e2e.yml
+++ b/ast-grep/rules/no-http-mutation-in-readonly-e2e.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-http-mutation-in-readonly-e2e
+message: Read-only E2E tests must not perform direct mutating HTTP requests.
+severity: error
+language: TypeScript
+files:
+  - "frontend/e2e/*readonly*.spec.ts"
+rule:
+  any:
+    - pattern: await $REQUEST.post($$$ARGS)
+    - pattern: await $REQUEST.put($$$ARGS)
+    - pattern: await $REQUEST.patch($$$ARGS)
+    - pattern: await $REQUEST.delete($$$ARGS)
+note: Production-read CI must stay read-only. Move signup, password reset, uploads, downloads, and API mutations to local/controlled suites.
+

--- a/ast-grep/rules/no-mutating-submit-in-readonly-e2e.yml
+++ b/ast-grep/rules/no-mutating-submit-in-readonly-e2e.yml
@@ -12,6 +12,5 @@ rule:
     - pattern: 'await $PAGE.getByText($NAME).click($$$ARGS)'
 constraints:
   NAME:
-    regex: "(Sign Up|Reset Password|Upload|Submit|Save|Request download|Request access|Start processing)"
+    regex: "(?i)(Sign Up|Reset Password|Upload|Submit|Save|Request download|Request access|Start processing)"
 note: It is fine for read-only tests to inspect forms or verify signed-out redirects; actual write submissions belong in local/controlled E2E.
-

--- a/ast-grep/rules/no-mutating-submit-in-readonly-e2e.yml
+++ b/ast-grep/rules/no-mutating-submit-in-readonly-e2e.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-mutating-submit-in-readonly-e2e
+message: Read-only E2E tests must not click controls that submit or start write flows.
+severity: error
+language: TypeScript
+files:
+  - "frontend/e2e/*readonly*.spec.ts"
+rule:
+  any:
+    - pattern: 'await $PAGE.getByRole($ROLE, { name: $NAME }).click($$$ARGS)'
+    - pattern: 'await $PAGE.getByText($NAME).click($$$ARGS)'
+constraints:
+  NAME:
+    regex: "(Sign Up|Reset Password|Upload|Submit|Save|Request download|Request access|Start processing)"
+note: It is fine for read-only tests to inspect forms or verify signed-out redirects; actual write submissions belong in local/controlled E2E.
+

--- a/docs/agents/local-review-instructions.md
+++ b/docs/agents/local-review-instructions.md
@@ -32,6 +32,9 @@ Prioritize:
 - Frontend UX regressions that affect real workflows, including broken responsive
   layouts, inaccessible controls, confusing states, missing loading/error states,
   or text/layout overlap.
+- Repo-specific guardrail violations caught by `scripts/lint-ast-grep.sh`,
+  especially read-only CI tests that start write flows, secret/env logging, or
+  broad browser dumps that make automated reviews noisy.
 
 Avoid:
 
@@ -84,6 +87,8 @@ When the user asks Codex to run the local review and improve the worktree:
 3. Fix only high-signal findings that are in scope for the branch.
 4. Preserve user changes and avoid unrelated refactors.
 5. Run the smallest relevant validation set.
+   Include `scripts/lint-ast-grep.sh` when the branch touches frontend, Python,
+   scripts, E2E tests, environment handling, or browser automation.
 6. Summarize what changed, what was validated, and what remains deferred.
 
 Do not commit, push, open a PR, mutate production, or perform production database

--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -53,6 +53,7 @@ source venv/bin/activate
 deadtrees dev test api
 deadtrees dev test processor
 scripts/lint-python.sh
+scripts/lint-ast-grep.sh
 scripts/test-api-smoke.sh
 npm --prefix frontend test
 npm --prefix frontend run lint
@@ -65,6 +66,11 @@ Use `scripts/lint-python.sh` for the fast Python critical-runtime lint gate; it
 is deliberately narrower than full Ruff cleanup and currently checks syntax,
 invalid control flow, and undefined names across API, shared, processor, CLI,
 and Python scripts.
+Use `scripts/lint-ast-grep.sh` after general code changes that touch frontend,
+Python, scripts, or tests. It enforces DeadTrees-specific guardrails that generic
+linters do not know: read-only E2E tests stay read-only, frontend code does not
+reach for privileged service-role env values, environment values are not logged,
+and browser checks avoid broad DOM/text dumps.
 Use `scripts/test-api-smoke.sh` for API, shared, Supabase migration, RLS/RPC, or
 backend storage/download changes that need the same backend-lite coverage as CI.
 For targeted follow-up after the test stack is already running, direct

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -55,6 +55,7 @@ rename while behavior is unchanged, the test is probably too coupled.
 | ---------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | Frontend utility       | `npm --prefix frontend test`                                            | pure data, validation, analytics, routing helpers                                   |
 | Frontend static        | `npm --prefix frontend run lint` and `npm --prefix frontend run build`  | TypeScript, lint, React hook, import, and production-build correctness              |
+| Repo guardrails        | `scripts/lint-ast-grep.sh`                                             | DeadTrees-specific AST rules for read-only CI safety, secret logging, and browser-test hygiene |
 | Frontend browser       | `npm --prefix frontend run test:e2e` or the browser regression playbook | user-facing routes, maps, auth shell, archive/detail/release flows                  |
 | Contributor local E2E  | `npm --prefix frontend run test:e2e:local`                              | authenticated upload shell, metadata submission contract, process request contract  |
 | Contributor write E2E  | `npm --prefix frontend run test:e2e:local:write`                        | local-only signup, password reset, upload start, download request side effects      |
@@ -80,6 +81,10 @@ Frontend build and lint are required frontend gates. Treat failures in
 `npm --prefix frontend run lint` or `npm --prefix frontend run build` as
 blocking for frontend changes unless the failure is clearly unrelated and
 documented.
+Run `scripts/lint-ast-grep.sh` after broad implementation changes and before PRs
+that touch frontend, Python, scripts, or tests. Add new ast-grep rules only for
+repo-specific mistakes that are cheap to detect and expensive to review manually;
+do not use ast-grep for subjective style preferences.
 
 `scripts/lint-python.sh` is intentionally a critical-runtime Ruff gate, not a
 full style gate. It checks `E9,F63,F7,F82` across Python surfaces so CI catches

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -99,3 +99,6 @@ for production-connected smoke checks.
 `npm --prefix frontend run build` and `npm --prefix frontend run lint` are
 required frontend checks. Treat failures as blocking for frontend changes unless
 the failure is clearly unrelated and documented.
+Run `scripts/lint-ast-grep.sh` from the repo root after frontend changes that
+touch E2E tests, environment usage, browser-debug code, or production-connected
+flows. The ast-grep rules are repo-specific guardrails, not formatting rules.

--- a/scripts/lint-ast-grep.sh
+++ b/scripts/lint-ast-grep.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AST_GREP_VERSION="${AST_GREP_VERSION:-0.42.2}"
+
+exec npx --yes --package "@ast-grep/cli@${AST_GREP_VERSION}" sg scan --config sgconfig.yml --report-style short "$@"
+

--- a/scripts/test-ast-grep-rules.sh
+++ b/scripts/test-ast-grep-rules.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AST_GREP_VERSION="${AST_GREP_VERSION:-0.42.2}"
+
+exec npx --yes --package "@ast-grep/cli@${AST_GREP_VERSION}" sg test --skip-snapshot-tests "$@"
+

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,5 @@
+ruleDirs:
+  - ast-grep/rules
+testConfigs:
+  - testDir: ast-grep/rule-tests
+


### PR DESCRIPTION
## Summary
- add repo-specific ast-grep guardrails for read-only E2E safety, secret/env logging, frontend credential boundaries, and browser-test hygiene
- add rule tests plus wrapper scripts for local and CI usage
- add an `ast-grep` PR workflow and update agent docs so future agents run the guardrail linter after relevant code changes

## Why
Generic ESLint/Ruff checks do not know DeadTrees-specific constraints, especially that production-read E2E tests must stay read-only and browser diagnostics should stay scoped. This adds a small, fast guardrail layer for mistakes that are cheap to detect and expensive to catch in review.

## Validation
- `scripts/test-ast-grep-rules.sh`
- `scripts/lint-ast-grep.sh --format github`
- `bash -n scripts/lint-ast-grep.sh scripts/test-ast-grep-rules.sh`
- workflow YAML parse via Ruby
- `git diff --check`

## Risk
Low. This adds a new PR check on relevant frontend/Python/script/test paths; if a rule is too strict, the failure should point to one explicit repo-specific guardrail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new path-filtered PR workflow and local scripts that may initially fail PRs if the new AST rules are too strict, but it doesn’t change runtime application behavior.
> 
> **Overview**
> Adds an `ast-grep` GitHub Actions workflow that runs on relevant TS/Python/script changes and executes both `sg test` (rule tests) and `sg scan` (lint) via new wrapper scripts.
> 
> Introduces repo-specific `ast-grep` rules (with YAML test cases) to block **read-only E2E** mutations (HTTP verbs and “submit/save/upload” clicks), prevent logging/printing env values, forbid privileged env access from frontend code, and discourage broad browser DOM/text dumps.
> 
> Updates agent/testing docs to require running `scripts/lint-ast-grep.sh` for changes touching frontend/Python/scripts/tests and to frame these as guardrails rather than style rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b87b534fad1cd1871105ff6ea4d02d4b1ef2061. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code validation rules to enforce secure environment variable handling, frontend authorization boundaries, and E2E test integrity.

* **Tests**
  * Added test configurations for new validation rules.

* **Chores**
  * Integrated automated code linting into CI/CD pipeline.
  * Updated documentation with new repository guardrails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->