### PR TITLE
feat(priwa): add point list qa panel

### DIFF
--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -249,6 +249,9 @@ export default function PriwaFieldMap({
     userLocation.isTracking &&
     userLocation.hasFix &&
     userLocation.hasZoomedToUser;
+  const pointListToggleLabel = isPointListOpen
+    ? "Punktliste schließen"
+    : "Punktliste öffnen";
 
   const handleAddPoint = useCallback(
     async (point: IPriwaPoint) => {
@@ -339,17 +342,18 @@ export default function PriwaFieldMap({
                 aria-label="Layer auswählen"
               />
             </Popover>
-            <Tooltip title="Punktliste">
+            <Tooltip title={pointListToggleLabel}>
               <Button
                 className="pointer-events-auto shadow-md"
                 type={isPointListOpen ? "primary" : "default"}
                 shape="circle"
                 size="large"
                 icon={<UnorderedListOutlined />}
+                aria-pressed={isPointListOpen}
                 onClick={() =>
                   setPointListOpen((currentIsOpen) => !currentIsOpen)
                 }
-                aria-label="Punktliste öffnen"
+                aria-label={pointListToggleLabel}
               />
             </Tooltip>
           </div>

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -4,6 +4,7 @@ import {
   EnvironmentOutlined,
   PlusOutlined,
   SlidersOutlined,
+  UnorderedListOutlined,
 } from "@ant-design/icons";
 import "ol/ol.css";
 import { Map } from "ol";
@@ -25,6 +26,7 @@ import {
   createPriwaPreviewLayer,
 } from "./createPriwaPointLayer";
 import PriwaPointDrawer from "./PriwaPointDrawer";
+import PriwaPointListPanel from "./PriwaPointListPanel";
 import type {
   IPriwaCoordinate,
   IPriwaPoint,
@@ -77,12 +79,22 @@ export default function PriwaFieldMap({
     useState<PriwaCoordinateSource>("qr");
   const [editingPoint, setEditingPoint] = useState<IPriwaPoint | null>(null);
   const [formSessionId, setFormSessionId] = useState(0);
+  const [isPointListOpen, setPointListOpen] = useState(false);
   const userLocation = useUserLocationLayer(mapRef);
   const {
     layer: userLocationLayer,
     locateUser,
     stop: stopUserLocation,
   } = userLocation;
+
+  const openPointForEditing = useCallback((point: IPriwaPoint) => {
+    setPointListOpen(false);
+    setFormSessionId((currentSessionId) => currentSessionId + 1);
+    setEditingPoint(point);
+    setSelectedCoordinate({ lat: point.lat, lon: point.lon });
+    setSelectedCoordinateSource(point.coordinateSource);
+    setDrawerOpen(true);
+  }, []);
 
   useEffect(() => {
     isPlacingPointRef.current = isPlacingPoint;
@@ -140,11 +152,7 @@ export default function PriwaFieldMap({
       );
 
       if (pointFeature) {
-        setFormSessionId((currentSessionId) => currentSessionId + 1);
-        setEditingPoint(pointFeature);
-        setSelectedCoordinate({ lat: pointFeature.lat, lon: pointFeature.lon });
-        setSelectedCoordinateSource(pointFeature.coordinateSource);
-        setDrawerOpen(true);
+        openPointForEditing(pointFeature);
       }
     });
 
@@ -157,7 +165,7 @@ export default function PriwaFieldMap({
       previewLayerRef.current = null;
       cogLayerRef.current = null;
     };
-  }, [locateUser, stopUserLocation, userLocationLayer]);
+  }, [locateUser, openPointForEditing, stopUserLocation, userLocationLayer]);
 
   useEffect(() => {
     const source = pointLayerRef.current?.getSource();
@@ -207,6 +215,7 @@ export default function PriwaFieldMap({
   }, []);
 
   const openNewPointDrawer = useCallback(() => {
+    setPointListOpen(false);
     setFormSessionId((currentSessionId) => currentSessionId + 1);
     setEditingPoint(null);
     setSelectedCoordinate(null);
@@ -215,6 +224,7 @@ export default function PriwaFieldMap({
   }, []);
 
   const requestMapPlacement = useCallback(() => {
+    setPointListOpen(false);
     setDrawerOpen(false);
     setPlacingPoint(true);
   }, []);
@@ -329,22 +339,48 @@ export default function PriwaFieldMap({
                 aria-label="Layer auswählen"
               />
             </Popover>
-          </div>
-
-          <div className="pointer-events-none absolute bottom-5 right-5 z-[60]">
-            <Tooltip title="Punkt aufnehmen" placement="left">
+            <Tooltip title="Punktliste">
               <Button
-                className="pointer-events-auto shadow-lg"
-                type="primary"
+                className="pointer-events-auto shadow-md"
+                type={isPointListOpen ? "primary" : "default"}
                 shape="circle"
                 size="large"
-                icon={<PlusOutlined />}
-                onClick={openNewPointDrawer}
-                aria-label="Punkt aufnehmen"
+                icon={<UnorderedListOutlined />}
+                onClick={() =>
+                  setPointListOpen((currentIsOpen) => !currentIsOpen)
+                }
+                aria-label="Punktliste öffnen"
               />
             </Tooltip>
           </div>
+
+          {!isPointListOpen && (
+            <div className="pointer-events-none absolute bottom-5 right-5 z-[60]">
+              <Tooltip title="Punkt aufnehmen" placement="left">
+                <Button
+                  className="pointer-events-auto shadow-lg"
+                  type="primary"
+                  shape="circle"
+                  size="large"
+                  icon={<PlusOutlined />}
+                  onClick={openNewPointDrawer}
+                  aria-label="Punkt aufnehmen"
+                />
+              </Tooltip>
+            </div>
+          )}
         </>
+      )}
+
+      {isPointListOpen && !isPlacingPoint && (
+        <PriwaPointListPanel
+          points={points}
+          projectName={projectName}
+          isLoading={isLoadingPoints}
+          onClose={() => setPointListOpen(false)}
+          onEditPoint={openPointForEditing}
+          onZoomToPoint={zoomToCoordinate}
+        />
       )}
 
       {isPlacingPoint && (

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,0 +1,164 @@
+import {
+  AimOutlined,
+  CheckCircleFilled,
+  EditOutlined,
+  EnvironmentOutlined,
+  WarningFilled,
+} from "@ant-design/icons";
+import { Button, Empty, Segmented, Tag } from "antd";
+import { useMemo, useState } from "react";
+
+import {
+  getPriwaFundLabel,
+  getPriwaPointSourceLabel,
+  getPriwaPointTitle,
+  isPriwaPointQaCandidate,
+} from "./priwaPointQa";
+import type { IPriwaPoint } from "./types";
+
+type PriwaPointFilter = "all" | "qa";
+
+interface PriwaPointListPanelProps {
+  points: IPriwaPoint[];
+  projectName: string;
+  isLoading?: boolean;
+  onClose: () => void;
+  onEditPoint: (point: IPriwaPoint) => void;
+  onZoomToPoint: (point: IPriwaPoint) => void;
+}
+
+export default function PriwaPointListPanel({
+  points,
+  projectName,
+  isLoading = false,
+  onClose,
+  onEditPoint,
+  onZoomToPoint,
+}: PriwaPointListPanelProps) {
+  const [filter, setFilter] = useState<PriwaPointFilter>("all");
+  const qaPoints = useMemo(
+    () => points.filter(isPriwaPointQaCandidate),
+    [points],
+  );
+  const exactCount = points.filter(
+    (point) => point.coordinateSource === "qr",
+  ).length;
+  const visiblePoints = filter === "qa" ? qaPoints : points;
+
+  return (
+    <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[50dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-auto md:top-24 md:w-[390px] md:max-h-[calc(100dvh-8rem)]">
+      <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-slate-950">Käferbaum QA</div>
+          <div className="truncate text-xs text-slate-500">{projectName}</div>
+        </div>
+        <Button size="small" onClick={onClose}>
+          Schließen
+        </Button>
+      </header>
+
+      <div className="grid grid-cols-3 border-b border-slate-200 text-center text-xs">
+        <div className="px-2 py-2">
+          <div className="text-base font-semibold text-slate-950">{points.length}</div>
+          <div className="text-slate-500">Gesamt</div>
+        </div>
+        <div className="border-x border-slate-200 px-2 py-2">
+          <div className="text-base font-semibold text-emerald-700">{exactCount}</div>
+          <div className="text-slate-500">Exakt</div>
+        </div>
+        <div className="px-2 py-2">
+          <div className="text-base font-semibold text-amber-700">{qaPoints.length}</div>
+          <div className="text-slate-500">QA</div>
+        </div>
+      </div>
+
+      <div className="border-b border-slate-200 px-3 py-2">
+        <Segmented
+          block
+          size="small"
+          value={filter}
+          onChange={(value) => setFilter(value as PriwaPointFilter)}
+          options={[
+            { label: "Alle", value: "all" },
+            { label: "QA prüfen", value: "qa" },
+          ]}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {visiblePoints.length === 0 ? (
+          <div className="px-3 py-8">
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={isLoading ? "Lade Punkte..." : "Keine Punkte"}
+            />
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-100">
+            {visiblePoints.map((point) => {
+              const isQa = isPriwaPointQaCandidate(point);
+              return (
+                <article
+                  key={point.id}
+                  className="grid grid-cols-[1fr_auto] gap-2 px-3 py-2.5"
+                >
+                  <button
+                    type="button"
+                    className="min-w-0 text-left"
+                    onClick={() => onZoomToPoint(point)}
+                  >
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      {isQa ? (
+                        <WarningFilled className="shrink-0 text-amber-500" />
+                      ) : (
+                        <CheckCircleFilled className="shrink-0 text-emerald-600" />
+                      )}
+                      <span className="truncate text-sm font-semibold text-slate-950">
+                        {getPriwaPointTitle(point)}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                      <Tag
+                        className="m-0"
+                        color={point.coordinateSource === "qr" ? "green" : "gold"}
+                      >
+                        {getPriwaPointSourceLabel(point)}
+                      </Tag>
+                      <Tag className="m-0">{getPriwaFundLabel(point)}</Tag>
+                      <span className="text-xs text-slate-500">{point.baumart}</span>
+                      <span className="text-xs text-slate-400">·</span>
+                      <span className="text-xs text-slate-500">{point.name}</span>
+                    </div>
+                    <div className="mt-1 truncate text-xs text-slate-500">
+                      {point.lat.toFixed(5)}, {point.lon.toFixed(5)} ·{" "}
+                      {point.datum}
+                    </div>
+                  </button>
+                  <div className="flex items-start gap-1">
+                    <Button
+                      aria-label="Punkt auf Karte zeigen"
+                      icon={<AimOutlined />}
+                      size="small"
+                      onClick={() => onZoomToPoint(point)}
+                    />
+                    <Button
+                      aria-label="Punkt bearbeiten"
+                      icon={<EditOutlined />}
+                      size="small"
+                      onClick={() => onEditPoint(point)}
+                    />
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <footer className="flex items-center gap-2 border-t border-slate-200 px-3 py-2 text-xs text-slate-500">
+        <EnvironmentOutlined />
+        <span>QA markiert geschätzte Lagen oder Punkte ohne Baumnr.</span>
+      </footer>
+    </section>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -44,6 +44,12 @@ export default function PriwaPointListPanel({
     (point) => point.coordinateSource === "qr",
   ).length;
   const visiblePoints = filter === "qa" ? qaPoints : points;
+  const emptyDescription =
+    isLoading
+      ? "Lade Punkte..."
+      : filter === "qa" && points.length > 0
+        ? "Keine QA-Punkte"
+        : "Keine Punkte";
 
   return (
     <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[50dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-auto md:top-24 md:w-[390px] md:max-h-[calc(100dvh-8rem)]">
@@ -90,7 +96,7 @@ export default function PriwaPointListPanel({
           <div className="px-3 py-8">
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description={isLoading ? "Lade Punkte..." : "Keine Punkte"}
+              description={emptyDescription}
             />
           </div>
         ) : (

--- a/frontend/src/components/PriwaField/priwaPointQa.test.ts
+++ b/frontend/src/components/PriwaField/priwaPointQa.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPriwaFundLabel,
+  getPriwaPointSourceLabel,
+  getPriwaPointTitle,
+  isPriwaPointQaCandidate,
+} from "./priwaPointQa";
+import type { IPriwaPoint } from "./types";
+
+const basePoint: IPriwaPoint = {
+  id: "point-1",
+  lat: 48.45596,
+  lon: 8.18013,
+  baumnr: "42",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "nein",
+  bohrloch: "nein",
+  harz: "nein",
+  nadel: "grün",
+  rinde: "0%",
+  kv: "0%",
+  name: "andere",
+  datum: "2026-05-19",
+  kom: "",
+  capturedAt: "2026-05-19T12:00:00.000Z",
+  coordinateSource: "qr",
+  gps: "ja",
+};
+
+describe("PRIWA point QA helpers", () => {
+  it("does not flag QR points with a tree number", () => {
+    expect(isPriwaPointQaCandidate(basePoint)).toBe(false);
+  });
+
+  it("flags estimated locations and missing tree numbers for QA", () => {
+    expect(
+      isPriwaPointQaCandidate({ ...basePoint, coordinateSource: "gps" }),
+    ).toBe(true);
+    expect(isPriwaPointQaCandidate({ ...basePoint, baumnr: " " })).toBe(true);
+  });
+
+  it("formats list labels from point state", () => {
+    expect(getPriwaPointSourceLabel(basePoint)).toBe("QR");
+    expect(getPriwaFundLabel({ ...basePoint, fund: "ja_kein_buchdrucker" }))
+      .toBe("Ja, kein Buchdrucker");
+    expect(getPriwaPointTitle({ ...basePoint, baumnr: "" })).toBe(
+      "Ohne Baumnr · 2026-05-19",
+    );
+  });
+});

--- a/frontend/src/components/PriwaField/priwaPointQa.ts
+++ b/frontend/src/components/PriwaField/priwaPointQa.ts
@@ -1,0 +1,20 @@
+import type { IPriwaPoint } from "./types";
+
+export const getPriwaPointSourceLabel = (point: IPriwaPoint) => {
+  if (point.coordinateSource === "qr") return "QR";
+  if (point.coordinateSource === "gps") return "GPS";
+  return "Karte";
+};
+
+export const getPriwaFundLabel = (point: IPriwaPoint) => {
+  if (point.fund === "ja_kein_buchdrucker") return "Ja, kein Buchdrucker";
+  if (point.fund === "ja") return "Ja";
+  if (point.fund === "nein") return "Nein";
+  return "Unsicher";
+};
+
+export const isPriwaPointQaCandidate = (point: IPriwaPoint) =>
+  point.coordinateSource !== "qr" || point.baumnr.trim().length === 0;
+
+export const getPriwaPointTitle = (point: IPriwaPoint) =>
+  point.baumnr.trim() || `Ohne Baumnr · ${point.datum}`;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -255,4 +255,16 @@
   textarea.ant-input {
     font-size: 16px !important;
   }
+
+  .priwa-point-drawer-root .ant-input,
+  .priwa-point-drawer-root .ant-input-affix-wrapper,
+  .priwa-point-drawer-root .ant-input-affix-wrapper input,
+  .priwa-point-drawer-root .ant-input-textarea textarea,
+  .priwa-point-drawer-root textarea.ant-input,
+  .priwa-point-drawer-root .ant-select-selector,
+  .priwa-point-drawer-root .ant-select-selection-item,
+  .priwa-point-drawer-root .ant-select-selection-placeholder,
+  .priwa-point-drawer-root .ant-select-selection-search-input {
+    font-size: 16px !important;
+  }
 }


### PR DESCRIPTION
## Summary
- add a PRIWA field-map point list panel with total/exact/QA counts and an all-vs-QA filter
- support zooming to a point and opening the existing point drawer from list rows
- fix iOS Safari input zoom in the PRIWA drawer by forcing mobile input/select controls to 16px

## Validation
- npm run lint
- npm test
- npm run build
- scripts/lint-ast-grep.sh
- Browser prod-profile smoke: signed in and opened /priwa-field, opened the empty point list panel, opened the drawer, no console errors
- Browser local seeded smoke: local Supabase project/member plus 3 PRIWA points; verified list rows, QA filter, edit-from-row drawer, no console errors

## Notes
- Local Supabase seed was validation-only and not committed.
- Build still emits the existing Vite chunk/dynamic-import warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new PRIWA map UI for listing/filtering points plus small shared helper logic and CSS tweaks; no backend/data model changes, so regression risk is limited to PRIWA map interactions on mobile/desktop.
> 
> **Overview**
> Adds a new *PRIWA point list* panel on the field map that shows total/exact/QA counts, supports an All vs *QA prüfen* filter, and lets users zoom to a point or open the existing edit drawer from the list.
> 
> Refactors map click-to-edit to reuse a shared `openPointForEditing` handler, ensures opening the drawer/placement closes the list, and updates mobile CSS to force 16px font sizes for inputs/selects inside the PRIWA drawer to avoid iOS Safari zoom. Also introduces `priwaPointQa` helper functions with `vitest` coverage for QA candidate detection and list labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cae1a2c81a2c192e687bccb5293807f0bc7ae52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toggleable point list panel displaying project points with QA filtering capability
  * Point list shows detailed information including coordinates, source type, fund status, and tree details
  * Added zoom and edit actions accessible from point list

* **Improvements**
  * Simplified point selection and editing workflow
  * Enhanced mobile input styling for consistency

* **Tests**
  * Added validation tests for point QA functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->