### PR TITLE
feat(priwa): add online field page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "canvas-confetti": "^1.9.4",
         "geotiff": "^2.1.3",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
+        "jsqr": "^1.4.0",
         "kompas": "^1.0.0",
         "localforage": "^1.10.0",
         "lodash": "^4.18.1",
@@ -8210,6 +8211,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsts": {
       "version": "2.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "canvas-confetti": "^1.9.4",
     "geotiff": "^2.1.3",
     "geotiff-geokeys-to-proj4": "^2024.4.13",
+    "jsqr": "^1.4.0",
     "kompas": "^1.0.0",
     "localforage": "^1.10.0",
     "lodash": "^4.18.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import DatasetReferencePatchEditor from "./pages/DatasetReferencePatchEditor";
 import DatasetLabelEditor from "./pages/DatasetLabelEditor";
 import DatasetCorrections from "./pages/DatasetCorrections";
 import Deadtrees from "./pages/Deadtrees";
+import PriwaField from "./pages/PriwaField";
 import Releases from "./pages/Releases";
 import ReleaseDetail from "./pages/ReleaseDetail";
 import SignUp from "./pages/auth/SignUp";
@@ -41,6 +42,7 @@ function LayoutWrapper() {
   const fullHeightPaths = [
     "/dataset",
     "/deadtrees",
+    "/priwa-field",
     "/dataset-audit",
     "/dataset-label",
     "/dataset-corrections",
@@ -144,6 +146,14 @@ function AppWithTracking() {
             element={<DatasetCorrections />}
           />
           <Route path="deadtrees" element={<Deadtrees />} />
+          <Route
+            path="priwa-field"
+            element={
+              <RequireAuth>
+                <PriwaField />
+              </RequireAuth>
+            }
+          />
           <Route path="releases" element={<Releases />} />
           <Route path="releases/:slug" element={<ReleaseDetail />} />
           <Route path="about" element={<About />} />

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "react-router-dom";
 const { Header } = Layout;
 
 import { useAuth } from "../hooks/useAuthProvider";
+import { usePriwaProjectMemberships } from "../hooks/usePriwaProjectMemberships";
 import { useCanAudit } from "../hooks/useUserPrivileges";
 import { useNavigate } from "react-router-dom";
 import { palette } from "../theme/palette";
@@ -46,6 +47,7 @@ export default function Navigation() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { session, signOut } = useAuth();
   const { canAudit } = useCanAudit();
+  const { data: priwaMemberships = [] } = usePriwaProjectMemberships();
   const nav = useNavigate();
   const location = useLocation();
 
@@ -57,6 +59,12 @@ export default function Navigation() {
 
   // Add audit navigation if user has audit privileges
   const navigation = [...defaultNavigation];
+  if (priwaMemberships.length > 0) {
+    navigation.splice(2, 0, {
+      key: "/priwa-field",
+      label: "PRIWA",
+    });
+  }
   if (canAudit) {
     // Insert the audit link before the Account link
     navigation.splice(navigation.length - 1, 0, auditNavigation);

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,0 +1,411 @@
+import { Alert, Button, Popover, Switch, Tooltip, Typography, message } from "antd";
+import {
+  AimOutlined,
+  EnvironmentOutlined,
+  PlusOutlined,
+  SlidersOutlined,
+} from "@ant-design/icons";
+import "ol/ol.css";
+import { Map } from "ol";
+import { defaults as defaultInteractions } from "ol/interaction";
+import TileLayerWebGL from "ol/layer/WebGLTile.js";
+import { unByKey } from "ol/Observable";
+import { fromLonLat, toLonLat } from "ol/proj";
+import View from "ol/View";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { createStandardMapControls } from "../../utils/basemaps";
+import { useUserLocationLayer } from "../../hooks/useUserLocationLayer";
+import { createLglDop20Layer } from "./createLglDop20Layer";
+import { createPriwaCogLayer } from "./createPriwaCogLayer";
+import {
+  createPriwaPointFeature,
+  createPriwaPointLayer,
+  createPriwaPreviewFeature,
+  createPriwaPreviewLayer,
+} from "./createPriwaPointLayer";
+import PriwaPointDrawer from "./PriwaPointDrawer";
+import type {
+  IPriwaCoordinate,
+  IPriwaPoint,
+  PriwaCoordinateSource,
+} from "./types";
+
+const FIELD_CENTER: [number, number] = [8.18013, 48.45596];
+
+interface PriwaFieldMapProps {
+  points: IPriwaPoint[];
+  isLoadingPoints?: boolean;
+  isSavingPoint?: boolean;
+  projectName: string;
+  cogPath?: string | null;
+  isCogLoading?: boolean;
+  errorMessage?: string | null;
+  onAddPoint: (point: IPriwaPoint) => Promise<void>;
+  onUpdatePoint: (point: IPriwaPoint) => Promise<void>;
+  onDeletePoint: (pointId: string) => Promise<void>;
+}
+
+export default function PriwaFieldMap({
+  points,
+  isLoadingPoints = false,
+  isSavingPoint = false,
+  projectName,
+  cogPath,
+  isCogLoading = false,
+  errorMessage = null,
+  onAddPoint,
+  onUpdatePoint,
+  onDeletePoint,
+}: PriwaFieldMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<Map | null>(null);
+  const isPlacingPointRef = useRef(false);
+  const pointLayerRef = useRef<ReturnType<typeof createPriwaPointLayer> | null>(
+    null,
+  );
+  const previewLayerRef = useRef<ReturnType<
+    typeof createPriwaPreviewLayer
+  > | null>(null);
+  const cogLayerRef = useRef<TileLayerWebGL | null>(null);
+  const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const [isCogVisible, setCogVisible] = useState(true);
+  const [isPlacingPoint, setPlacingPoint] = useState(false);
+  const [selectedCoordinate, setSelectedCoordinate] =
+    useState<IPriwaCoordinate | null>(null);
+  const [selectedCoordinateSource, setSelectedCoordinateSource] =
+    useState<PriwaCoordinateSource>("qr");
+  const [editingPoint, setEditingPoint] = useState<IPriwaPoint | null>(null);
+  const [formSessionId, setFormSessionId] = useState(0);
+  const userLocation = useUserLocationLayer(mapRef);
+  const {
+    layer: userLocationLayer,
+    locateUser,
+    stop: stopUserLocation,
+  } = userLocation;
+
+  useEffect(() => {
+    isPlacingPointRef.current = isPlacingPoint;
+    document.body.classList.toggle("priwa-placement-mode", isPlacingPoint);
+
+    return () => {
+      document.body.classList.remove("priwa-placement-mode");
+    };
+  }, [isPlacingPoint]);
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+
+    const dopLayer = createLglDop20Layer();
+    const pointLayer = createPriwaPointLayer([]);
+    const previewLayer = createPriwaPreviewLayer();
+    pointLayerRef.current = pointLayer;
+    previewLayerRef.current = previewLayer;
+
+    const map = new Map({
+      target: containerRef.current,
+      layers: [dopLayer, pointLayer, previewLayer, userLocationLayer],
+      view: new View({
+        center: fromLonLat(FIELD_CENTER),
+        zoom: 19,
+        minZoom: 8,
+        maxZoom: 21,
+        projection: "EPSG:3857",
+      }),
+      interactions: defaultInteractions({
+        pinchRotate: false,
+        altShiftDragRotate: false,
+      }),
+      controls: createStandardMapControls({
+        includeZoom: false,
+        includeAttribution: true,
+      }),
+    });
+
+    mapRef.current = map;
+    locateUser(false);
+
+    const clickKey = map.on("singleclick", (event) => {
+      if (isPlacingPointRef.current) return;
+
+      const pointFeature = map.forEachFeatureAtPixel(
+        event.pixel,
+        (feature) => {
+          const point = feature.get("point") as IPriwaPoint | undefined;
+          return point ?? null;
+        },
+        {
+          hitTolerance: 18,
+        },
+      );
+
+      if (pointFeature) {
+        setFormSessionId((currentSessionId) => currentSessionId + 1);
+        setEditingPoint(pointFeature);
+        setSelectedCoordinate({ lat: pointFeature.lat, lon: pointFeature.lon });
+        setSelectedCoordinateSource(pointFeature.coordinateSource);
+        setDrawerOpen(true);
+      }
+    });
+
+    return () => {
+      stopUserLocation();
+      unByKey(clickKey);
+      map.setTarget(undefined);
+      mapRef.current = null;
+      pointLayerRef.current = null;
+      previewLayerRef.current = null;
+      cogLayerRef.current = null;
+    };
+  }, [locateUser, stopUserLocation, userLocationLayer]);
+
+  useEffect(() => {
+    const source = pointLayerRef.current?.getSource();
+    if (!source) return;
+
+    source.clear();
+    points.forEach((point) =>
+      source.addFeature(createPriwaPointFeature(point)),
+    );
+  }, [points]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (cogLayerRef.current) {
+      map.removeLayer(cogLayerRef.current);
+      cogLayerRef.current = null;
+    }
+
+    if (!cogPath || !isCogVisible) return;
+
+    const cogLayer = createPriwaCogLayer(cogPath);
+    cogLayerRef.current = cogLayer;
+    map.getLayers().insertAt(1, cogLayer);
+  }, [cogPath, isCogVisible]);
+
+  const handlePreviewCoordinate = useCallback(
+    (coordinate: IPriwaCoordinate | null) => {
+      const source = previewLayerRef.current?.getSource();
+      if (!source) return;
+
+      source.clear();
+      if (coordinate) {
+        source.addFeature(createPriwaPreviewFeature(coordinate));
+      }
+    },
+    [],
+  );
+
+  const zoomToCoordinate = useCallback((coordinate: IPriwaCoordinate) => {
+    mapRef.current?.getView().animate({
+      center: fromLonLat([coordinate.lon, coordinate.lat]),
+      zoom: 20,
+      duration: 500,
+    });
+  }, []);
+
+  const openNewPointDrawer = useCallback(() => {
+    setFormSessionId((currentSessionId) => currentSessionId + 1);
+    setEditingPoint(null);
+    setSelectedCoordinate(null);
+    setSelectedCoordinateSource("qr");
+    setDrawerOpen(true);
+  }, []);
+
+  const requestMapPlacement = useCallback(() => {
+    setDrawerOpen(false);
+    setPlacingPoint(true);
+  }, []);
+
+  const cancelMapPlacement = useCallback(() => {
+    setPlacingPoint(false);
+    setDrawerOpen(true);
+  }, []);
+
+  const acceptMapPlacement = useCallback(() => {
+    const center = mapRef.current?.getView().getCenter();
+    if (!center) return;
+
+    const [lon, lat] = toLonLat(center);
+    setSelectedCoordinate({ lat, lon });
+    setSelectedCoordinateSource("map");
+    setPlacingPoint(false);
+    setDrawerOpen(true);
+  }, []);
+
+  const locationButtonActive =
+    userLocation.isTracking &&
+    userLocation.hasFix &&
+    userLocation.hasZoomedToUser;
+
+  const handleAddPoint = useCallback(
+    async (point: IPriwaPoint) => {
+      await onAddPoint(point);
+      message.success("Käferbaum gespeichert");
+    },
+    [onAddPoint],
+  );
+
+  const handleUpdatePoint = useCallback(
+    async (point: IPriwaPoint) => {
+      await onUpdatePoint(point);
+      message.success("Käferbaum aktualisiert");
+    },
+    [onUpdatePoint],
+  );
+
+  const handleDeletePoint = useCallback(
+    async (pointId: string) => {
+      await onDeletePoint(pointId);
+      message.success("Käferbaum gelöscht");
+      setDrawerOpen(false);
+      setEditingPoint(null);
+    },
+    [onDeletePoint],
+  );
+
+  const layerPanel = (
+    <div className="w-64 space-y-3">
+      <div>
+        <Typography.Text strong>Layer</Typography.Text>
+        <div className="text-xs text-gray-500">
+          PRIWA Punkte bleiben immer sichtbar.
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="text-sm font-medium text-gray-900">
+            Drohnenlayer
+          </div>
+          <div className="text-xs text-gray-500">
+            {isCogLoading
+              ? "Lade Drohnenlayer..."
+              : cogPath
+                ? "Optionaler Overlay"
+                : "Folgt in einem eigenen Schritt"}
+          </div>
+        </div>
+        <Switch
+          checked={isCogVisible}
+          disabled={!cogPath}
+          onChange={setCogVisible}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="relative h-full min-h-[100dvh] w-full overflow-hidden bg-neutral-950">
+      <div ref={containerRef} className="absolute inset-0" />
+
+      {!isPlacingPoint && (
+        <>
+          <div className="pointer-events-none absolute left-4 top-20 z-10 flex flex-col gap-2 md:top-24">
+            <Tooltip title="Aktuelle Position">
+              <Button
+                className="pointer-events-auto shadow-md"
+                type={locationButtonActive ? "primary" : "default"}
+                shape="circle"
+                size="large"
+                icon={
+                  userLocation.isLocating ? (
+                    <AimOutlined spin />
+                  ) : (
+                    <EnvironmentOutlined />
+                  )
+                }
+                onClick={() => userLocation.locateUser(true)}
+                aria-label="Aktuelle Position aktivieren"
+              />
+            </Tooltip>
+            <Popover trigger="click" placement="rightTop" content={layerPanel}>
+              <Button
+                className="pointer-events-auto shadow-md"
+                shape="circle"
+                size="large"
+                icon={<SlidersOutlined />}
+                aria-label="Layer auswählen"
+              />
+            </Popover>
+          </div>
+
+          <div className="pointer-events-none absolute bottom-5 right-5 z-[60]">
+            <Tooltip title="Punkt aufnehmen" placement="left">
+              <Button
+                className="pointer-events-auto shadow-lg"
+                type="primary"
+                shape="circle"
+                size="large"
+                icon={<PlusOutlined />}
+                onClick={openNewPointDrawer}
+                aria-label="Punkt aufnehmen"
+              />
+            </Tooltip>
+          </div>
+        </>
+      )}
+
+      {isPlacingPoint && (
+        <div className="pointer-events-none absolute inset-0 z-[70]">
+          <div className="absolute left-1/2 top-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2">
+            <div className="absolute left-1/2 top-0 h-12 border-l-2 border-white drop-shadow" />
+            <div className="absolute left-0 top-1/2 w-12 border-t-2 border-white drop-shadow" />
+            <div className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-emerald-600 bg-white/80" />
+          </div>
+          <div className="pointer-events-auto absolute bottom-4 left-4 right-4 flex gap-2 rounded-md bg-white/95 p-2 shadow-lg backdrop-blur md:bottom-5">
+            <Button block onClick={cancelMapPlacement}>
+              Abbrechen
+            </Button>
+            <Button block type="primary" onClick={acceptMapPlacement}>
+              Punkt übernehmen
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!isPlacingPoint && (
+        <div className="pointer-events-none absolute right-4 top-20 z-10 rounded-md bg-white/90 px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm backdrop-blur md:top-24">
+          {userLocation.locationError ??
+            `${projectName} · ${
+              isLoadingPoints
+                ? "Lade Punkte"
+                : `${points.length} ${points.length === 1 ? "Punkt" : "Punkte"}`
+            }`}
+          {userLocation.isHeadingActive ? " · Richtung" : ""}
+        </div>
+      )}
+
+      {errorMessage && !isPlacingPoint && (
+        <Alert
+          className="absolute bottom-20 left-4 right-4 z-[55] shadow-lg md:left-auto md:w-96"
+          type="error"
+          showIcon
+          message="PRIWA Daten konnten nicht geladen werden"
+          description={errorMessage}
+        />
+      )}
+
+      <PriwaPointDrawer
+        open={isDrawerOpen}
+        formSessionId={formSessionId}
+        editingPoint={editingPoint}
+        selectedCoordinate={selectedCoordinate}
+        selectedCoordinateSource={selectedCoordinateSource}
+        currentUserCoordinate={userLocation.currentCoordinate}
+        onClose={() => {
+          setDrawerOpen(false);
+          setEditingPoint(null);
+        }}
+        onAddPoint={handleAddPoint}
+        onUpdatePoint={handleUpdatePoint}
+        onDeletePoint={handleDeletePoint}
+        isSaving={isSavingPoint}
+        onRequestMapPlacement={requestMapPlacement}
+        onPreviewCoordinate={handlePreviewCoordinate}
+        onZoomToPoint={zoomToCoordinate}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -112,8 +112,6 @@ interface IPriwaPointFormValues {
   name: PriwaObserverName;
   datum: string;
   kom: string;
-  grueneNadeln?: PriwaYesNo | null;
-  andererSchaden?: boolean;
 }
 
 const createDefaultFormValues = (): IPriwaPointFormValues => ({
@@ -129,8 +127,6 @@ const createDefaultFormValues = (): IPriwaPointFormValues => ({
   name: "andere",
   datum: today(),
   kom: "",
-  grueneNadeln: null,
-  andererSchaden: false,
 });
 
 const createFormValuesFromPoint = (
@@ -148,8 +144,6 @@ const createFormValuesFromPoint = (
   name: point.name,
   datum: point.datum,
   kom: point.kom,
-  grueneNadeln: point.grueneNadeln ?? null,
-  andererSchaden: point.andererSchaden ?? false,
 });
 
 interface PriwaPointDrawerProps {
@@ -271,6 +265,9 @@ export default function PriwaPointDrawer({
 
     try {
       const values = await form.validateFields();
+      const savedCoordinateSource = willUseEstimatedGps
+        ? "gps"
+        : coordinateSource;
       const savedPoint: IPriwaPoint = {
         id: editingPoint?.id ?? crypto.randomUUID(),
         lat: effectiveCoordinate.lat,
@@ -288,12 +285,11 @@ export default function PriwaPointDrawer({
         datum: values.datum,
         kom: values.kom?.trim() ?? "",
         capturedAt: editingPoint?.capturedAt ?? new Date().toISOString(),
-        coordinateSource: willUseEstimatedGps ? "gps" : coordinateSource,
+        coordinateSource: savedCoordinateSource,
         gps: willUseEstimatedGps ? "nein" : "ja",
         isEstimatedLocation: willUseEstimatedGps,
-        grueneNadeln: values.grueneNadeln ?? null,
-        andererSchaden: values.andererSchaden ?? false,
-        rawQrValue: rawQrValue.trim() || editingPoint?.rawQrValue,
+        rawQrValue:
+          savedCoordinateSource === "qr" ? rawQrValue.trim() || undefined : undefined,
       };
 
       if (editingPoint) {
@@ -535,23 +531,6 @@ export default function PriwaPointDrawer({
 
           <section className="mt-3 space-y-2 border-t border-gray-200 pt-3">
             <Typography.Text strong>Optional</Typography.Text>
-            <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
-              <Form.Item label="Grüne Nadeln" name="grueneNadeln">
-                <Select
-                  allowClear
-                  placeholder="optional"
-                  options={yesNoOptions}
-                />
-              </Form.Item>
-              <Form.Item label="Anderer Schaden" name="andererSchaden">
-                <Select
-                  options={[
-                    { label: "Nein", value: false },
-                    { label: "Ja", value: true },
-                  ]}
-                />
-              </Form.Item>
-            </div>
             <Form.Item
               label="Kommentar"
               name="kom"

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -1,0 +1,595 @@
+import {
+  Alert,
+  Button,
+  Collapse,
+  Drawer,
+  Form,
+  Input,
+  Modal,
+  Select,
+  Typography,
+  message,
+} from "antd";
+import {
+  AimOutlined,
+  CheckCircleFilled,
+  DownOutlined,
+  EnvironmentOutlined,
+  QrcodeOutlined,
+  SaveOutlined,
+  DeleteOutlined,
+} from "@ant-design/icons";
+import { useEffect, useMemo, useState } from "react";
+
+import { parseGoogleMapsCoordinates } from "./parseGoogleMapsCoordinates";
+import QrCoordinateScanner from "./QrCoordinateScanner";
+import type {
+  IPriwaCoordinate,
+  IPriwaPoint,
+  PriwaBaumart,
+  PriwaBohrloch,
+  PriwaCoordinateSource,
+  PriwaFund,
+  PriwaHarz,
+  PriwaNadel,
+  PriwaObserverName,
+  PriwaPercentClass,
+  PriwaYesNo,
+} from "./types";
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const observerOptions: Array<{ label: string; value: PriwaObserverName }> = [
+  { label: "Sigi Huber", value: "Sigi Huber" },
+  { label: "Martin Schade", value: "Martin Schade" },
+  { label: "Maurice Mayer", value: "Maurice Mayer" },
+  { label: "Lukas Ruf", value: "Lukas Ruf" },
+  { label: "Markus Mayer", value: "Markus Mayer" },
+  { label: "Andere", value: "andere" },
+];
+
+const fundOptions: Array<{ label: string; value: PriwaFund }> = [
+  { label: "Ja", value: "ja" },
+  { label: "Ja, kein Buchdrucker", value: "ja_kein_buchdrucker" },
+  { label: "Nein", value: "nein" },
+  { label: "Unsicher", value: "unsicher" },
+];
+
+const baumartOptions: Array<{ label: string; value: PriwaBaumart }> = [
+  { label: "Fichte", value: "Fichte" },
+  { label: "Tanne", value: "Tanne" },
+  { label: "Douglasie", value: "Douglasie" },
+  { label: "Lärche", value: "Lärche" },
+  { label: "Kiefer", value: "Kiefer" },
+  { label: "Anderes Nadelholz", value: "anderes Nadelholz" },
+  { label: "Laubholz", value: "Laubholz" },
+];
+
+const yesNoOptions: Array<{ label: string; value: PriwaYesNo }> = [
+  { label: "Ja", value: "ja" },
+  { label: "Nein", value: "nein" },
+];
+
+const bohrlochOptions: Array<{ label: string; value: PriwaBohrloch }> = [
+  { label: "Ja", value: "ja" },
+  { label: "Nein", value: "nein" },
+  { label: "Ja, kein Buchdrucker", value: "ja_kein_buchdrucker" },
+];
+
+const harzOptions: Array<{ label: string; value: PriwaHarz }> = [
+  { label: "Vereinzelte Harztropfen", value: "vereinzelte Harztropfen" },
+  {
+    label: "Mittlerer/flächiger Harzfluss",
+    value: "mittlerer/flächiger Harzfluss",
+  },
+  { label: "Nein", value: "nein" },
+];
+
+const nadelOptions: Array<{ label: string; value: PriwaNadel }> = [
+  { label: "Grün", value: "grün" },
+  { label: "Fahlgrün/gelblich", value: "fahlgrün/gelblich" },
+  { label: "Rot/braun", value: "rot/braun" },
+  { label: "Abgefallen", value: "abgefallen" },
+];
+
+const percentOptions: Array<{ label: string; value: PriwaPercentClass }> = [
+  { label: "0%", value: "0%" },
+  { label: "Bis 25%", value: "bis25%" },
+  { label: "Bis 50%", value: "bis50%" },
+  { label: ">50%", value: ">50%" },
+];
+
+interface IPriwaPointFormValues {
+  baumnr: string;
+  fund: PriwaFund;
+  baumart: PriwaBaumart;
+  bm: PriwaYesNo;
+  bohrloch: PriwaBohrloch;
+  harz: PriwaHarz;
+  nadel: PriwaNadel;
+  rinde: PriwaPercentClass;
+  kv: PriwaPercentClass;
+  name: PriwaObserverName;
+  datum: string;
+  kom: string;
+  grueneNadeln?: PriwaYesNo | null;
+  andererSchaden?: boolean;
+}
+
+const createDefaultFormValues = (): IPriwaPointFormValues => ({
+  baumnr: "",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "nein",
+  bohrloch: "nein",
+  harz: "nein",
+  nadel: "grün",
+  rinde: "0%",
+  kv: "0%",
+  name: "andere",
+  datum: today(),
+  kom: "",
+  grueneNadeln: null,
+  andererSchaden: false,
+});
+
+const createFormValuesFromPoint = (
+  point: IPriwaPoint,
+): IPriwaPointFormValues => ({
+  baumnr: point.baumnr,
+  fund: point.fund,
+  baumart: point.baumart,
+  bm: point.bm,
+  bohrloch: point.bohrloch,
+  harz: point.harz,
+  nadel: point.nadel,
+  rinde: point.rinde,
+  kv: point.kv,
+  name: point.name,
+  datum: point.datum,
+  kom: point.kom,
+  grueneNadeln: point.grueneNadeln ?? null,
+  andererSchaden: point.andererSchaden ?? false,
+});
+
+interface PriwaPointDrawerProps {
+  open: boolean;
+  formSessionId: number;
+  editingPoint: IPriwaPoint | null;
+  selectedCoordinate: IPriwaCoordinate | null;
+  selectedCoordinateSource: PriwaCoordinateSource;
+  currentUserCoordinate: IPriwaCoordinate | null;
+  onClose: () => void;
+  onAddPoint: (point: IPriwaPoint) => Promise<void>;
+  onUpdatePoint: (point: IPriwaPoint) => Promise<void>;
+  onDeletePoint: (pointId: string) => Promise<void>;
+  isSaving?: boolean;
+  onRequestMapPlacement: () => void;
+  onPreviewCoordinate: (coordinate: IPriwaCoordinate | null) => void;
+  onZoomToPoint: (coordinate: IPriwaCoordinate) => void;
+}
+
+export default function PriwaPointDrawer({
+  open,
+  formSessionId,
+  editingPoint,
+  selectedCoordinate,
+  selectedCoordinateSource,
+  currentUserCoordinate,
+  onClose,
+  onAddPoint,
+  onUpdatePoint,
+  onDeletePoint,
+  isSaving = false,
+  onRequestMapPlacement,
+  onPreviewCoordinate,
+  onZoomToPoint,
+}: PriwaPointDrawerProps) {
+  const [form] = Form.useForm<IPriwaPointFormValues>();
+  const [rawQrValue, setRawQrValue] = useState("");
+  const [coordinate, setCoordinate] = useState<IPriwaCoordinate | null>(null);
+  const [coordinateSource, setCoordinateSource] =
+    useState<PriwaCoordinateSource>("qr");
+  const [isQrScannerOpen, setQrScannerOpen] = useState(false);
+
+  const qrCoordinate = useMemo(
+    () => parseGoogleMapsCoordinates(rawQrValue),
+    [rawQrValue],
+  );
+
+  useEffect(() => {
+    if (formSessionId === 0) return;
+
+    if (editingPoint) {
+      form.setFieldsValue(createFormValuesFromPoint(editingPoint));
+      setRawQrValue(editingPoint.rawQrValue ?? "");
+      return;
+    }
+
+    form.setFieldsValue(createDefaultFormValues());
+    setRawQrValue("");
+  }, [editingPoint, form, formSessionId]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (selectedCoordinate) {
+      setCoordinate(selectedCoordinate);
+      setCoordinateSource(selectedCoordinateSource);
+      return;
+    }
+
+    if (editingPoint) {
+      setCoordinate({ lat: editingPoint.lat, lon: editingPoint.lon });
+      setCoordinateSource(editingPoint.coordinateSource);
+      return;
+    }
+
+    setCoordinate(null);
+    setCoordinateSource(selectedCoordinateSource);
+  }, [editingPoint, open, selectedCoordinate, selectedCoordinateSource]);
+
+  useEffect(() => {
+    if (!open || !qrCoordinate) return;
+
+    setCoordinate(qrCoordinate);
+    setCoordinateSource("qr");
+    setQrScannerOpen(false);
+  }, [open, qrCoordinate]);
+
+  useEffect(() => {
+    onPreviewCoordinate(open ? coordinate : null);
+  }, [coordinate, onPreviewCoordinate, open]);
+
+  const useCurrentGpsCoordinate = () => {
+    if (!currentUserCoordinate) return;
+
+    setCoordinate(currentUserCoordinate);
+    setCoordinateSource("gps");
+  };
+
+  const effectiveCoordinate = coordinate ?? currentUserCoordinate;
+  const willUseEstimatedGps = !coordinate && !!currentUserCoordinate;
+  const positionLabel = willUseEstimatedGps
+    ? "GPS geschätzt"
+    : coordinate
+      ? coordinateSource === "qr"
+        ? "QR"
+        : coordinateSource === "map"
+          ? "Karte"
+          : "GPS"
+      : "Keine Position";
+  const positionDetail = effectiveCoordinate
+    ? `${effectiveCoordinate.lat.toFixed(5)}, ${effectiveCoordinate.lon.toFixed(5)}`
+    : "QR, GPS oder Karte";
+  const hasConfirmedLocation = !!coordinate;
+  const requiresBaumnr =
+    willUseEstimatedGps || (hasConfirmedLocation && coordinateSource !== "qr");
+
+  const handleSave = async () => {
+    if (!effectiveCoordinate) return;
+
+    try {
+      const values = await form.validateFields();
+      const savedPoint: IPriwaPoint = {
+        id: editingPoint?.id ?? crypto.randomUUID(),
+        lat: effectiveCoordinate.lat,
+        lon: effectiveCoordinate.lon,
+        baumnr: values.baumnr?.trim() ?? "",
+        fund: values.fund,
+        baumart: values.baumart,
+        bm: values.bm,
+        bohrloch: values.bohrloch,
+        harz: values.harz,
+        nadel: values.nadel,
+        rinde: values.rinde,
+        kv: values.kv,
+        name: values.name,
+        datum: values.datum,
+        kom: values.kom?.trim() ?? "",
+        capturedAt: editingPoint?.capturedAt ?? new Date().toISOString(),
+        coordinateSource: willUseEstimatedGps ? "gps" : coordinateSource,
+        gps: willUseEstimatedGps ? "nein" : "ja",
+        isEstimatedLocation: willUseEstimatedGps,
+        grueneNadeln: values.grueneNadeln ?? null,
+        andererSchaden: values.andererSchaden ?? false,
+        rawQrValue: rawQrValue.trim() || editingPoint?.rawQrValue,
+      };
+
+      if (editingPoint) {
+        await onUpdatePoint(savedPoint);
+      } else {
+        await onAddPoint(savedPoint);
+      }
+
+      onZoomToPoint(effectiveCoordinate);
+      form.setFieldsValue(createDefaultFormValues());
+      setRawQrValue("");
+      setCoordinate(null);
+      setCoordinateSource("qr");
+      setQrScannerOpen(false);
+      onClose();
+    } catch (error) {
+      message.error(
+        error instanceof Error
+          ? error.message
+          : "Käferbaum konnte nicht gespeichert werden",
+      );
+    }
+  };
+
+  const handleDelete = () => {
+    if (!editingPoint) return;
+
+    Modal.confirm({
+      title: "Käferbaum löschen?",
+      content:
+        "Der Eintrag wird nur ausgeblendet und kann später in der Datenbank wiederhergestellt werden.",
+      okText: "Löschen",
+      okButtonProps: { danger: true },
+      cancelText: "Abbrechen",
+      onOk: async () => {
+        try {
+          await onDeletePoint(editingPoint.id);
+        } catch (error) {
+          message.error(
+            error instanceof Error
+              ? error.message
+              : "Käferbaum konnte nicht gelöscht werden",
+          );
+          throw error;
+        }
+      },
+    });
+  };
+
+  return (
+    <Drawer
+      title={editingPoint ? "Käferbaum bearbeiten" : "Käferbaum aufnehmen"}
+      open={open}
+      onClose={onClose}
+      placement="right"
+      width="min(430px, 100vw)"
+      rootClassName="priwa-point-drawer-root"
+      className="priwa-point-drawer"
+      destroyOnClose={false}
+      styles={{
+        body: { overflowX: "hidden", padding: "14px 18px 18px" },
+        content: { maxWidth: "100vw", overflowX: "hidden" },
+      }}
+    >
+      <div className="space-y-3">
+        <section
+          className={
+            hasConfirmedLocation
+              ? "rounded-md border border-emerald-500 bg-emerald-50 p-2.5 shadow-sm shadow-emerald-900/10"
+              : "rounded-md border border-gray-200 bg-gray-50 p-2.5"
+          }
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <div
+                className={
+                  hasConfirmedLocation
+                    ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white"
+                    : "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500"
+                }
+              >
+                {hasConfirmedLocation ? (
+                  <CheckCircleFilled />
+                ) : (
+                  <EnvironmentOutlined />
+                )}
+              </div>
+              <div className="min-w-0">
+                <Typography.Text
+                  strong
+                  className={
+                    hasConfirmedLocation ? "text-emerald-900" : "text-gray-900"
+                  }
+                >
+                  {hasConfirmedLocation ? "Position gesetzt" : positionLabel}
+                </Typography.Text>
+                <div
+                  className={
+                    hasConfirmedLocation
+                      ? "truncate text-xs font-medium text-emerald-800"
+                      : "truncate text-xs text-gray-500"
+                  }
+                >
+                  {hasConfirmedLocation
+                    ? `${positionLabel} · ${positionDetail}`
+                    : positionDetail}
+                </div>
+              </div>
+            </div>
+            <div className="flex shrink-0 gap-1.5">
+              <Button
+                className="h-11 w-12"
+                style={{ height: 44, minWidth: 48, width: 48 }}
+                icon={<QrcodeOutlined />}
+                onClick={() => setQrScannerOpen(true)}
+                aria-label="QR scannen"
+              />
+              <Button
+                className="h-11 w-12"
+                style={{ height: 44, minWidth: 48, width: 48 }}
+                icon={<EnvironmentOutlined />}
+                disabled={!currentUserCoordinate}
+                onClick={useCurrentGpsCoordinate}
+                aria-label="GPS übernehmen"
+              />
+              <Button
+                className="h-11 w-12"
+                style={{ height: 44, minWidth: 48, width: 48 }}
+                icon={<AimOutlined />}
+                onClick={onRequestMapPlacement}
+                aria-label="Auf Karte setzen"
+              />
+            </div>
+          </div>
+          {willUseEstimatedGps && (
+            <Alert
+              className="mt-3"
+              type="warning"
+              showIcon
+              message="Schnellspeichern nutzt GPS als geschätzte Lage."
+            />
+          )}
+        </section>
+
+        <Modal
+          title="QR scannen"
+          open={isQrScannerOpen}
+          onCancel={() => setQrScannerOpen(false)}
+          footer={null}
+          destroyOnHidden
+        >
+          <QrCoordinateScanner autoStart onDetected={setRawQrValue} />
+          <Form layout="vertical" className="mt-3">
+            <Form.Item label="QR / Google Maps Link manuell">
+              <Input.TextArea
+                value={rawQrValue}
+                onChange={(event) => setRawQrValue(event.target.value)}
+                autoSize={{ minRows: 2, maxRows: 3 }}
+                placeholder="https://www.google.com/maps/search/?api=1&query=48.456025,8.180315"
+              />
+            </Form.Item>
+          </Form>
+        </Modal>
+
+        <Form
+          layout="vertical"
+          form={form}
+          className="[&_.ant-form-item]:mb-2.5 [&_.ant-form-item-label]:pb-0.5 [&_.ant-form-item-label>label]:text-xs [&_.ant-form-item-label>label]:font-medium"
+        >
+          <Collapse
+            ghost
+            size="small"
+            defaultActiveKey={editingPoint ? ["baum"] : []}
+            expandIcon={({ isActive }) => (
+              <DownOutlined rotate={isActive ? 180 : 0} />
+            )}
+            items={[
+              {
+                key: "baum",
+                label: <Typography.Text strong>Baum</Typography.Text>,
+                children: (
+                  <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+                    <Form.Item
+                      label="Baumnr"
+                      name="baumnr"
+                      rules={[
+                        {
+                          required: requiresBaumnr,
+                          whitespace: true,
+                          message:
+                            "Baumnr ist für GPS- oder Kartenpositionen erforderlich",
+                        },
+                      ]}
+                    >
+                      <Input maxLength={20} placeholder="optional" />
+                    </Form.Item>
+                    <Form.Item label="Fund" name="fund">
+                      <Select options={fundOptions} />
+                    </Form.Item>
+                    <Form.Item label="Name" name="name">
+                      <Select options={observerOptions} />
+                    </Form.Item>
+                    <Form.Item label="Datum" name="datum">
+                      <Input type="date" />
+                    </Form.Item>
+                  </div>
+                ),
+              },
+            ]}
+            className="rounded-md border border-gray-200 bg-white [&_.ant-collapse-content-box]:pb-1 [&_.ant-collapse-content-box]:pt-0 [&_.ant-collapse-header]:px-0 [&_.ant-collapse-header]:py-1.5"
+          />
+
+          <section className="mt-3 space-y-2 border-t border-gray-200 pt-3">
+            <Typography.Text strong>Befallssymptome</Typography.Text>
+            <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+              <Form.Item label="Baumart" name="baumart">
+                <Select options={baumartOptions} />
+              </Form.Item>
+              <Form.Item label="Bohrmehl" name="bm">
+                <Select options={yesNoOptions} />
+              </Form.Item>
+              <Form.Item label="Bohrloch" name="bohrloch">
+                <Select options={bohrlochOptions} />
+              </Form.Item>
+              <Form.Item label="Harzfluss" name="harz">
+                <Select options={harzOptions} />
+              </Form.Item>
+              <Form.Item label="Nadelfarbe" name="nadel">
+                <Select options={nadelOptions} />
+              </Form.Item>
+              <Form.Item label="Rindenverluste" name="rinde">
+                <Select options={percentOptions} />
+              </Form.Item>
+              <Form.Item label="Kronenverluste" name="kv">
+                <Select options={percentOptions} />
+              </Form.Item>
+            </div>
+          </section>
+
+          <section className="mt-3 space-y-2 border-t border-gray-200 pt-3">
+            <Typography.Text strong>Optional</Typography.Text>
+            <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+              <Form.Item label="Grüne Nadeln" name="grueneNadeln">
+                <Select
+                  allowClear
+                  placeholder="optional"
+                  options={yesNoOptions}
+                />
+              </Form.Item>
+              <Form.Item label="Anderer Schaden" name="andererSchaden">
+                <Select
+                  options={[
+                    { label: "Nein", value: false },
+                    { label: "Ja", value: true },
+                  ]}
+                />
+              </Form.Item>
+            </div>
+            <Form.Item
+              label="Kommentar"
+              name="kom"
+              rules={[{ max: 200, message: "Maximal 200 Zeichen" }]}
+            >
+              <Input.TextArea
+                maxLength={200}
+                showCount
+                autoSize={{ minRows: 2, maxRows: 4 }}
+              />
+            </Form.Item>
+          </section>
+
+          <Button
+            className="mt-3"
+            type="primary"
+            icon={<SaveOutlined />}
+            block
+            disabled={!effectiveCoordinate}
+            loading={isSaving}
+            onClick={handleSave}
+          >
+            {editingPoint ? "Aktualisieren" : "Schnellspeichern"}
+          </Button>
+          {editingPoint && (
+            <Button
+              className="mt-2"
+              danger
+              icon={<DeleteOutlined />}
+              block
+              disabled={isSaving}
+              onClick={handleDelete}
+            >
+              Löschen
+            </Button>
+          )}
+        </Form>
+      </div>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/PriwaField/QrCoordinateScanner.tsx
+++ b/frontend/src/components/PriwaField/QrCoordinateScanner.tsx
@@ -1,0 +1,166 @@
+import { Alert, Button, Space } from "antd";
+import { CameraOutlined, StopOutlined } from "@ant-design/icons";
+import jsQR from "jsqr";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const getCameraErrorMessage = (error: unknown) => {
+  const errorName =
+    error instanceof DOMException || error instanceof Error ? error.name : "";
+
+  if (!window.isSecureContext) {
+    return "Kamera braucht HTTPS oder localhost. Bitte diese Testversion über eine sichere Adresse öffnen.";
+  }
+
+  if (!navigator.mediaDevices?.getUserMedia) {
+    return "Dieser Browser unterstützt keinen direkten Kamerazugriff. Google-Maps-Link bitte manuell einfügen.";
+  }
+
+  if (errorName === "NotAllowedError" || errorName === "SecurityError") {
+    return "Kamera ist blockiert. Bitte Kamera für diese Website in den Browser-/Systemeinstellungen erlauben.";
+  }
+
+  if (errorName === "NotFoundError" || errorName === "DevicesNotFoundError") {
+    return "Keine Kamera gefunden. Google-Maps-Link bitte manuell einfügen.";
+  }
+
+  if (errorName === "NotReadableError" || errorName === "TrackStartError") {
+    return "Kamera ist gerade nicht verfügbar. Bitte andere Kamera-Apps schließen und erneut versuchen.";
+  }
+
+  return "QR-Scan konnte nicht gestartet werden. Google-Maps-Link bitte manuell einfügen.";
+};
+
+interface QrCoordinateScannerProps {
+  autoStart?: boolean;
+  onDetected: (value: string) => void;
+}
+
+export default function QrCoordinateScanner({
+  autoStart = false,
+  onDetected,
+}: QrCoordinateScannerProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const hasAutoStartedRef = useRef(false);
+  const [isScanning, setIsScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stopScanning = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+
+    setIsScanning(false);
+  }, []);
+
+  const scanFrame = useCallback(() => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+
+    if (
+      !video ||
+      !canvas ||
+      video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA
+    ) {
+      animationFrameRef.current = window.requestAnimationFrame(scanFrame);
+      return;
+    }
+
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) {
+      animationFrameRef.current = window.requestAnimationFrame(scanFrame);
+      return;
+    }
+
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+    const qrCode = jsQR(imageData.data, imageData.width, imageData.height);
+
+    if (qrCode?.data) {
+      onDetected(qrCode.data);
+      stopScanning();
+      return;
+    }
+
+    animationFrameRef.current = window.requestAnimationFrame(scanFrame);
+  }, [onDetected, stopScanning]);
+
+  const startScanning = useCallback(async () => {
+    stopScanning();
+
+    try {
+      setError(null);
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: { ideal: "environment" },
+        },
+        audio: false,
+      });
+
+      streamRef.current = stream;
+      setIsScanning(true);
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+
+      animationFrameRef.current = window.requestAnimationFrame(scanFrame);
+    } catch (scanError) {
+      setError(getCameraErrorMessage(scanError));
+      stopScanning();
+    }
+  }, [scanFrame, stopScanning]);
+
+  useEffect(() => {
+    if (!autoStart || hasAutoStartedRef.current) return;
+
+    hasAutoStartedRef.current = true;
+    void startScanning();
+  }, [autoStart, startScanning]);
+
+  useEffect(() => stopScanning, [stopScanning]);
+
+  return (
+    <div className="space-y-3">
+      {error && <Alert type="warning" showIcon message={error} />}
+      <div className="overflow-hidden rounded-md bg-black">
+        <video
+          ref={videoRef}
+          className="aspect-video w-full object-cover"
+          muted
+          playsInline
+        />
+      </div>
+      <canvas ref={canvasRef} className="hidden" />
+      <Space>
+        <Button
+          icon={<CameraOutlined />}
+          onClick={startScanning}
+          disabled={isScanning}
+        >
+          Kamera starten
+        </Button>
+        <Button
+          icon={<StopOutlined />}
+          onClick={stopScanning}
+          disabled={!isScanning}
+        >
+          Stop
+        </Button>
+      </Space>
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/createLglDop20Layer.ts
+++ b/frontend/src/components/PriwaField/createLglDop20Layer.ts
@@ -1,0 +1,45 @@
+import TileLayer from "ol/layer/Tile";
+import { get as getProjection } from "ol/proj";
+import WMTS from "ol/source/WMTS";
+import WMTSTileGrid from "ol/tilegrid/WMTS";
+import { getTopLeft, getWidth } from "ol/extent";
+
+const LGL_DOP20_WMTS_URL =
+  "https://owsproxy.lgl-bw.de/owsproxy/ows/WMTS_LGL-BW_ATKIS_DOP_20_C";
+const LGL_DOP20_ATTRIBUTION = "Datengrundlage: LGL, www.lgl-bw.de";
+
+export const createLglDop20Layer = () => {
+  const projection = getProjection("EPSG:3857");
+  if (!projection) {
+    throw new Error("EPSG:3857 projection is unavailable");
+  }
+
+  const projectionExtent = projection.getExtent();
+  const baseResolution = getWidth(projectionExtent) / 256;
+  const resolutions = Array.from(
+    { length: 21 },
+    (_, zoom) => baseResolution / 2 ** zoom,
+  );
+  const matrixIds = resolutions.map(
+    (_, zoom) => `GoogleMapsCompatible:${zoom}`,
+  );
+
+  return new TileLayer({
+    preload: 1,
+    source: new WMTS({
+      url: LGL_DOP20_WMTS_URL,
+      layer: "DOP_20_C",
+      matrixSet: "GoogleMapsCompatible",
+      format: "image/jpeg",
+      style: "default",
+      projection,
+      tileGrid: new WMTSTileGrid({
+        origin: getTopLeft(projectionExtent),
+        resolutions,
+        matrixIds,
+      }),
+      attributions: LGL_DOP20_ATTRIBUTION,
+      wrapX: true,
+    }),
+  });
+};

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.ts
@@ -1,0 +1,23 @@
+import TileLayerWebGL from "ol/layer/WebGLTile.js";
+import { GeoTIFF } from "ol/source";
+
+import { Settings } from "../../config";
+
+export const createPriwaCogLayer = (cogPath: string) =>
+  new TileLayerWebGL({
+    source: new GeoTIFF({
+      sources: [
+        {
+          url: Settings.COG_BASE_URL + cogPath,
+          nodata: 0,
+          bands: [1, 2, 3],
+        },
+      ],
+      convertToRGB: true,
+    }),
+    opacity: 0.82,
+    maxZoom: 23,
+    zIndex: 10,
+    cacheSize: 4096,
+    preload: 0,
+  });

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.ts
@@ -1,0 +1,92 @@
+import Feature from "ol/Feature";
+import { Point } from "ol/geom";
+import VectorLayer from "ol/layer/Vector";
+import { fromLonLat } from "ol/proj";
+import VectorSource from "ol/source/Vector";
+import { Circle as CircleStyle, Fill, Stroke, Style, Text } from "ol/style";
+
+import type { IPriwaCoordinate, IPriwaPoint, PriwaFund } from "./types";
+
+const fundColors: Record<PriwaFund, string> = {
+  ja: "rgba(220, 38, 38, 0.96)",
+  ja_kein_buchdrucker: "rgba(217, 119, 6, 0.96)",
+  nein: "rgba(22, 163, 74, 0.96)",
+  unsicher: "rgba(217, 119, 6, 0.96)",
+};
+
+const pointStyle = (point: IPriwaPoint) => {
+  const coreStyle = new Style({
+    image: new CircleStyle({
+      radius: point.isEstimatedLocation ? 7 : 8,
+      fill: new Fill({ color: fundColors[point.fund] }),
+      stroke: new Stroke({
+        color: point.isEstimatedLocation
+          ? "rgba(251, 191, 36, 0.98)"
+          : "rgba(255, 255, 255, 0.96)",
+        width: point.isEstimatedLocation ? 2 : 3,
+      }),
+    }),
+    text: point.baumnr
+      ? new Text({
+          text: point.baumnr,
+          offsetY: -18,
+          font: "600 12px Inter, system-ui, sans-serif",
+          fill: new Fill({ color: "#111827" }),
+          stroke: new Stroke({ color: "rgba(255,255,255,0.96)", width: 4 }),
+        })
+      : undefined,
+  });
+
+  if (!point.isEstimatedLocation) return coreStyle;
+
+  return [
+    new Style({
+      image: new CircleStyle({
+        radius: 13,
+        fill: new Fill({ color: "rgba(251, 191, 36, 0.12)" }),
+        stroke: new Stroke({
+          color: "rgba(251, 191, 36, 0.9)",
+          width: 2,
+          lineDash: [4, 4],
+        }),
+      }),
+    }),
+    coreStyle,
+  ];
+};
+
+export const createPriwaPointFeature = (point: IPriwaPoint) => {
+  const feature = new Feature({
+    geometry: new Point(fromLonLat([point.lon, point.lat])),
+    point,
+  });
+  feature.setId(point.id);
+  feature.setStyle(pointStyle(point));
+  return feature;
+};
+
+export const createPriwaPointLayer = (points: IPriwaPoint[]) =>
+  new VectorLayer({
+    source: new VectorSource({
+      features: points.map(createPriwaPointFeature),
+    }),
+    zIndex: 40,
+  });
+
+export const createPriwaPreviewLayer = () =>
+  new VectorLayer({
+    source: new VectorSource(),
+    zIndex: 45,
+    style: new Style({
+      image: new CircleStyle({
+        radius: 10,
+        fill: new Fill({ color: "rgba(37, 99, 235, 0.28)" }),
+        stroke: new Stroke({ color: "rgba(37, 99, 235, 0.98)", width: 3 }),
+      }),
+    }),
+  });
+
+export const createPriwaPreviewFeature = (coordinate: IPriwaCoordinate) =>
+  new Feature({
+    geometry: new Point(fromLonLat([coordinate.lon, coordinate.lat])),
+  });

--- a/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.test.ts
+++ b/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGoogleMapsCoordinates } from "./parseGoogleMapsCoordinates";
+
+const decodedQrUrls = [
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.456025%2C8.180315",
+    48.456025,
+    8.180315,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455937%2C8.180047",
+    48.455937,
+    8.180047,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455811%2C8.179944",
+    48.455811,
+    8.179944,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455805%2C8.180053",
+    48.455805,
+    8.180053,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455851%2C8.180082",
+    48.455851,
+    8.180082,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455879%2C8.179991",
+    48.455879,
+    8.179991,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455998%2C8.180189",
+    48.455998,
+    8.180189,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.456106%2C8.180173",
+    48.456106,
+    8.180173,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.456023%2C8.180116",
+    48.456023,
+    8.180116,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455986%2C8.179919",
+    48.455986,
+    8.179919,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455991%2C8.180012",
+    48.455991,
+    8.180012,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.456043%2C8.180224",
+    48.456043,
+    8.180224,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455942%2C8.180311",
+    48.455942,
+    8.180311,
+  ],
+  [
+    "https://www.google.com/maps/search/?api=1&query=48.455939%2C8.180238",
+    48.455939,
+    8.180238,
+  ],
+] as const;
+
+describe("parseGoogleMapsCoordinates", () => {
+  it.each(decodedQrUrls)(
+    "extracts coordinates from supplied QR Google Maps URL %#",
+    (url, lat, lon) => {
+      expect(parseGoogleMapsCoordinates(url)).toEqual({ lat, lon });
+    },
+  );
+
+  it("extracts coordinates from common Google Maps URL variants", () => {
+    expect(
+      parseGoogleMapsCoordinates(
+        "https://maps.google.com/?q=48.456025,8.180315",
+      ),
+    ).toEqual({
+      lat: 48.456025,
+      lon: 8.180315,
+    });
+    expect(
+      parseGoogleMapsCoordinates(
+        "https://www.google.com/maps/@48.456025,8.180315,19z",
+      ),
+    ).toEqual({
+      lat: 48.456025,
+      lon: 8.180315,
+    });
+    expect(parseGoogleMapsCoordinates("48.456025, 8.180315")).toEqual({
+      lat: 48.456025,
+      lon: 8.180315,
+    });
+  });
+
+  it("rejects text without usable coordinates", () => {
+    expect(
+      parseGoogleMapsCoordinates(
+        "https://maps.app.goo.gl/example-without-expanded-coordinates",
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.test.ts
+++ b/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.test.ts
@@ -113,4 +113,10 @@ describe("parseGoogleMapsCoordinates", () => {
       ),
     ).toBeNull();
   });
+
+  it("rejects malformed percent escapes without throwing", () => {
+    expect(
+      parseGoogleMapsCoordinates("https://maps.example/?q=48.45%foo,8.18"),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.ts
+++ b/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.ts
@@ -1,0 +1,67 @@
+import type { IPriwaCoordinate } from "./types";
+
+const COORDINATE_PAIR_PATTERN =
+  /(-?\d{1,2}(?:\.\d+)?)\s*[,;\s]\s*(-?\d{1,3}(?:\.\d+)?)/;
+
+const GOOGLE_MAPS_AT_PATTERN =
+  /@(-?\d{1,2}(?:\.\d+)?),(-?\d{1,3}(?:\.\d+)?)(?:,|$)/;
+
+const GOOGLE_MAPS_DATA_PATTERN =
+  /!3d(-?\d{1,2}(?:\.\d+)?)!4d(-?\d{1,3}(?:\.\d+)?)/;
+
+const isValidCoordinate = ({ lat, lon }: IPriwaCoordinate) =>
+  Number.isFinite(lat) &&
+  Number.isFinite(lon) &&
+  lat >= -90 &&
+  lat <= 90 &&
+  lon >= -180 &&
+  lon <= 180;
+
+const coordinateFromMatch = (
+  match: RegExpMatchArray | null,
+): IPriwaCoordinate | null => {
+  if (!match) return null;
+
+  const coordinate = {
+    lat: Number(match[1]),
+    lon: Number(match[2]),
+  };
+
+  return isValidCoordinate(coordinate) ? coordinate : null;
+};
+
+const parseCoordinatePair = (value: string): IPriwaCoordinate | null =>
+  coordinateFromMatch(value.match(COORDINATE_PAIR_PATTERN));
+
+export const parseGoogleMapsCoordinates = (
+  rawValue: string,
+): IPriwaCoordinate | null => {
+  const trimmedValue = rawValue.trim();
+  if (!trimmedValue) return null;
+
+  const decodedValue = decodeURIComponent(trimmedValue);
+
+  const dataCoordinate = coordinateFromMatch(
+    decodedValue.match(GOOGLE_MAPS_DATA_PATTERN),
+  );
+  if (dataCoordinate) return dataCoordinate;
+
+  const atCoordinate = coordinateFromMatch(
+    decodedValue.match(GOOGLE_MAPS_AT_PATTERN),
+  );
+  if (atCoordinate) return atCoordinate;
+
+  try {
+    const url = new URL(decodedValue);
+    const queryCoordinate =
+      parseCoordinatePair(url.searchParams.get("query") ?? "") ??
+      parseCoordinatePair(url.searchParams.get("q") ?? "") ??
+      parseCoordinatePair(url.pathname);
+
+    if (queryCoordinate) return queryCoordinate;
+  } catch {
+    // Plain coordinate text is valid QR content too.
+  }
+
+  return parseCoordinatePair(decodedValue);
+};

--- a/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.ts
+++ b/frontend/src/components/PriwaField/parseGoogleMapsCoordinates.ts
@@ -33,13 +33,21 @@ const coordinateFromMatch = (
 const parseCoordinatePair = (value: string): IPriwaCoordinate | null =>
   coordinateFromMatch(value.match(COORDINATE_PAIR_PATTERN));
 
+const safelyDecodeUriComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
 export const parseGoogleMapsCoordinates = (
   rawValue: string,
 ): IPriwaCoordinate | null => {
   const trimmedValue = rawValue.trim();
   if (!trimmedValue) return null;
 
-  const decodedValue = decodeURIComponent(trimmedValue);
+  const decodedValue = safelyDecodeUriComponent(trimmedValue);
 
   const dataCoordinate = coordinateFromMatch(
     decodedValue.match(GOOGLE_MAPS_DATA_PATTERN),

--- a/frontend/src/components/PriwaField/types.ts
+++ b/frontend/src/components/PriwaField/types.ts
@@ -53,8 +53,6 @@ export interface IPriwaPoint extends IPriwaCoordinate {
   gps: PriwaGpsQuality;
   isEstimatedLocation?: boolean;
   bhd?: number | null;
-  grueneNadeln?: PriwaYesNo | null;
-  andererSchaden?: boolean;
   fotoQrName?: string;
   rawQrValue?: string;
 }

--- a/frontend/src/components/PriwaField/types.ts
+++ b/frontend/src/components/PriwaField/types.ts
@@ -1,0 +1,60 @@
+export interface IPriwaCoordinate {
+  lat: number;
+  lon: number;
+}
+
+export type PriwaCoordinateSource = "qr" | "gps" | "map";
+export type PriwaGpsQuality = "ja" | "nein";
+export type PriwaObserverName =
+  | "Sigi Huber"
+  | "Martin Schade"
+  | "Maurice Mayer"
+  | "Lukas Ruf"
+  | "Markus Mayer"
+  | "andere";
+export type PriwaFund = "ja" | "ja_kein_buchdrucker" | "nein" | "unsicher";
+export type PriwaBaumart =
+  | "Fichte"
+  | "Tanne"
+  | "Douglasie"
+  | "Lärche"
+  | "Kiefer"
+  | "anderes Nadelholz"
+  | "Laubholz";
+export type PriwaYesNo = "ja" | "nein";
+export type PriwaBohrloch = "ja" | "nein" | "ja_kein_buchdrucker";
+export type PriwaHarz =
+  | "vereinzelte Harztropfen"
+  | "mittlerer/flächiger Harzfluss"
+  | "nein";
+export type PriwaNadel =
+  | "grün"
+  | "fahlgrün/gelblich"
+  | "rot/braun"
+  | "abgefallen";
+export type PriwaPercentClass = "0%" | "bis25%" | "bis50%" | ">50%";
+
+export interface IPriwaPoint extends IPriwaCoordinate {
+  id: string;
+  baumnr: string;
+  fund: PriwaFund;
+  baumart: PriwaBaumart;
+  bm: PriwaYesNo;
+  bohrloch: PriwaBohrloch;
+  harz: PriwaHarz;
+  nadel: PriwaNadel;
+  rinde: PriwaPercentClass;
+  kv: PriwaPercentClass;
+  name: PriwaObserverName;
+  datum: string;
+  kom: string;
+  capturedAt: string;
+  coordinateSource: PriwaCoordinateSource;
+  gps: PriwaGpsQuality;
+  isEstimatedLocation?: boolean;
+  bhd?: number | null;
+  grueneNadeln?: PriwaYesNo | null;
+  andererSchaden?: boolean;
+  fotoQrName?: string;
+  rawQrValue?: string;
+}

--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
@@ -1,0 +1,212 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { supabase } from "../../hooks/useSupabase";
+import type { IPriwaPoint, PriwaCoordinateSource } from "./types";
+
+type PriwaDbLocationSource = "qr_exact" | "gps_estimated" | "map_estimated";
+
+interface IPriwaGeometryPoint {
+  type: "Point";
+  coordinates: [number, number];
+}
+
+interface IPriwaKaeferbaumRow {
+  id: string;
+  project_id: string;
+  geom: IPriwaGeometryPoint | string | null;
+  location_source: PriwaDbLocationSource;
+  is_exact_location?: boolean;
+  baumnr: string | null;
+  fund: IPriwaPoint["fund"];
+  baumart: IPriwaPoint["baumart"];
+  bm: IPriwaPoint["bm"];
+  bohrloch: IPriwaPoint["bohrloch"];
+  harz: IPriwaPoint["harz"];
+  nadel: IPriwaPoint["nadel"];
+  rinde: IPriwaPoint["rinde"] | null;
+  kv: IPriwaPoint["kv"] | null;
+  name: IPriwaPoint["name"];
+  datum: string;
+  kom: string | null;
+  raw_qr_value: string | null;
+  created_at: string;
+  updated_at: string;
+  client_updated_at: string | null;
+}
+
+const toDbLocationSource = (
+  source: PriwaCoordinateSource,
+): PriwaDbLocationSource => {
+  if (source === "qr") return "qr_exact";
+  if (source === "gps") return "gps_estimated";
+  return "map_estimated";
+};
+
+const fromDbLocationSource = (
+  source: PriwaDbLocationSource,
+): PriwaCoordinateSource => {
+  if (source === "qr_exact") return "qr";
+  if (source === "gps_estimated") return "gps";
+  return "map";
+};
+
+const parseGeometryPoint = (
+  geom: IPriwaKaeferbaumRow["geom"],
+): IPriwaGeometryPoint | null => {
+  if (!geom) return null;
+
+  if (typeof geom === "string") {
+    try {
+      const parsed = JSON.parse(geom) as IPriwaGeometryPoint;
+      return parsed.type === "Point" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return geom.type === "Point" ? geom : null;
+};
+
+const rowToPoint = (row: IPriwaKaeferbaumRow): IPriwaPoint | null => {
+  const geom = parseGeometryPoint(row.geom);
+  if (!geom) return null;
+
+  const [lon, lat] = geom.coordinates;
+  const coordinateSource = fromDbLocationSource(row.location_source);
+
+  return {
+    id: row.id,
+    lat,
+    lon,
+    baumnr: row.baumnr ?? "",
+    fund: row.fund,
+    baumart: row.baumart,
+    bm: row.bm,
+    bohrloch: row.bohrloch,
+    harz: row.harz,
+    nadel: row.nadel,
+    rinde: row.rinde ?? "0%",
+    kv: row.kv ?? "0%",
+    name: row.name,
+    datum: row.datum,
+    kom: row.kom ?? "",
+    capturedAt: row.created_at,
+    coordinateSource,
+    gps: coordinateSource === "qr" ? "ja" : "nein",
+    isEstimatedLocation: row.location_source !== "qr_exact",
+    rawQrValue: row.raw_qr_value ?? undefined,
+  };
+};
+
+const pointToRow = (projectId: string, point: IPriwaPoint) => ({
+  id: point.id,
+  project_id: projectId,
+  geom: {
+    type: "Point",
+    coordinates: [point.lon, point.lat],
+  } satisfies IPriwaGeometryPoint,
+  location_source: toDbLocationSource(point.coordinateSource),
+  baumnr: point.baumnr.trim() || null,
+  fund: point.fund,
+  baumart: point.baumart,
+  bm: point.bm,
+  bohrloch: point.bohrloch,
+  harz: point.harz,
+  nadel: point.nadel,
+  rinde: point.rinde || null,
+  kv: point.kv || null,
+  name: point.name,
+  datum: point.datum,
+  kom: point.kom.trim() || null,
+  raw_qr_value: point.rawQrValue?.trim() || null,
+  client_updated_at: new Date().toISOString(),
+});
+
+const priwaPointsQueryKey = (projectId: string | null | undefined) => [
+  "priwa-kaeferbaeume",
+  projectId,
+];
+
+export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  const pointsQuery = useQuery({
+    queryKey: priwaPointsQueryKey(projectId),
+    enabled: !!projectId,
+    queryFn: async () => {
+      if (!projectId) return [];
+
+      const { data, error } = await supabase
+        .from("priwa_kaeferbaeume")
+        .select(
+          "id, project_id, geom, location_source, is_exact_location, baumnr, fund, baumart, bm, bohrloch, harz, nadel, rinde, kv, name, datum, kom, raw_qr_value, created_at, updated_at, client_updated_at",
+        )
+        .eq("project_id", projectId)
+        .order("updated_at", { ascending: false });
+
+      if (error) throw error;
+
+      return ((data ?? []) as IPriwaKaeferbaumRow[])
+        .map(rowToPoint)
+        .filter((point): point is IPriwaPoint => point !== null);
+    },
+    staleTime: 30 * 1000,
+  });
+
+  const invalidatePoints = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: priwaPointsQueryKey(projectId),
+    });
+  };
+
+  const createPoint = useMutation({
+    mutationFn: async (point: IPriwaPoint) => {
+      if (!projectId) throw new Error("PRIWA project membership is required.");
+
+      const { error } = await supabase
+        .from("priwa_kaeferbaeume")
+        .insert(pointToRow(projectId, point));
+
+      if (error) throw error;
+    },
+    onSuccess: invalidatePoints,
+  });
+
+  const updatePoint = useMutation({
+    mutationFn: async (point: IPriwaPoint) => {
+      if (!projectId) throw new Error("PRIWA project membership is required.");
+
+      const { error } = await supabase
+        .from("priwa_kaeferbaeume")
+        .update(pointToRow(projectId, point))
+        .eq("id", point.id);
+
+      if (error) throw error;
+    },
+    onSuccess: invalidatePoints,
+  });
+
+  const deletePoint = useMutation({
+    mutationFn: async (pointId: string) => {
+      const { error } = await supabase
+        .from("priwa_kaeferbaeume")
+        .update({ deleted_at: new Date().toISOString() })
+        .eq("id", pointId);
+
+      if (error) throw error;
+    },
+    onSuccess: invalidatePoints,
+  });
+
+  return {
+    points: pointsQuery.data ?? [],
+    isLoading: pointsQuery.isLoading,
+    isRefetching: pointsQuery.isRefetching,
+    error: pointsQuery.error,
+    createPoint: createPoint.mutateAsync,
+    updatePoint: updatePoint.mutateAsync,
+    deletePoint: deletePoint.mutateAsync,
+    isSaving:
+      createPoint.isPending || updatePoint.isPending || deletePoint.isPending,
+  };
+}

--- a/frontend/src/hooks/usePriwaProjectMemberships.ts
+++ b/frontend/src/hooks/usePriwaProjectMemberships.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useAuth } from "./useAuthProvider";
+import { supabase } from "./useSupabase";
+
+export interface IPriwaProjectMembership {
+  projectId: string;
+  projectName: string;
+  projectSlug: string;
+  role: "field_user" | "coordinator" | "admin";
+}
+
+interface IPriwaMembershipRow {
+  project_id: string;
+  role: IPriwaProjectMembership["role"];
+  priwa_projects:
+    | {
+        id: string;
+        name: string;
+        slug: string;
+      }
+    | Array<{
+        id: string;
+        name: string;
+        slug: string;
+      }>
+    | null;
+}
+
+const firstProject = (project: IPriwaMembershipRow["priwa_projects"]) =>
+  Array.isArray(project) ? (project[0] ?? null) : project;
+
+export function usePriwaProjectMemberships() {
+  const { status } = useAuth();
+
+  return useQuery({
+    queryKey: ["priwa-project-memberships"],
+    enabled: status === "authenticated",
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("priwa_project_memberships")
+        .select("project_id, role, priwa_projects(id, slug, name)")
+        .order("created_at", { ascending: true });
+
+      if (error) throw error;
+
+      return ((data ?? []) as IPriwaMembershipRow[])
+        .map((membership) => {
+          const project = firstProject(membership.priwa_projects);
+          if (!project) return null;
+
+          return {
+            projectId: membership.project_id,
+            projectName: project.name,
+            projectSlug: project.slug,
+            role: membership.role,
+          } satisfies IPriwaProjectMembership;
+        })
+        .filter((membership): membership is IPriwaProjectMembership => membership !== null);
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/usePriwaProjectMemberships.ts
+++ b/frontend/src/hooks/usePriwaProjectMemberships.ts
@@ -31,11 +31,11 @@ const firstProject = (project: IPriwaMembershipRow["priwa_projects"]) =>
   Array.isArray(project) ? (project[0] ?? null) : project;
 
 export function usePriwaProjectMemberships() {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
   return useQuery({
-    queryKey: ["priwa-project-memberships"],
-    enabled: status === "authenticated",
+    queryKey: ["priwa-project-memberships", user?.id],
+    enabled: status === "authenticated" && !!user?.id,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("priwa_project_memberships")

--- a/frontend/src/hooks/useUserLocationLayer.ts
+++ b/frontend/src/hooks/useUserLocationLayer.ts
@@ -1,0 +1,348 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import Feature from "ol/Feature";
+import type { FeatureLike } from "ol/Feature";
+import { Point } from "ol/geom";
+import Geometry from "ol/geom/Geometry";
+import { circular as circularPolygon } from "ol/geom/Polygon";
+import VectorLayer from "ol/layer/Vector";
+import { fromLonLat, toLonLat } from "ol/proj";
+import VectorSource from "ol/source/Vector";
+import { Circle as CircleStyle, Fill, Icon, Stroke, Style } from "ol/style";
+import type { Map } from "ol";
+import createKompas from "kompas";
+
+const LOCATION_HEADING_ICON_SRC = "/assets/location-heading.svg";
+
+type DeviceOrientationWithPermission = typeof DeviceOrientationEvent & {
+  requestPermission?: () => Promise<"granted" | "denied">;
+};
+
+interface KompasTracker {
+  watch(): KompasTracker;
+  clear(): KompasTracker;
+  on(eventName: "heading", callback: (heading: number) => void): KompasTracker;
+}
+
+const getGeolocationErrorMessage = (error: GeolocationPositionError) => {
+  if (!window.isSecureContext) {
+    return "Standort braucht HTTPS oder localhost. Bitte diese Testversion über eine sichere Adresse öffnen.";
+  }
+
+  if (error.code === error.PERMISSION_DENIED) {
+    return "Standort ist blockiert. Bitte Standort für diese Website und Safari/Brave in den System- und Browser-Einstellungen erlauben.";
+  }
+
+  if (error.code === error.POSITION_UNAVAILABLE) {
+    return "Standort ist gerade nicht verfügbar. Auf macOS hilft oft WLAN aktivieren, weil Safari/Brave Standort über Systemdienste beziehen.";
+  }
+
+  if (error.code === error.TIMEOUT) {
+    return "Standortabfrage hat zu lange gedauert. Bitte draußen oder mit besserem Empfang erneut versuchen.";
+  }
+
+  return "Standort konnte nicht ermittelt werden.";
+};
+
+const userAccuracyStyle = new Style({
+  fill: new Fill({ color: "rgba(59, 130, 246, 0.16)" }),
+  stroke: new Stroke({ color: "rgba(59, 130, 246, 0.32)", width: 1.5 }),
+});
+
+const userLocationStyle = (feature: FeatureLike) => {
+  if (feature.getGeometry()?.getType() === "Polygon") {
+    return userAccuracyStyle;
+  }
+
+  const heading = feature.get("heading");
+  const rotation =
+    typeof heading === "number" && Number.isFinite(heading)
+      ? (heading * Math.PI) / 180
+      : 0;
+
+  return [
+    new Style({
+      image: new Icon({
+        src: LOCATION_HEADING_ICON_SRC,
+        anchor: [0.5, 0.5],
+        anchorXUnits: "fraction",
+        anchorYUnits: "fraction",
+        rotateWithView: true,
+        rotation,
+        scale: 0.9,
+      }),
+      zIndex: 61,
+    }),
+    new Style({
+      image: new CircleStyle({
+        radius: 5.5,
+        fill: new Fill({ color: "rgba(37, 99, 235, 0.98)" }),
+        stroke: new Stroke({ color: "rgba(255,255,255,0.96)", width: 2.5 }),
+      }),
+      zIndex: 62,
+    }),
+  ];
+};
+
+export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
+  const geolocationWatchIdRef = useRef<number | null>(null);
+  const userLocationFeatureRef = useRef<Feature<Point> | null>(null);
+  const userAccuracyFeatureRef = useRef<Feature<Geometry> | null>(null);
+  const shouldAnimateToUserRef = useRef(false);
+  const compassTrackerRef = useRef<KompasTracker | null>(null);
+
+  const [isTracking, setIsTracking] = useState(false);
+  const [isLocating, setIsLocating] = useState(false);
+  const [hasFix, setHasFix] = useState(false);
+  const [hasZoomedToUser, setHasZoomedToUser] = useState(false);
+  const [isHeadingActive, setIsHeadingActive] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [currentCoordinate, setCurrentCoordinate] = useState<{
+    lat: number;
+    lon: number;
+  } | null>(null);
+
+  const layer = useMemo(
+    () =>
+      new VectorLayer({
+        source: new VectorSource<Feature<Geometry>>(),
+        style: userLocationStyle,
+        zIndex: 60,
+      }),
+    [],
+  );
+
+  const animateToUserLocation = useCallback(
+    (coordinates: number[]) => {
+      const view = mapRef.current?.getView();
+      if (!view) return;
+
+      view.animate({
+        center: coordinates,
+        zoom: Math.max(view.getZoom() || 0, 18),
+        duration: 600,
+      });
+      setHasZoomedToUser(true);
+    },
+    [mapRef],
+  );
+
+  const updateUserHeading = useCallback((heading: number | null) => {
+    const userFeature = userLocationFeatureRef.current;
+    if (
+      !userFeature ||
+      typeof heading !== "number" ||
+      !Number.isFinite(heading)
+    )
+      return;
+
+    userFeature.set("heading", heading);
+    userFeature.changed();
+    setIsHeadingActive(true);
+  }, []);
+
+  const updateUserLocationFeature = useCallback(
+    (
+      coordinates: number[],
+      accuracyInMeters?: number | null,
+      heading?: number | null,
+    ) => {
+      const userLocationSource = layer.getSource();
+      if (!userLocationSource) return;
+
+      let userFeature = userLocationFeatureRef.current;
+      if (!userFeature) {
+        userFeature = new Feature({ geometry: new Point(coordinates) });
+        userLocationFeatureRef.current = userFeature;
+        userLocationSource.addFeature(userFeature);
+      } else {
+        userFeature.setGeometry(new Point(coordinates));
+      }
+
+      let accuracyFeature = userAccuracyFeatureRef.current;
+      if (
+        typeof accuracyInMeters === "number" &&
+        Number.isFinite(accuracyInMeters) &&
+        accuracyInMeters > 0
+      ) {
+        const accuracyGeometry = circularPolygon(
+          toLonLat(coordinates),
+          accuracyInMeters,
+          64,
+        );
+        accuracyGeometry.transform(
+          "EPSG:4326",
+          mapRef.current?.getView().getProjection() ?? "EPSG:3857",
+        );
+
+        if (!accuracyFeature) {
+          accuracyFeature = new Feature({ geometry: accuracyGeometry });
+          userAccuracyFeatureRef.current = accuracyFeature;
+          userLocationSource.addFeature(accuracyFeature);
+        } else {
+          accuracyFeature.setGeometry(accuracyGeometry);
+        }
+        accuracyFeature.changed();
+      } else if (accuracyFeature) {
+        userLocationSource.removeFeature(accuracyFeature);
+        userAccuracyFeatureRef.current = null;
+      }
+
+      if (typeof heading === "number" && Number.isFinite(heading)) {
+        userFeature.set("heading", heading);
+        setIsHeadingActive(true);
+      }
+
+      userFeature.changed();
+      setHasFix(true);
+    },
+    [layer, mapRef],
+  );
+
+  const startOrientationTracking = useCallback(
+    async (requestPermission: boolean) => {
+      if (
+        typeof window === "undefined" ||
+        typeof DeviceOrientationEvent === "undefined"
+      )
+        return;
+
+      const OrientationEventWithPermission =
+        DeviceOrientationEvent as DeviceOrientationWithPermission;
+      if (
+        requestPermission &&
+        typeof OrientationEventWithPermission.requestPermission === "function"
+      ) {
+        try {
+          const permission =
+            await OrientationEventWithPermission.requestPermission();
+          if (permission !== "granted") return;
+        } catch {
+          return;
+        }
+      } else if (
+        !requestPermission &&
+        typeof OrientationEventWithPermission.requestPermission === "function"
+      ) {
+        return;
+      }
+
+      if (compassTrackerRef.current) return;
+
+      const tracker = createKompas().on("heading", updateUserHeading).watch();
+      compassTrackerRef.current = tracker;
+      setIsHeadingActive(true);
+    },
+    [updateUserHeading],
+  );
+
+  const stop = useCallback(() => {
+    if (geolocationWatchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(geolocationWatchIdRef.current);
+      geolocationWatchIdRef.current = null;
+    }
+
+    compassTrackerRef.current?.clear();
+    compassTrackerRef.current = null;
+    setIsTracking(false);
+    setIsLocating(false);
+    setIsHeadingActive(false);
+  }, []);
+
+  const locateUser = useCallback(
+    async (requestOrientationPermission = false) => {
+      if (!navigator.geolocation) {
+        setLocationError("Dieser Browser unterstützt keine Standortabfrage.");
+        return;
+      }
+
+      if (!window.isSecureContext) {
+        setLocationError(
+          "Standort braucht HTTPS oder localhost. Bitte diese Testversion über eine sichere Adresse öffnen.",
+        );
+        return;
+      }
+
+      try {
+        const permissionStatus = await navigator.permissions?.query({
+          name: "geolocation" as PermissionName,
+        });
+        if (permissionStatus?.state === "denied") {
+          setLocationError(
+            "Standort ist im Browser blockiert. Bitte Website-Einstellungen für diese Adresse zurücksetzen oder Standort erlauben.",
+          );
+          return;
+        }
+      } catch {
+        // Safari may not expose a useful Permissions API state for geolocation.
+      }
+
+      setLocationError(null);
+      void startOrientationTracking(requestOrientationPermission);
+      shouldAnimateToUserRef.current = true;
+      setIsTracking(true);
+      setIsLocating(true);
+
+      const existingCoordinates = userLocationFeatureRef.current
+        ?.getGeometry()
+        ?.getCoordinates();
+      if (existingCoordinates) {
+        animateToUserLocation(existingCoordinates);
+        shouldAnimateToUserRef.current = false;
+        setIsLocating(false);
+      }
+
+      if (geolocationWatchIdRef.current !== null) return;
+
+      geolocationWatchIdRef.current = navigator.geolocation.watchPosition(
+        (position) => {
+          const { latitude, longitude } = position.coords;
+          const center = fromLonLat([longitude, latitude]);
+          const heading =
+            typeof position.coords.heading === "number" &&
+            Number.isFinite(position.coords.heading)
+              ? position.coords.heading
+              : null;
+
+          setCurrentCoordinate({ lat: latitude, lon: longitude });
+          updateUserLocationFeature(center, position.coords.accuracy, heading);
+          if (shouldAnimateToUserRef.current) {
+            animateToUserLocation(center);
+            shouldAnimateToUserRef.current = false;
+          }
+          setIsTracking(true);
+          setIsLocating(false);
+        },
+        (error) => {
+          setLocationError(getGeolocationErrorMessage(error));
+          stop();
+          shouldAnimateToUserRef.current = false;
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 120000,
+        },
+      );
+    },
+    [
+      animateToUserLocation,
+      startOrientationTracking,
+      stop,
+      updateUserLocationFeature,
+    ],
+  );
+
+  return {
+    layer,
+    locateUser,
+    stop,
+    isTracking,
+    isLocating,
+    hasFix,
+    hasZoomedToUser,
+    isHeadingActive,
+    locationError,
+    currentCoordinate,
+  };
+};

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -1,0 +1,76 @@
+import PriwaFieldMap from "../components/PriwaField/PriwaFieldMap";
+import { usePriwaKaeferbaeume } from "../components/PriwaField/usePriwaKaeferbaeume";
+import { usePriwaProjectMemberships } from "../hooks/usePriwaProjectMemberships";
+import { Alert, Result, Spin } from "antd";
+
+export default function PriwaField() {
+  const {
+    data: memberships = [],
+    error: membershipError,
+    isLoading: isLoadingMemberships,
+  } = usePriwaProjectMemberships();
+  const activeMembership = memberships[0] ?? null;
+  const {
+    points,
+    isLoading: isLoadingPoints,
+    isRefetching,
+    error: pointsError,
+    createPoint,
+    updatePoint,
+    deletePoint,
+    isSaving,
+  } = usePriwaKaeferbaeume(activeMembership?.projectId);
+
+  if (isLoadingMemberships) {
+    return (
+      <div className="flex min-h-[100dvh] items-center justify-center bg-slate-950 text-white">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (membershipError) {
+    return (
+      <div className="flex min-h-[100dvh] items-center justify-center bg-slate-50 p-6">
+        <Alert
+          type="error"
+          showIcon
+          message="PRIWA Mitgliedschaft konnte nicht geprüft werden"
+          description={
+            membershipError instanceof Error
+              ? membershipError.message
+              : "Bitte später erneut versuchen."
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!activeMembership) {
+    return (
+      <div className="flex min-h-[100dvh] items-center justify-center bg-slate-50 p-6">
+        <Result
+          status="403"
+          title="Kein PRIWA Zugriff"
+          subTitle="Diese Feldkarte ist nur für Mitglieder eines PRIWA Projekts verfügbar."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <PriwaFieldMap
+      points={points}
+      projectName={activeMembership.projectName}
+      isLoadingPoints={isLoadingPoints || isRefetching}
+      isSavingPoint={isSaving}
+      cogPath={null}
+      errorMessage={
+        pointsError instanceof Error ? pointsError.message : null
+      }
+      onAddPoint={createPoint}
+      onUpdatePoint={updatePoint}
+      onDeletePoint={deletePoint}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add the production /priwa-field route for authenticated PRIWA members
- reuse the tested DT-474 map, QR scanner, point drawer, and user-location UX
- replace local-only point storage with Supabase reads, inserts, updates, and soft deletes against priwa_kaeferbaeume
- show PRIWA navigation only for users with project membership

## Validation
- npm run build
- npm run lint
- npm run test -- PriwaField
- scripts/lint-ast-grep.sh
- browser smoke: /priwa-field redirects anonymous users to /sign-in?returnTo=%2Fpriwa-field with the local env profile loaded

## Notes
- Drone dataset layer selection and offline storage/sync are intentionally left for follow-up PRIWA PRs.
- Local browser smoke logged a Supabase realtime connection refusal because the local Supabase stack was not running; the route and auth redirect still rendered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated route with camera/geolocation access and new Supabase read/write/soft-delete paths for PRIWA points; failures or schema/permission mismatches could break the new page or data integrity for field users.
> 
> **Overview**
> Introduces a new authenticated ` /priwa-field ` page for PRIWA project members, including full-height layout handling and conditional “PRIWA” navigation that only appears when `usePriwaProjectMemberships` returns memberships.
> 
> Adds a new OpenLayers-based field map workflow to capture/edit “Käferbaum” points (QR scan/manual coordinate parsing, GPS/map placement, preview + styling), plus a new `useUserLocationLayer` hook for live location/heading display.
> 
> Replaces local-only point handling with Supabase-backed CRUD via `usePriwaKaeferbaeume` (query, insert, update, and soft delete via `deleted_at`) and includes tests for robust Google Maps/coordinate parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c1712ff88cfce1f436f8e6800921dd88c5f6ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->