### PR TITLE
feat(priwa): add project membership and field schema

### DIFF
--- a/api/tests/db/test_priwa_field_schema.py
+++ b/api/tests/db/test_priwa_field_schema.py
@@ -139,8 +139,73 @@ def test_priwa_member_can_create_update_and_soft_delete_kaeferbaum(priwa_project
 			{'deleted_at': datetime.now(timezone.utc).isoformat()}
 		).eq('id', created['id']).execute()
 		active_records = client.table('priwa_kaeferbaeume').select('*').eq('id', created['id']).execute()
+		blocked_update = (
+			client.table('priwa_kaeferbaeume')
+			.update({'fund': 'should-not-change'})
+			.eq('id', created['id'])
+			.execute()
+		)
 
 	assert active_records.data == []
+	assert blocked_update.data == []
+
+	with use_service_client() as client:
+		soft_deleted = (
+			client.table('priwa_kaeferbaeume')
+			.select('deleted_at,deleted_by,fund')
+			.eq('id', created['id'])
+			.single()
+			.execute()
+		)
+
+	assert soft_deleted.data['deleted_at'] is not None
+	assert soft_deleted.data['deleted_by'] == priwa_project['member_id']
+	assert soft_deleted.data['fund'] == 'kontrolliert'
+
+
+def test_priwa_kaeferbaum_identity_project_and_server_timestamps_are_locked(priwa_project):
+	"""Client writes cannot move a record, replace its id, or forge server timestamps."""
+	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	client_timestamp = '2000-01-01T00:00:00+00:00'
+
+	with use_client(member_token) as client:
+		inserted = client.table('priwa_kaeferbaeume').insert(
+			kaeferbaum_payload(
+				priwa_project['id'],
+				created_at=client_timestamp,
+				updated_at=client_timestamp,
+			)
+		).execute()
+
+	created = inserted.data[0]
+	replacement_id = str(uuid.uuid4())
+	replacement_project_id = str(uuid.uuid4())
+
+	assert not created['created_at'].startswith('2000-01-01')
+	assert not created['updated_at'].startswith('2000-01-01')
+
+	with use_client(member_token) as client:
+		updated = (
+			client.table('priwa_kaeferbaeume')
+			.update(
+				{
+					'id': replacement_id,
+					'project_id': replacement_project_id,
+					'fund': 'kontrolliert',
+				}
+			)
+			.eq('id', created['id'])
+			.execute()
+		)
+
+	assert updated.data[0]['id'] == created['id']
+	assert updated.data[0]['project_id'] == priwa_project['id']
+	assert updated.data[0]['fund'] == 'kontrolliert'
+
+	with use_service_client() as client:
+		replacement_records = client.table('priwa_kaeferbaeume').select('id').eq('id', replacement_id).execute()
+
+	assert replacement_records.data == []
 
 
 def test_priwa_kaeferbaum_requires_baumnr_for_estimated_locations(priwa_project):

--- a/api/tests/db/test_priwa_field_schema.py
+++ b/api/tests/db/test_priwa_field_schema.py
@@ -1,0 +1,175 @@
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+
+from shared.db import login, use_client, use_service_client
+from shared.settings import settings
+
+
+def priwa_point(lon=8.2044, lat=48.4064):
+	return {'type': 'Point', 'coordinates': [lon, lat]}
+
+
+def kaeferbaum_payload(project_id, **overrides):
+	payload = {
+		'project_id': project_id,
+		'geom': priwa_point(),
+		'location_source': 'qr_exact',
+		'baumnr': None,
+		'fund': 'fresh',
+		'baumart': 'Fichte',
+		'bm': 'ja',
+		'bohrloch': 'nein',
+		'harz': 'ja',
+		'nadel': 'braun',
+		'rinde': None,
+		'kv': None,
+		'name': 'Test Observer',
+		'datum': '2026-05-19',
+		'kom': 'Local PRIWA schema smoke',
+		'raw_qr_value': 'https://maps.google.com/?q=48.4064,8.2044',
+	}
+	payload.update(overrides)
+	return payload
+
+
+@pytest.fixture(scope='function')
+def priwa_project(test_user, test_user2):
+	project_id = str(uuid.uuid4())
+	slug = f'test-priwa-{project_id}'
+
+	with use_service_client() as client:
+		client.table('priwa_projects').insert(
+			{
+				'id': project_id,
+				'slug': slug,
+				'name': 'Test PRIWA Project',
+			}
+		).execute()
+		client.table('priwa_project_memberships').insert(
+			{
+				'project_id': project_id,
+				'user_id': test_user,
+				'role': 'field_user',
+			}
+		).execute()
+
+	try:
+		yield {'id': project_id, 'slug': slug, 'member_id': test_user, 'non_member_id': test_user2}
+	finally:
+		with use_service_client() as client:
+			client.table('priwa_kaeferbaeume').delete().eq('project_id', project_id).execute()
+			client.table('priwa_project_memberships').delete().eq('project_id', project_id).execute()
+			client.table('priwa_projects').delete().eq('id', project_id).execute()
+
+
+def test_priwa_membership_gates_projects_and_kaeferbaeume(priwa_project, test_user):
+	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	non_member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+	kaeferbaum_id = str(uuid.uuid4())
+
+	with use_service_client() as client:
+		client.table('priwa_kaeferbaeume').insert(
+			kaeferbaum_payload(
+				priwa_project['id'],
+				id=kaeferbaum_id,
+				created_by=test_user,
+				updated_by=test_user,
+			)
+		).execute()
+
+	with use_client(member_token) as client:
+		projects = client.table('priwa_projects').select('*').eq('id', priwa_project['id']).execute()
+		memberships = (
+			client.table('priwa_project_memberships').select('*').eq('project_id', priwa_project['id']).execute()
+		)
+		records = client.table('priwa_kaeferbaeume').select('*').eq('id', kaeferbaum_id).execute()
+
+	assert len(projects.data) == 1
+	assert len(memberships.data) == 1
+	assert len(records.data) == 1
+	assert records.data[0]['is_exact_location'] is True
+
+	with use_client(non_member_token) as client:
+		projects = client.table('priwa_projects').select('*').eq('id', priwa_project['id']).execute()
+		memberships = (
+			client.table('priwa_project_memberships').select('*').eq('project_id', priwa_project['id']).execute()
+		)
+		records = client.table('priwa_kaeferbaeume').select('*').eq('id', kaeferbaum_id).execute()
+
+	assert projects.data == []
+	assert memberships.data == []
+	assert records.data == []
+
+
+def test_priwa_member_can_create_update_and_soft_delete_kaeferbaum(priwa_project):
+	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+
+	with use_client(member_token) as client:
+		inserted = client.table('priwa_kaeferbaeume').insert(
+			kaeferbaum_payload(priwa_project['id'])
+		).execute()
+
+	created = inserted.data[0]
+	assert created['created_by'] == priwa_project['member_id']
+	assert created['updated_by'] == priwa_project['member_id']
+
+	with use_client(member_token) as client:
+		updated = (
+			client.table('priwa_kaeferbaeume')
+			.update({'baumnr': 'KB-001', 'fund': 'kontrolliert'})
+			.eq('id', created['id'])
+			.execute()
+		)
+
+	assert updated.data[0]['baumnr'] == 'KB-001'
+	assert updated.data[0]['updated_by'] == priwa_project['member_id']
+
+	with use_client(member_token) as client:
+		with pytest.raises(Exception):
+			client.table('priwa_kaeferbaeume').delete().eq('id', created['id']).execute()
+
+		client.table('priwa_kaeferbaeume').update(
+			{'deleted_at': datetime.now(timezone.utc).isoformat()}
+		).eq('id', created['id']).execute()
+		active_records = client.table('priwa_kaeferbaeume').select('*').eq('id', created['id']).execute()
+
+	assert active_records.data == []
+
+
+def test_priwa_kaeferbaum_requires_baumnr_for_estimated_locations(priwa_project):
+	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+
+	with use_client(member_token) as client:
+		with pytest.raises(Exception):
+			client.table('priwa_kaeferbaeume').insert(
+				kaeferbaum_payload(
+					priwa_project['id'],
+					location_source='gps_estimated',
+					baumnr=None,
+					raw_qr_value=None,
+				)
+			).execute()
+
+		inserted = client.table('priwa_kaeferbaeume').insert(
+			kaeferbaum_payload(
+				priwa_project['id'],
+				location_source='map_estimated',
+				baumnr='KB-002',
+				raw_qr_value=None,
+			)
+		).execute()
+
+	assert inserted.data[0]['baumnr'] == 'KB-002'
+	assert inserted.data[0]['is_exact_location'] is False
+
+
+def test_priwa_non_member_cannot_write_kaeferbaum(priwa_project):
+	non_member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_client(non_member_token) as client:
+		with pytest.raises(Exception):
+			client.table('priwa_kaeferbaeume').insert(
+				kaeferbaum_payload(priwa_project['id'])
+			).execute()

--- a/api/tests/db/test_priwa_field_schema.py
+++ b/api/tests/db/test_priwa_field_schema.py
@@ -8,10 +8,12 @@ from shared.settings import settings
 
 
 def priwa_point(lon=8.2044, lat=48.4064):
+	"""Return a GeoJSON point near the PRIWA Renchtal field area."""
 	return {'type': 'Point', 'coordinates': [lon, lat]}
 
 
 def kaeferbaum_payload(project_id, **overrides):
+	"""Build a valid default Käferbaum payload with optional field overrides."""
 	payload = {
 		'project_id': project_id,
 		'geom': priwa_point(),
@@ -36,6 +38,7 @@ def kaeferbaum_payload(project_id, **overrides):
 
 @pytest.fixture(scope='function')
 def priwa_project(test_user, test_user2):
+	"""Create an isolated PRIWA project with one member and one non-member."""
 	project_id = str(uuid.uuid4())
 	slug = f'test-priwa-{project_id}'
 
@@ -65,6 +68,7 @@ def priwa_project(test_user, test_user2):
 
 
 def test_priwa_membership_gates_projects_and_kaeferbaeume(priwa_project, test_user):
+	"""Members can read project records while non-members see no PRIWA data."""
 	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
 	non_member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
 	kaeferbaum_id = str(uuid.uuid4())
@@ -104,6 +108,7 @@ def test_priwa_membership_gates_projects_and_kaeferbaeume(priwa_project, test_us
 
 
 def test_priwa_member_can_create_update_and_soft_delete_kaeferbaum(priwa_project):
+	"""Members can write current-state records and soft-delete them only by update."""
 	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
 
 	with use_client(member_token) as client:
@@ -139,6 +144,7 @@ def test_priwa_member_can_create_update_and_soft_delete_kaeferbaum(priwa_project
 
 
 def test_priwa_kaeferbaum_requires_baumnr_for_estimated_locations(priwa_project):
+	"""Estimated GPS or map locations require a tree number for later matching."""
 	member_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
 
 	with use_client(member_token) as client:
@@ -166,6 +172,7 @@ def test_priwa_kaeferbaum_requires_baumnr_for_estimated_locations(priwa_project)
 
 
 def test_priwa_non_member_cannot_write_kaeferbaum(priwa_project):
+	"""Non-members cannot create Käferbaum records in a PRIWA project."""
 	non_member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
 
 	with use_client(non_member_token) as client:

--- a/supabase/migrations/20260519090000_add_priwa_field_schema.sql
+++ b/supabase/migrations/20260519090000_add_priwa_field_schema.sql
@@ -126,11 +126,13 @@ begin
             end if;
         end if;
 
-        NEW.created_at = coalesce(NEW.created_at, now());
-        NEW.updated_at = coalesce(NEW.updated_at, NEW.created_at, now());
+        NEW.created_at = now();
+        NEW.updated_at = NEW.created_at;
         return NEW;
     end if;
 
+    NEW.id = OLD.id;
+    NEW.project_id = OLD.project_id;
     NEW.created_at = OLD.created_at;
     NEW.created_by = OLD.created_by;
     NEW.updated_at = now();
@@ -203,7 +205,10 @@ on "public"."priwa_kaeferbaeume"
 as permissive
 for update
 to authenticated
-using (public.priwa_is_project_member(project_id))
+using (
+    deleted_at is null
+    and public.priwa_is_project_member(project_id)
+)
 with check (
     public.priwa_is_project_member(project_id)
     and updated_by = (select auth.uid())

--- a/supabase/migrations/20260519090000_add_priwa_field_schema.sql
+++ b/supabase/migrations/20260519090000_add_priwa_field_schema.sql
@@ -1,0 +1,214 @@
+create type "public"."priwa_project_role" as enum ('field_user', 'coordinator', 'admin');
+
+create type "public"."priwa_location_source" as enum ('qr_exact', 'gps_estimated', 'map_estimated');
+
+create table "public"."priwa_projects" (
+    "id" uuid not null default gen_random_uuid(),
+    "slug" text not null,
+    "name" text not null,
+    "created_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."priwa_projects" enable row level security;
+
+create table "public"."priwa_project_memberships" (
+    "project_id" uuid not null,
+    "user_id" uuid not null,
+    "role" priwa_project_role not null default 'field_user',
+    "created_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."priwa_project_memberships" enable row level security;
+
+create table "public"."priwa_kaeferbaeume" (
+    "id" uuid not null default gen_random_uuid(),
+    "project_id" uuid not null,
+    "geom" geometry(Point, 4326) not null,
+    "location_source" priwa_location_source not null,
+    "is_exact_location" boolean generated always as (location_source = 'qr_exact'::priwa_location_source) stored,
+    "baumnr" text,
+    "fund" text not null,
+    "baumart" text not null,
+    "bm" text not null,
+    "bohrloch" text not null,
+    "harz" text not null,
+    "nadel" text not null,
+    "rinde" text,
+    "kv" text,
+    "name" text not null,
+    "datum" date not null,
+    "kom" text,
+    "raw_qr_value" text,
+    "created_by" uuid not null,
+    "updated_by" uuid not null,
+    "deleted_by" uuid,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now(),
+    "deleted_at" timestamp with time zone,
+    "client_updated_at" timestamp with time zone
+);
+
+alter table "public"."priwa_kaeferbaeume" enable row level security;
+
+CREATE UNIQUE INDEX priwa_projects_pkey ON public.priwa_projects USING btree (id);
+CREATE UNIQUE INDEX priwa_projects_slug_key ON public.priwa_projects USING btree (slug);
+CREATE UNIQUE INDEX priwa_project_memberships_pkey ON public.priwa_project_memberships USING btree (project_id, user_id);
+CREATE INDEX priwa_project_memberships_user_idx ON public.priwa_project_memberships USING btree (user_id, project_id);
+CREATE UNIQUE INDEX priwa_kaeferbaeume_pkey ON public.priwa_kaeferbaeume USING btree (id);
+CREATE INDEX priwa_kaeferbaeume_geom_idx ON public.priwa_kaeferbaeume USING gist (geom);
+CREATE INDEX priwa_kaeferbaeume_project_idx ON public.priwa_kaeferbaeume USING btree (project_id);
+CREATE INDEX priwa_kaeferbaeume_baumnr_idx ON public.priwa_kaeferbaeume USING btree (baumnr);
+CREATE INDEX priwa_kaeferbaeume_active_project_idx ON public.priwa_kaeferbaeume USING btree (project_id, updated_at desc) WHERE deleted_at is null;
+
+alter table "public"."priwa_projects" add constraint "priwa_projects_pkey" PRIMARY KEY using index "priwa_projects_pkey";
+alter table "public"."priwa_projects" add constraint "priwa_projects_slug_key" UNIQUE using index "priwa_projects_slug_key";
+alter table "public"."priwa_project_memberships" add constraint "priwa_project_memberships_pkey" PRIMARY KEY using index "priwa_project_memberships_pkey";
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_pkey" PRIMARY KEY using index "priwa_kaeferbaeume_pkey";
+
+alter table "public"."priwa_project_memberships" add constraint "priwa_project_memberships_project_id_fkey" FOREIGN KEY (project_id) REFERENCES priwa_projects(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."priwa_project_memberships" validate constraint "priwa_project_memberships_project_id_fkey";
+
+alter table "public"."priwa_project_memberships" add constraint "priwa_project_memberships_user_id_fkey" FOREIGN KEY (user_id) REFERENCES auth.users(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."priwa_project_memberships" validate constraint "priwa_project_memberships_user_id_fkey";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_project_id_fkey" FOREIGN KEY (project_id) REFERENCES priwa_projects(id) ON UPDATE CASCADE not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_project_id_fkey";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_created_by_fkey" FOREIGN KEY (created_by) REFERENCES auth.users(id) ON UPDATE CASCADE not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_created_by_fkey";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_updated_by_fkey" FOREIGN KEY (updated_by) REFERENCES auth.users(id) ON UPDATE CASCADE not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_updated_by_fkey";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_deleted_by_fkey" FOREIGN KEY (deleted_by) REFERENCES auth.users(id) ON UPDATE CASCADE not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_deleted_by_fkey";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_baumnr_required_for_estimated_location" CHECK (
+    location_source = 'qr_exact'::priwa_location_source
+    or nullif(btrim(baumnr), '') is not null
+) not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_baumnr_required_for_estimated_location";
+
+alter table "public"."priwa_kaeferbaeume" add constraint "priwa_kaeferbaeume_soft_delete_actor_check" CHECK (
+    (deleted_at is null and deleted_by is null)
+    or (deleted_at is not null and deleted_by is not null)
+) not valid;
+alter table "public"."priwa_kaeferbaeume" validate constraint "priwa_kaeferbaeume_soft_delete_actor_check";
+
+create or replace function public.priwa_is_project_member(p_project_id uuid)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+    select exists (
+        select 1
+        from public.priwa_project_memberships membership
+        where membership.project_id = p_project_id
+          and membership.user_id = (select auth.uid())
+    );
+$$;
+
+create or replace function public.priwa_set_kaeferbaum_actor_fields()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+    current_actor uuid := (select auth.uid());
+begin
+    if TG_OP = 'INSERT' then
+        if current_actor is not null then
+            NEW.created_by = coalesce(NEW.created_by, current_actor);
+            NEW.updated_by = coalesce(NEW.updated_by, current_actor);
+            if NEW.deleted_at is not null then
+                NEW.deleted_by = coalesce(NEW.deleted_by, current_actor);
+            end if;
+        end if;
+
+        NEW.created_at = coalesce(NEW.created_at, now());
+        NEW.updated_at = coalesce(NEW.updated_at, NEW.created_at, now());
+        return NEW;
+    end if;
+
+    NEW.created_at = OLD.created_at;
+    NEW.created_by = OLD.created_by;
+    NEW.updated_at = now();
+
+    if current_actor is not null then
+        NEW.updated_by = current_actor;
+        if OLD.deleted_at is null and NEW.deleted_at is not null then
+            NEW.deleted_by = coalesce(NEW.deleted_by, current_actor);
+        end if;
+    end if;
+
+    return NEW;
+end;
+$$;
+
+CREATE TRIGGER priwa_kaeferbaeume_set_actor_fields
+BEFORE INSERT OR UPDATE ON public.priwa_kaeferbaeume
+FOR EACH ROW EXECUTE FUNCTION public.priwa_set_kaeferbaum_actor_fields();
+
+grant select on table "public"."priwa_projects" to "authenticated";
+grant select on table "public"."priwa_project_memberships" to "authenticated";
+grant select, insert, update on table "public"."priwa_kaeferbaeume" to "authenticated";
+grant all on table "public"."priwa_projects" to "service_role";
+grant all on table "public"."priwa_project_memberships" to "service_role";
+grant all on table "public"."priwa_kaeferbaeume" to "service_role";
+revoke all on function public.priwa_is_project_member(uuid) from public;
+revoke all on function public.priwa_set_kaeferbaum_actor_fields() from public;
+grant execute on function public.priwa_is_project_member(uuid) to "authenticated";
+grant execute on function public.priwa_is_project_member(uuid) to "service_role";
+
+create policy "PRIWA members can read their projects"
+on "public"."priwa_projects"
+as permissive
+for select
+to authenticated
+using (public.priwa_is_project_member(id));
+
+create policy "PRIWA users can read own memberships"
+on "public"."priwa_project_memberships"
+as permissive
+for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+create policy "PRIWA members can read active kaeferbaeume"
+on "public"."priwa_kaeferbaeume"
+as permissive
+for select
+to authenticated
+using (
+    deleted_at is null
+    and public.priwa_is_project_member(project_id)
+);
+
+create policy "PRIWA members can create kaeferbaeume"
+on "public"."priwa_kaeferbaeume"
+as permissive
+for insert
+to authenticated
+with check (
+    public.priwa_is_project_member(project_id)
+    and created_by = (select auth.uid())
+    and updated_by = (select auth.uid())
+    and deleted_at is null
+    and deleted_by is null
+);
+
+create policy "PRIWA members can update kaeferbaeume"
+on "public"."priwa_kaeferbaeume"
+as permissive
+for update
+to authenticated
+using (public.priwa_is_project_member(project_id))
+with check (
+    public.priwa_is_project_member(project_id)
+    and updated_by = (select auth.uid())
+    and (
+        (deleted_at is null and deleted_by is null)
+        or (deleted_at is not null and deleted_by = (select auth.uid()))
+    )
+);


### PR DESCRIPTION
## Summary

Adds the first production schema foundation for PRIWA field work:

- `priwa_projects` and `priwa_project_memberships` for project-scoped access
- `priwa_kaeferbaeume` as the current-state Käferbaum record table
- RLS policies so only project members can read/write records for their project
- required point geometry and `location_source` values for QR/GPS/map placement
- `baumnr` required when the location is estimated rather than QR-exact
- soft-delete fields and actor/timestamp stamping on Käferbaum rows

This intentionally does not include online UI persistence, offline sync, dataset assignment, history tables, or an audit/event table.

## Validation

- `python3 -m py_compile api/tests/db/test_priwa_field_schema.py`
- `scripts/lint-python.sh`
- `scripts/lint-ast-grep.sh`

Blocked locally:

- `supabase status`
- `venv/bin/deadtrees dev test api api/tests/db/test_priwa_field_schema.py`

Both are blocked because the local Docker daemon is not reachable: `Cannot connect to the Docker daemon at unix:///Users/januschvajna-jehle/.docker/run/docker.sock`.

## Risk / limitations

- Membership rows are DB-managed for now.
- Soft-deleted rows are hidden from member reads; recovery remains a DB/service-role operation in this PR.
- Offline sync and online UI persistence are intentionally deferred to follow-up PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Postgres types/tables plus RLS policies and trigger-based actor stamping, which can affect data access and write behavior for authenticated users if misconfigured. Test coverage helps, but schema/RLS changes are inherently higher impact than app-only changes.
> 
> **Overview**
> Adds a new PRIWA Postgres schema via migration: `priwa_projects`, `priwa_project_memberships`, and `priwa_kaeferbaeume` (with required point geometry, `location_source` enum, and a generated `is_exact_location`).
> 
> Enforces data rules and access control with RLS policies (members-only reads/writes), check constraints (e.g., `baumnr` required for estimated locations), and a trigger to stamp `created_by`/`updated_by`/`deleted_by` and timestamps; hard deletes are effectively disallowed in favor of soft delete.
> 
> Adds integration-style DB tests validating membership gating, create/update flow, soft-delete visibility, and the `baumnr` constraint for estimated locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31823ff4c779c7ed3871d1078f064cb06c3c233. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced PRIWA project management system supporting project creation and member-based collaboration
  * Added geospatial field recording with location precision indicators and complete change history
  * Implemented role-based access controls to manage project membership and data permissions

* **Tests**
  * Added integration tests validating project access controls, membership gating, and field data operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->