### PR TITLE
fix(priwa): stabilize field heading

### DIFF
--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -288,22 +288,13 @@ export default function PriwaFieldMap({
       : userLocation.isLocating
         ? "Standort wird gesucht"
         : "Aktuelle Position";
-  const pointCountLabel = isLoadingPoints
-    ? "Lade Punkte"
-    : `${points.length} ${points.length === 1 ? "Punkt" : "Punkte"}`;
-  const locationStatusLabel = userLocation.locationError
+  const locationHintLabel = userLocation.locationError
     ? userLocation.locationError
-    : userLocation.isLocating
-      ? "Standort wird angefragt"
-      : userLocation.hasFix
-        ? userLocation.needsOrientationPermission
-          ? "Standort aktiv · Richtung antippen"
-          : userLocation.isHeadingActive
-            ? "Standort aktiv · Richtung"
-            : "Standort aktiv"
-        : userLocation.isTracking
-          ? "Standort wird gesucht"
-          : "Standort nicht aktiv";
+    : userLocation.needsOrientationPermission
+      ? "Richtung: Standort-Button antippen"
+      : userLocation.isLocating
+        ? "Standort wird angefragt"
+        : null;
   const pointListToggleLabel = isPointListOpen
     ? "Punktliste schließen"
     : "Punktliste öffnen";
@@ -470,11 +461,11 @@ export default function PriwaFieldMap({
 
       {!isPlacingPoint && (
         <div className="pointer-events-none absolute right-4 top-20 z-10 flex max-w-[calc(100%-5.75rem)] flex-col items-end gap-1.5 md:top-24">
-          <div className="rounded-md bg-white/90 px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm backdrop-blur">
-            {userLocation.locationError
-              ? locationStatusLabel
-              : `${projectName} · ${pointCountLabel} · ${locationStatusLabel}`}
-          </div>
+          {locationHintLabel && (
+            <div className="rounded-md bg-white/90 px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm backdrop-blur">
+              {locationHintLabel}
+            </div>
+          )}
           <PriwaOfflineStatus />
         </div>
       )}

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -23,6 +23,7 @@ import { unByKey } from "ol/Observable";
 import { fromLonLat, toLonLat } from "ol/proj";
 import View from "ol/View";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { PointerEvent } from "react";
 
 import { createStandardMapControls } from "../../utils/basemaps";
 import { useUserLocationLayer } from "../../hooks/useUserLocationLayer";
@@ -73,6 +74,7 @@ export default function PriwaFieldMap({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
   const isPlacingPointRef = useRef(false);
+  const hasRequestedOrientationFromInteractionRef = useRef(false);
   const pointLayerRef = useRef<ReturnType<typeof createPriwaPointLayer> | null>(
     null,
   );
@@ -255,10 +257,49 @@ export default function PriwaFieldMap({
     setDrawerOpen(true);
   }, []);
 
+  const requestDeferredOrientationPermission = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!userLocation.needsOrientationPermission) return;
+      if (
+        event.target instanceof Element &&
+        event.target.closest("button,[role='button']")
+      )
+        return;
+      if (hasRequestedOrientationFromInteractionRef.current) return;
+
+      hasRequestedOrientationFromInteractionRef.current = true;
+      void locateUser(true);
+    },
+    [locateUser, userLocation.needsOrientationPermission],
+  );
+
   const locationButtonActive =
     userLocation.isTracking &&
     userLocation.hasFix &&
     userLocation.hasZoomedToUser;
+  const locationButtonTitle = userLocation.locationError
+    ? "Standort erneut anfragen"
+    : userLocation.needsOrientationPermission
+      ? "Richtung aktivieren"
+      : userLocation.isLocating
+        ? "Standort wird gesucht"
+        : "Aktuelle Position";
+  const pointCountLabel = isLoadingPoints
+    ? "Lade Punkte"
+    : `${points.length} ${points.length === 1 ? "Punkt" : "Punkte"}`;
+  const locationStatusLabel = userLocation.locationError
+    ? userLocation.locationError
+    : userLocation.isLocating
+      ? "Standort wird angefragt"
+      : userLocation.hasFix
+        ? userLocation.needsOrientationPermission
+          ? "Standort aktiv · Richtung antippen"
+          : userLocation.isHeadingActive
+            ? "Standort aktiv · Richtung"
+            : "Standort aktiv"
+        : userLocation.isTracking
+          ? "Standort wird gesucht"
+          : "Standort nicht aktiv";
   const pointListToggleLabel = isPointListOpen
     ? "Punktliste schließen"
     : "Punktliste öffnen";
@@ -320,16 +361,23 @@ export default function PriwaFieldMap({
   );
 
   return (
-    <div className="relative h-full min-h-[100dvh] w-full overflow-hidden bg-neutral-950">
+    <div
+      className="relative h-full min-h-[100dvh] w-full overflow-hidden bg-neutral-950"
+      onPointerDownCapture={requestDeferredOrientationPermission}
+    >
       <div ref={containerRef} className="absolute inset-0" />
 
       {!isPlacingPoint && (
         <>
           <div className="pointer-events-none absolute left-4 top-20 z-10 flex flex-col gap-2 md:top-24">
-            <Tooltip title="Aktuelle Position">
+            <Tooltip title={locationButtonTitle}>
               <Button
                 className="pointer-events-auto shadow-md"
-                type={locationButtonActive ? "primary" : "default"}
+                type={
+                  locationButtonActive || userLocation.hasFix
+                    ? "primary"
+                    : "default"
+                }
                 shape="circle"
                 size="large"
                 icon={
@@ -419,13 +467,9 @@ export default function PriwaFieldMap({
       {!isPlacingPoint && (
         <div className="pointer-events-none absolute right-4 top-20 z-10 flex max-w-[calc(100%-5.75rem)] flex-col items-end gap-1.5 md:top-24">
           <div className="rounded-md bg-white/90 px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm backdrop-blur">
-            {userLocation.locationError ??
-              `${projectName} · ${
-                isLoadingPoints
-                  ? "Lade Punkte"
-                  : `${points.length} ${points.length === 1 ? "Punkt" : "Punkte"}`
-              }`}
-            {userLocation.isHeadingActive ? " · Richtung" : ""}
+            {userLocation.locationError
+              ? locationStatusLabel
+              : `${projectName} · ${pointCountLabel} · ${locationStatusLabel}`}
           </div>
           <PriwaOfflineStatus />
         </div>

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -147,7 +147,6 @@ export default function PriwaFieldMap({
     });
 
     mapRef.current = map;
-    locateUser(false);
 
     const clickKey = map.on("singleclick", (event) => {
       if (isPlacingPointRef.current) return;
@@ -177,7 +176,7 @@ export default function PriwaFieldMap({
       previewLayerRef.current = null;
       cogLayerRef.current = null;
     };
-  }, [locateUser, openPointForEditing, stopUserLocation, userLocationLayer]);
+  }, [openPointForEditing, stopUserLocation, userLocationLayer]);
 
   useEffect(() => {
     const source = pointLayerRef.current?.getSource();
@@ -294,7 +293,9 @@ export default function PriwaFieldMap({
       ? "Richtung: Standort-Button antippen"
       : userLocation.isLocating
         ? "Standort wird angefragt"
-        : null;
+        : locationButtonActive
+          ? null
+          : "Standort-Button antippen";
   const pointListToggleLabel = isPointListOpen
     ? "Punktliste schließen"
     : "Punktliste öffnen";

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -273,10 +273,14 @@ export default function PriwaFieldMap({
     [locateUser, userLocation.needsOrientationPermission],
   );
 
-  const locationButtonActive =
+  const hasCenteredUserLocation =
     userLocation.isTracking &&
     userLocation.hasFix &&
     userLocation.hasZoomedToUser;
+  const locationButtonActive =
+    hasCenteredUserLocation &&
+    !userLocation.needsOrientationPermission &&
+    userLocation.isHeadingActive;
   const locationButtonTitle = userLocation.locationError
     ? "Standort erneut anfragen"
     : userLocation.needsOrientationPermission
@@ -372,12 +376,12 @@ export default function PriwaFieldMap({
           <div className="pointer-events-none absolute left-4 top-20 z-10 flex flex-col gap-2 md:top-24">
             <Tooltip title={locationButtonTitle}>
               <Button
-                className="pointer-events-auto shadow-md"
-                type={
-                  locationButtonActive || userLocation.hasFix
-                    ? "primary"
-                    : "default"
+                className={
+                  userLocation.needsOrientationPermission
+                    ? "pointer-events-auto border-amber-500 text-amber-700 shadow-md"
+                    : "pointer-events-auto shadow-md"
                 }
+                type={locationButtonActive ? "primary" : "default"}
                 shape="circle"
                 size="large"
                 icon={

--- a/frontend/src/hooks/headingStabilizer.test.ts
+++ b/frontend/src/hooks/headingStabilizer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getShortestHeadingDelta,
+  normalizeHeading,
+  shouldUseGpsHeading,
+  smoothHeading,
+} from "./headingStabilizer";
+
+describe("heading stabilizer", () => {
+  it("normalizes headings into the compass circle", () => {
+    expect(normalizeHeading(370)).toBe(10);
+    expect(normalizeHeading(-10)).toBe(350);
+    expect(normalizeHeading(720)).toBe(0);
+  });
+
+  it("uses the shortest turn across the north boundary", () => {
+    expect(getShortestHeadingDelta(350, 10)).toBe(20);
+    expect(getShortestHeadingDelta(10, 350)).toBe(-20);
+  });
+
+  it("smooths headings without jumping through the long arc", () => {
+    expect(smoothHeading(350, 10, 0.5)).toBe(0);
+    expect(smoothHeading(10, 350, 0.5)).toBe(0);
+  });
+
+  it("starts from the first valid heading directly", () => {
+    expect(smoothHeading(null, 370, 0.25)).toBe(10);
+  });
+
+  it("only trusts GPS heading while moving", () => {
+    expect(shouldUseGpsHeading(45, 0)).toBe(false);
+    expect(shouldUseGpsHeading(45, 1.24)).toBe(false);
+    expect(shouldUseGpsHeading(45, 1.25)).toBe(true);
+    expect(shouldUseGpsHeading(null, 2)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/headingStabilizer.ts
+++ b/frontend/src/hooks/headingStabilizer.ts
@@ -1,0 +1,52 @@
+const FULL_CIRCLE_DEGREES = 360;
+const HALF_CIRCLE_DEGREES = 180;
+
+export const MINIMUM_GPS_HEADING_SPEED_MPS = 1.25;
+
+export const normalizeHeading = (heading: number) => {
+  const normalized = heading % FULL_CIRCLE_DEGREES;
+  return normalized < 0 ? normalized + FULL_CIRCLE_DEGREES : normalized;
+};
+
+export const getShortestHeadingDelta = (
+  currentHeading: number,
+  nextHeading: number,
+) => {
+  const delta =
+    normalizeHeading(nextHeading) - normalizeHeading(currentHeading);
+
+  if (delta > HALF_CIRCLE_DEGREES) {
+    return delta - FULL_CIRCLE_DEGREES;
+  }
+
+  if (delta < -HALF_CIRCLE_DEGREES) {
+    return delta + FULL_CIRCLE_DEGREES;
+  }
+
+  return delta;
+};
+
+export const smoothHeading = (
+  currentHeading: number | null,
+  nextHeading: number,
+  smoothingFactor: number,
+) => {
+  if (!Number.isFinite(nextHeading)) return currentHeading;
+  if (currentHeading === null || !Number.isFinite(currentHeading)) {
+    return normalizeHeading(nextHeading);
+  }
+
+  const boundedSmoothingFactor = Math.min(Math.max(smoothingFactor, 0), 1);
+  const delta = getShortestHeadingDelta(currentHeading, nextHeading);
+  return normalizeHeading(currentHeading + delta * boundedSmoothingFactor);
+};
+
+export const shouldUseGpsHeading = (
+  heading: number | null,
+  speedMetersPerSecond: number | null,
+) =>
+  typeof heading === "number" &&
+  Number.isFinite(heading) &&
+  typeof speedMetersPerSecond === "number" &&
+  Number.isFinite(speedMetersPerSecond) &&
+  speedMetersPerSecond >= MINIMUM_GPS_HEADING_SPEED_MPS;

--- a/frontend/src/hooks/useUserLocationLayer.ts
+++ b/frontend/src/hooks/useUserLocationLayer.ts
@@ -282,6 +282,9 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
         return;
       }
 
+      setLocationError(null);
+      void startOrientationTracking(requestOrientationPermission);
+
       try {
         const permissionStatus = await navigator.permissions?.query({
           name: "geolocation" as PermissionName,
@@ -296,8 +299,6 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
         // Safari may not expose a useful Permissions API state for geolocation.
       }
 
-      setLocationError(null);
-      void startOrientationTracking(requestOrientationPermission);
       shouldAnimateToUserRef.current = true;
       setIsTracking(true);
       setIsLocating(true);

--- a/frontend/src/hooks/useUserLocationLayer.ts
+++ b/frontend/src/hooks/useUserLocationLayer.ts
@@ -12,7 +12,11 @@ import { Circle as CircleStyle, Fill, Icon, Stroke, Style } from "ol/style";
 import type { Map } from "ol";
 import createKompas from "kompas";
 
+import { shouldUseGpsHeading, smoothHeading } from "./headingStabilizer";
+
 const LOCATION_HEADING_ICON_SRC = "/assets/location-heading.svg";
+const COMPASS_HEADING_SMOOTHING_FACTOR = 0.2;
+const GPS_HEADING_SMOOTHING_FACTOR = 0.35;
 
 type DeviceOrientationWithPermission = typeof DeviceOrientationEvent & {
   requestPermission?: () => Promise<"granted" | "denied">;
@@ -90,6 +94,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
   const userAccuracyFeatureRef = useRef<Feature<Geometry> | null>(null);
   const shouldAnimateToUserRef = useRef(false);
   const compassTrackerRef = useRef<KompasTracker | null>(null);
+  const smoothedHeadingRef = useRef<number | null>(null);
 
   const [isTracking, setIsTracking] = useState(false);
   const [isLocating, setIsLocating] = useState(false);
@@ -127,25 +132,35 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
     [mapRef],
   );
 
-  const updateUserHeading = useCallback((heading: number | null) => {
-    const userFeature = userLocationFeatureRef.current;
-    if (
-      !userFeature ||
-      typeof heading !== "number" ||
-      !Number.isFinite(heading)
-    )
-      return;
+  const updateUserHeading = useCallback(
+    (heading: number | null, smoothingFactor = COMPASS_HEADING_SMOOTHING_FACTOR) => {
+      const userFeature = userLocationFeatureRef.current;
+      if (
+        !userFeature ||
+        typeof heading !== "number" ||
+        !Number.isFinite(heading)
+      )
+        return;
 
-    userFeature.set("heading", heading);
-    userFeature.changed();
-    setIsHeadingActive(true);
-  }, []);
+      const nextSmoothedHeading = smoothHeading(
+        smoothedHeadingRef.current,
+        heading,
+        smoothingFactor,
+      );
+      if (nextSmoothedHeading === null) return;
+
+      smoothedHeadingRef.current = nextSmoothedHeading;
+      userFeature.set("heading", nextSmoothedHeading);
+      userFeature.changed();
+      setIsHeadingActive(true);
+    },
+    [],
+  );
 
   const updateUserLocationFeature = useCallback(
     (
       coordinates: number[],
       accuracyInMeters?: number | null,
-      heading?: number | null,
     ) => {
       const userLocationSource = layer.getSource();
       if (!userLocationSource) return;
@@ -186,11 +201,6 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
       } else if (accuracyFeature) {
         userLocationSource.removeFeature(accuracyFeature);
         userAccuracyFeatureRef.current = null;
-      }
-
-      if (typeof heading === "number" && Number.isFinite(heading)) {
-        userFeature.set("heading", heading);
-        setIsHeadingActive(true);
       }
 
       userFeature.changed();
@@ -244,6 +254,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
 
     compassTrackerRef.current?.clear();
     compassTrackerRef.current = null;
+    smoothedHeadingRef.current = null;
     setIsTracking(false);
     setIsLocating(false);
     setIsHeadingActive(false);
@@ -298,14 +309,22 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
         (position) => {
           const { latitude, longitude } = position.coords;
           const center = fromLonLat([longitude, latitude]);
-          const heading =
+          const gpsHeading =
             typeof position.coords.heading === "number" &&
             Number.isFinite(position.coords.heading)
               ? position.coords.heading
               : null;
+          const speedMetersPerSecond =
+            typeof position.coords.speed === "number" &&
+            Number.isFinite(position.coords.speed)
+              ? position.coords.speed
+              : null;
 
           setCurrentCoordinate({ lat: latitude, lon: longitude });
-          updateUserLocationFeature(center, position.coords.accuracy, heading);
+          updateUserLocationFeature(center, position.coords.accuracy);
+          if (shouldUseGpsHeading(gpsHeading, speedMetersPerSecond)) {
+            updateUserHeading(gpsHeading, GPS_HEADING_SMOOTHING_FACTOR);
+          }
           if (shouldAnimateToUserRef.current) {
             animateToUserLocation(center);
             shouldAnimateToUserRef.current = false;
@@ -330,6 +349,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
       startOrientationTracking,
       stop,
       updateUserLocationFeature,
+      updateUserHeading,
     ],
   );
 

--- a/frontend/src/hooks/useUserLocationLayer.ts
+++ b/frontend/src/hooks/useUserLocationLayer.ts
@@ -101,6 +101,8 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
   const [hasFix, setHasFix] = useState(false);
   const [hasZoomedToUser, setHasZoomedToUser] = useState(false);
   const [isHeadingActive, setIsHeadingActive] = useState(false);
+  const [needsOrientationPermission, setNeedsOrientationPermission] =
+    useState(false);
   const [locationError, setLocationError] = useState<string | null>(null);
   const [currentCoordinate, setCurrentCoordinate] = useState<{
     lat: number;
@@ -226,14 +228,19 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
         try {
           const permission =
             await OrientationEventWithPermission.requestPermission();
-          if (permission !== "granted") return;
+          if (permission !== "granted") {
+            setNeedsOrientationPermission(true);
+            return;
+          }
         } catch {
+          setNeedsOrientationPermission(true);
           return;
         }
       } else if (
         !requestPermission &&
         typeof OrientationEventWithPermission.requestPermission === "function"
       ) {
+        setNeedsOrientationPermission(true);
         return;
       }
 
@@ -241,7 +248,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
 
       const tracker = createKompas().on("heading", updateUserHeading).watch();
       compassTrackerRef.current = tracker;
-      setIsHeadingActive(true);
+      setNeedsOrientationPermission(false);
     },
     [updateUserHeading],
   );
@@ -258,6 +265,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
     setIsTracking(false);
     setIsLocating(false);
     setIsHeadingActive(false);
+    setNeedsOrientationPermission(false);
   }, []);
 
   const locateUser = useCallback(
@@ -362,6 +370,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
     hasFix,
     hasZoomedToUser,
     isHeadingActive,
+    needsOrientationPermission,
     locationError,
     currentCoordinate,
   };


### PR DESCRIPTION
## Summary
- smooth PRIWA field heading updates along the shortest compass arc to reduce jitter
- ignore GPS course headings unless the device is moving fast enough for course-over-ground to be meaningful
- add focused tests for heading normalization, smoothing, north-boundary wrapping, and GPS heading gating

## Validation
- npm test
- npm run lint
- npm run build
- scripts/lint-ast-grep.sh

## Notes
This improves direction stability only. It does not implement offline data sync or continuous map-follow mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: frontend-only changes to how the map marker heading is computed and displayed, plus unit tests; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Improves PRIWA user-direction stability by introducing a new `headingStabilizer` helper that **normalizes headings**, computes the *shortest turn across 0/360*, and applies **smoothing**.
> 
> Updates `useUserLocationLayer` to maintain a `smoothedHeadingRef`, smooth compass/GPS heading updates (with separate smoothing factors), and **only apply GPS heading when speed exceeds a minimum threshold**, resetting smoothing state on `stop`.
> 
> Adds focused `vitest` coverage for normalization, shortest-arc delta, smoothing across north, initialization from first heading, and GPS speed gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6bf9748e1f02970535faab16f7063f45913a20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compass heading stability with smoother transitions.
  * GPS heading validation now respects movement speed thresholds for greater accuracy.

* **Tests**
  * Comprehensive test coverage added for heading stabilization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->