### PR TITLE
fix(processing): refresh status timestamps on updates

### DIFF
--- a/shared/status.py
+++ b/shared/status.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Optional
 from .models import StatusEnum
 from .db import use_client
@@ -73,6 +74,7 @@ def update_status(
 			update_data['error_message'] = error_message
 
 		if update_data:
+			update_data['updated_at'] = datetime.now(timezone.utc).isoformat()
 			with use_client(token) as client:
 				# First check if status exists
 				result = client.table(settings.statuses_table).select('id').eq('dataset_id', dataset_id).execute()

--- a/shared/tests/test_status.py
+++ b/shared/tests/test_status.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+from shared.models import StatusEnum
+from shared.status import update_status
+
+
+def test_update_status_refreshes_updated_at(monkeypatch):
+	updates = []
+	inserts = []
+
+	class _ExecuteResult:
+		data = [{'id': 1}]
+
+	class _EqQuery:
+		def __init__(self, payload=None):
+			self.payload = payload
+
+		def eq(self, field, value):
+			assert field == 'dataset_id'
+			assert value == 123
+			return self
+
+		def execute(self):
+			return _ExecuteResult()
+
+	class _Table:
+		def select(self, fields):
+			assert fields == 'id'
+			return _EqQuery()
+
+		def update(self, payload):
+			updates.append(payload)
+			return _EqQuery(payload)
+
+		def insert(self, payload):
+			inserts.append(payload)
+			return _EqQuery(payload)
+
+	class _Client:
+		def table(self, name):
+			assert name == 'v2_statuses'
+			return _Table()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	monkeypatch.setattr('shared.status.use_client', lambda token: _Client())
+
+	update_status('token', dataset_id=123, current_status=StatusEnum.ortho_processing)
+
+	assert inserts == []
+	assert len(updates) == 1
+	assert updates[0]['current_status'] == StatusEnum.ortho_processing
+	updated_at = datetime.fromisoformat(updates[0]['updated_at'])
+	assert updated_at.tzinfo is not None
+
+
+def test_update_status_sets_updated_at_when_creating_status(monkeypatch):
+	inserts = []
+
+	class _EmptyResult:
+		data = []
+
+	class _EqQuery:
+		def eq(self, field, value):
+			assert field == 'dataset_id'
+			assert value == 123
+			return self
+
+		def execute(self):
+			return _EmptyResult()
+
+	class _InsertQuery:
+		def execute(self):
+			return None
+
+	class _Table:
+		def select(self, fields):
+			assert fields == 'id'
+			return _EqQuery()
+
+		def insert(self, payload):
+			inserts.append(payload)
+			return _InsertQuery()
+
+	class _Client:
+		def table(self, name):
+			assert name == 'v2_statuses'
+			return _Table()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	monkeypatch.setattr('shared.status.use_client', lambda token: _Client())
+
+	update_status('token', dataset_id=123, is_upload_done=True)
+
+	assert len(inserts) == 1
+	assert inserts[0]['dataset_id'] == 123
+	assert inserts[0]['is_upload_done'] is True
+	updated_at = datetime.fromisoformat(inserts[0]['updated_at'])
+	assert updated_at.tzinfo is not None


### PR DESCRIPTION
## Summary
- Refresh `v2_statuses.updated_at` whenever `update_status()` mutates a status row.
- Add focused unit coverage for existing-row updates and first-time status inserts.

## Why
Processor status checks were reporting stale status timestamps even while processing logs and queue movement showed active work. The table has an `updated_at` default, but no production trigger updates it after mutations, so app-side status updates need to advance the timestamp explicitly.

## Validation
- `venv/bin/python -m py_compile shared/status.py shared/tests/test_status.py`
- `docker run --rm -e SUPABASE_URL=http://localhost:54321 -e SUPABASE_KEY=dummy deadtrees-test-processor-test python -m pytest shared/tests/test_status.py -q`

## Risk
Low. This only adds a UTC timestamp to existing status insert/update payloads; no production data was changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a UTC `updated_at` field to status insert/update payloads and introduces isolated unit tests around that behavior.
> 
> **Overview**
> Ensures `update_status()` always bumps `v2_statuses.updated_at` by adding an explicit UTC ISO timestamp whenever any status fields are mutated (both for updating an existing row and inserting the first row).
> 
> Adds focused unit tests that stub the Supabase client to verify `updated_at` is set and timezone-aware for both the update and insert paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7421c755c10352d9830eec815e4641caabe7d14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset status updates now automatically record a timestamp in UTC (ISO 8601 format) whenever a status is modified or newly created, improving audit trails and data visibility.

* **Tests**
  * Added comprehensive test coverage for status update operations, including validation that timestamps are correctly set during both status updates and new status creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->