### PR TITLE
feat(priwa): add offline points sync queue

### DIFF
--- a/.github/workflows/frontend-hosting-merge.yml
+++ b/.github/workflows/frontend-hosting-merge.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: frontend
     env:
       VITE_MODE: production
-      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+      VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       VITE_SAM_API_URL: ${{ secrets.VITE_SAM_API_URL }}
       VITE_POSTHOG_PROJECT_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY }}

--- a/.github/workflows/frontend-hosting-pull-request.yml
+++ b/.github/workflows/frontend-hosting-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
         timeout-minutes: 8
         env:
           VITE_MODE: production
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
           VITE_SAM_API_URL: ${{ secrets.VITE_SAM_API_URL }}
           VITE_POSTHOG_PROJECT_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY }}
@@ -55,7 +55,7 @@ jobs:
         working-directory: frontend
     env:
       VITE_MODE: production
-      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+      VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       VITE_SAM_API_URL: ${{ secrets.VITE_SAM_API_URL }}
       VITE_POSTHOG_PROJECT_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY }}

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -13,6 +13,7 @@ import {
   EnvironmentOutlined,
   PlusOutlined,
   SlidersOutlined,
+  SyncOutlined,
   UnorderedListOutlined,
 } from "@ant-design/icons";
 import "ol/ol.css";
@@ -38,6 +39,7 @@ import {
 import PriwaPointDrawer from "./PriwaPointDrawer";
 import PriwaPointListPanel from "./PriwaPointListPanel";
 import PriwaOfflineStatus from "./PriwaOfflineStatus";
+import type { IPriwaSyncSummary } from "./priwaOfflineSync";
 import type {
   IPriwaCoordinate,
   IPriwaPoint,
@@ -54,9 +56,11 @@ interface PriwaFieldMapProps {
   cogPath?: string | null;
   isCogLoading?: boolean;
   errorMessage?: string | null;
+  syncSummary?: IPriwaSyncSummary;
   onAddPoint: (point: IPriwaPoint) => Promise<void>;
   onUpdatePoint: (point: IPriwaPoint) => Promise<void>;
   onDeletePoint: (pointId: string) => Promise<void>;
+  onSyncNow?: () => Promise<void>;
 }
 
 export default function PriwaFieldMap({
@@ -67,9 +71,11 @@ export default function PriwaFieldMap({
   cogPath,
   isCogLoading = false,
   errorMessage = null,
+  syncSummary,
   onAddPoint,
   onUpdatePoint,
   onDeletePoint,
+  onSyncNow,
 }: PriwaFieldMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
@@ -325,6 +331,7 @@ export default function PriwaFieldMap({
     },
     [onDeletePoint],
   );
+  const hasPendingSync = (syncSummary?.total ?? 0) > 0;
 
   const layerPanel = (
     <div className="w-64 space-y-3">
@@ -352,6 +359,17 @@ export default function PriwaFieldMap({
           disabled={!cogPath}
           onChange={setCogVisible}
         />
+      </div>
+      <div className="border-t border-slate-200 pt-3">
+        <Button
+          block
+          size="small"
+          icon={<SyncOutlined spin={!!syncSummary?.syncing} />}
+          disabled={!hasPendingSync || !onSyncNow}
+          onClick={() => void onSyncNow?.()}
+        >
+          Jetzt synchronisieren
+        </Button>
       </div>
     </div>
   );
@@ -467,7 +485,7 @@ export default function PriwaFieldMap({
               {locationHintLabel}
             </div>
           )}
-          <PriwaOfflineStatus />
+          <PriwaOfflineStatus syncSummary={syncSummary} />
         </div>
       )}
 

--- a/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
+++ b/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
@@ -2,24 +2,50 @@ import { CloudSyncOutlined, DisconnectOutlined } from "@ant-design/icons";
 import { Tag, Tooltip } from "antd";
 
 import { getPriwaOfflineStatusView } from "./priwaOfflineStatusView";
+import type { IPriwaSyncSummary } from "./priwaOfflineSync";
 import { usePriwaOfflineStatus } from "./usePriwaOfflineStatus";
 
-export default function PriwaOfflineStatus() {
+interface PriwaOfflineStatusProps {
+  syncSummary?: IPriwaSyncSummary;
+}
+
+const getSyncLabel = (syncSummary?: IPriwaSyncSummary) => {
+  if (!syncSummary || syncSummary.total === 0) return null;
+  if (syncSummary.failed > 0) return `${syncSummary.failed} Sync Fehler`;
+  if (syncSummary.syncing > 0) return "Synchronisiert...";
+  return `${syncSummary.pending} ausstehend`;
+};
+
+export default function PriwaOfflineStatus({
+  syncSummary,
+}: PriwaOfflineStatusProps) {
   const { isOnline, serviceWorker } = usePriwaOfflineStatus();
   const statusView = getPriwaOfflineStatusView(
     serviceWorker.status,
     isOnline,
   );
-  const tooltipTitle = serviceWorker.errorMessage ?? statusView.label;
+  const syncLabel = getSyncLabel(syncSummary);
+  const label = syncLabel ?? statusView.label;
+  const color =
+    syncSummary && syncSummary.failed > 0
+      ? "error"
+      : syncSummary && syncSummary.total > 0
+        ? "processing"
+        : statusView.color;
+  const tooltipTitle =
+    serviceWorker.errorMessage ??
+    (syncSummary && syncSummary.total > 0
+      ? `${syncSummary.pending} pending, ${syncSummary.syncing} syncing, ${syncSummary.failed} failed`
+      : statusView.label);
 
   return (
     <Tooltip title={tooltipTitle}>
       <Tag
         className="pointer-events-auto m-0 rounded-md border-0 px-2.5 py-1 text-xs font-medium shadow-sm"
-        color={statusView.color}
+        color={color}
         icon={isOnline ? <CloudSyncOutlined /> : <DisconnectOutlined />}
       >
-        {statusView.label}
+        {label}
       </Tag>
     </Tooltip>
   );

--- a/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
+++ b/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
@@ -35,7 +35,7 @@ export default function PriwaOfflineStatus({
   const tooltipTitle =
     serviceWorker.errorMessage ??
     (syncSummary && syncSummary.total > 0
-      ? `${syncSummary.pending} pending, ${syncSummary.syncing} syncing, ${syncSummary.failed} failed`
+      ? `${syncSummary.pending} ausstehend, ${syncSummary.syncing} wird synchronisiert, ${syncSummary.failed} fehlgeschlagen`
       : statusView.label);
 
   return (

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -185,6 +185,7 @@ export default function PriwaPointDrawer({
   const [coordinateSource, setCoordinateSource] =
     useState<PriwaCoordinateSource>("qr");
   const [isQrScannerOpen, setQrScannerOpen] = useState(false);
+  const [activeCollapseKeys, setActiveCollapseKeys] = useState<string[]>([]);
 
   const qrCoordinate = useMemo(
     () => parseGoogleMapsCoordinates(rawQrValue),
@@ -197,11 +198,13 @@ export default function PriwaPointDrawer({
     if (editingPoint) {
       form.setFieldsValue(createFormValuesFromPoint(editingPoint));
       setRawQrValue(editingPoint.rawQrValue ?? "");
+      setActiveCollapseKeys(["baum"]);
       return;
     }
 
     form.setFieldsValue(createDefaultFormValues());
     setRawQrValue("");
+    setActiveCollapseKeys([]);
   }, [editingPoint, form, formSessionId]);
 
   useEffect(() => {
@@ -264,7 +267,16 @@ export default function PriwaPointDrawer({
     if (!effectiveCoordinate) return;
 
     try {
-      const values = await form.validateFields();
+      if (requiresBaumnr) {
+        setActiveCollapseKeys((keys) =>
+          keys.includes("baum") ? keys : [...keys, "baum"],
+        );
+      }
+
+      const values = {
+        ...createDefaultFormValues(),
+        ...(await form.validateFields()),
+      };
       const savedCoordinateSource = willUseEstimatedGps
         ? "gps"
         : coordinateSource;
@@ -287,7 +299,7 @@ export default function PriwaPointDrawer({
         capturedAt: editingPoint?.capturedAt ?? new Date().toISOString(),
         coordinateSource: savedCoordinateSource,
         gps: willUseEstimatedGps ? "nein" : "ja",
-        isEstimatedLocation: willUseEstimatedGps,
+        isEstimatedLocation: savedCoordinateSource !== "qr",
         rawQrValue:
           savedCoordinateSource === "qr" ? rawQrValue.trim() || undefined : undefined,
       };
@@ -463,7 +475,10 @@ export default function PriwaPointDrawer({
           <Collapse
             ghost
             size="small"
-            defaultActiveKey={editingPoint ? ["baum"] : []}
+            activeKey={activeCollapseKeys}
+            onChange={(keys) =>
+              setActiveCollapseKeys(Array.isArray(keys) ? keys : [keys])
+            }
             expandIcon={({ isActive }) => (
               <DownOutlined rotate={isActive ? 180 : 0} />
             )}
@@ -471,6 +486,7 @@ export default function PriwaPointDrawer({
               {
                 key: "baum",
                 label: <Typography.Text strong>Baum</Typography.Text>,
+                forceRender: true,
                 children: (
                   <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
                     <Form.Item

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -44,6 +44,9 @@ export default function PriwaPointListPanel({
     (point) => point.coordinateSource === "qr",
   ).length;
   const visiblePoints = filter === "qa" ? qaPoints : points;
+  const pendingSyncCount = points.filter(
+    (point) => point.syncStatus && point.syncStatus !== "synced",
+  ).length;
   const emptyDescription =
     isLoading
       ? "Lade Punkte..."
@@ -56,7 +59,10 @@ export default function PriwaPointListPanel({
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-slate-950">Käferbaum QA</div>
-          <div className="truncate text-xs text-slate-500">{projectName}</div>
+          <div className="truncate text-xs text-slate-500">
+            {projectName}
+            {pendingSyncCount > 0 ? ` · ${pendingSyncCount} lokal` : ""}
+          </div>
         </div>
         <Button size="small" onClick={onClose}>
           Schließen
@@ -131,6 +137,14 @@ export default function PriwaPointListPanel({
                         {getPriwaPointSourceLabel(point)}
                       </Tag>
                       <Tag className="m-0">{getPriwaFundLabel(point)}</Tag>
+                      {point.syncStatus && point.syncStatus !== "synced" && (
+                        <Tag
+                          className="m-0"
+                          color={point.syncStatus === "failed" ? "red" : "blue"}
+                        >
+                          {point.syncStatus === "failed" ? "Fehler" : "Lokal"}
+                        </Tag>
+                      )}
                       <span className="text-xs text-slate-500">{point.baumart}</span>
                       <span className="text-xs text-slate-400">·</span>
                       <span className="text-xs text-slate-500">{point.name}</span>

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.ts
@@ -37,9 +37,30 @@ const pointStyle = (point: IPriwaPoint) => {
       : undefined,
   });
 
-  if (!point.isEstimatedLocation) return coreStyle;
+  const syncStyle =
+    point.syncStatus && point.syncStatus !== "synced"
+      ? new Style({
+          image: new CircleStyle({
+            radius: point.syncStatus === "failed" ? 17 : 16,
+            fill: new Fill({ color: "rgba(255,255,255,0.01)" }),
+            stroke: new Stroke({
+              color:
+                point.syncStatus === "failed"
+                  ? "rgba(220, 38, 38, 0.95)"
+                  : "rgba(37, 99, 235, 0.95)",
+              width: 3,
+              lineDash: [3, 4],
+            }),
+          }),
+        })
+      : null;
+
+  if (!point.isEstimatedLocation) {
+    return syncStyle ? [syncStyle, coreStyle] : coreStyle;
+  }
 
   return [
+    ...(syncStyle ? [syncStyle] : []),
     new Style({
       image: new CircleStyle({
         radius: 13,

--- a/frontend/src/components/PriwaField/priwaOfflineQueue.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineQueue.ts
@@ -1,0 +1,35 @@
+import {
+  loadPriwaSyncQueue,
+  savePriwaSyncQueue,
+  type IPriwaQueuedMutation,
+} from "./priwaOfflineStore";
+
+type PriwaQueueUpdater = (
+  queue: IPriwaQueuedMutation[],
+) => IPriwaQueuedMutation[];
+
+let queueTransaction = Promise.resolve();
+
+export const updatePriwaSyncQueue = async (
+  projectId: string,
+  userId: string,
+  updater: PriwaQueueUpdater,
+  onUpdated?: (queue: IPriwaQueuedMutation[]) => void,
+) => {
+  const transaction = queueTransaction
+    .catch(() => undefined)
+    .then(async () => {
+      const currentQueue = await loadPriwaSyncQueue(projectId, userId);
+      const nextQueue = updater(currentQueue);
+      await savePriwaSyncQueue(projectId, userId, nextQueue);
+      onUpdated?.(nextQueue);
+      return nextQueue;
+    });
+
+  queueTransaction = transaction.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  return transaction;
+};

--- a/frontend/src/components/PriwaField/priwaOfflineStore.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineStore.ts
@@ -1,0 +1,99 @@
+import localforage from "localforage";
+
+import type { IPriwaPoint, PriwaPointSyncOperation } from "./types";
+
+export type PriwaQueuedMutationStatus = "pending" | "syncing" | "failed";
+
+export interface IPriwaCachedProjectMembership {
+  projectId: string;
+  projectName: string;
+  projectSlug: string;
+  role: "field_user" | "coordinator" | "admin";
+}
+
+export interface IPriwaQueuedMutation {
+  id: string;
+  projectId: string;
+  userId: string;
+  pointId: string;
+  type: PriwaPointSyncOperation;
+  point?: IPriwaPoint;
+  queuedAt: string;
+  updatedAt: string;
+  retryCount: number;
+  status: PriwaQueuedMutationStatus;
+  lastError?: string;
+}
+
+const priwaOfflineStore = localforage.createInstance({
+  name: "deadtrees-priwa-field",
+  storeName: "offline",
+});
+
+const pointsKey = (projectId: string) => `points:${projectId}`;
+const queueKey = (projectId: string, userId: string) =>
+  `sync-queue:${projectId}:${userId}`;
+const membershipsKey = (userId: string) => `memberships:${userId}`;
+
+export const loadCachedPriwaPoints = async (projectId: string) =>
+  (await priwaOfflineStore.getItem<IPriwaPoint[]>(pointsKey(projectId))) ?? [];
+
+export const saveCachedPriwaPoints = async (
+  projectId: string,
+  points: IPriwaPoint[],
+) => {
+  await priwaOfflineStore.setItem(pointsKey(projectId), points);
+};
+
+export const loadPriwaSyncQueue = async (projectId: string, userId: string) =>
+  (await priwaOfflineStore.getItem<IPriwaQueuedMutation[]>(
+    queueKey(projectId, userId),
+  )) ?? [];
+
+export const savePriwaSyncQueue = async (
+  projectId: string,
+  userId: string,
+  queue: IPriwaQueuedMutation[],
+) => {
+  await priwaOfflineStore.setItem(queueKey(projectId, userId), queue);
+};
+
+export const loadCachedPriwaMemberships = async (userId: string) =>
+  (await priwaOfflineStore.getItem<IPriwaCachedProjectMembership[]>(
+    membershipsKey(userId),
+  )) ?? [];
+
+export const saveCachedPriwaMemberships = async (
+  userId: string,
+  memberships: IPriwaCachedProjectMembership[],
+) => {
+  await priwaOfflineStore.setItem(membershipsKey(userId), memberships);
+};
+
+export const createPriwaQueuedMutation = ({
+  projectId,
+  userId,
+  type,
+  point,
+  pointId,
+}: {
+  projectId: string;
+  userId: string;
+  type: PriwaPointSyncOperation;
+  point?: IPriwaPoint;
+  pointId: string;
+}): IPriwaQueuedMutation => {
+  const now = new Date().toISOString();
+  return {
+    id: `${projectId}:${userId}:${pointId}`,
+    projectId,
+    userId,
+    pointId,
+    type,
+    point,
+    queuedAt: now,
+    updatedAt: now,
+    retryCount: 0,
+    status: "pending",
+  };
+};

--- a/frontend/src/components/PriwaField/priwaOfflineSync.test.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineSync.test.ts
@@ -86,6 +86,25 @@ describe("PRIWA offline sync helpers", () => {
     ]);
   });
 
+  it("keeps failed deletes visible for retry and recovery", () => {
+    const queue = [
+      {
+        ...mutation("delete", undefined),
+        status: "failed" as const,
+        lastError: "Network error",
+      },
+    ];
+
+    expect(mergePriwaOfflinePoints([basePoint], queue)).toEqual([
+      expect.objectContaining({
+        id: "point-1",
+        syncStatus: "failed",
+        syncOperation: "delete",
+        syncError: "Network error",
+      }),
+    ]);
+  });
+
   it("summarizes queue state for the field status badge", () => {
     expect(
       getPriwaSyncSummary([

--- a/frontend/src/components/PriwaField/priwaOfflineSync.test.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineSync.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import type { IPriwaPoint } from "./types";
+import {
+  coalescePriwaQueuedMutation,
+  getPriwaSyncSummary,
+  mergePriwaOfflinePoints,
+} from "./priwaOfflineSync";
+import type { IPriwaQueuedMutation } from "./priwaOfflineStore";
+
+const basePoint: IPriwaPoint = {
+  id: "point-1",
+  lat: 48.456,
+  lon: 8.18,
+  baumnr: "42",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "ja",
+  bohrloch: "ja",
+  harz: "nein",
+  nadel: "grün",
+  rinde: "0%",
+  kv: "0%",
+  name: "Sigi Huber",
+  datum: "2026-05-19",
+  kom: "",
+  capturedAt: "2026-05-19T08:00:00.000Z",
+  coordinateSource: "qr",
+  gps: "ja",
+};
+
+const mutation = (
+  type: IPriwaQueuedMutation["type"],
+  point: IPriwaPoint | undefined = basePoint,
+): IPriwaQueuedMutation => ({
+  id: `project-1:user-1:${point?.id ?? "point-1"}`,
+  projectId: "project-1",
+  userId: "user-1",
+  pointId: point?.id ?? "point-1",
+  type,
+  point,
+  queuedAt: "2026-05-19T08:01:00.000Z",
+  updatedAt: "2026-05-19T08:01:00.000Z",
+  retryCount: 0,
+  status: "pending",
+});
+
+describe("PRIWA offline sync helpers", () => {
+  it("coalesces create followed by update into a single create", () => {
+    const editedPoint = { ...basePoint, baumnr: "43" };
+    const queue = coalescePriwaQueuedMutation([], mutation("create"));
+    const nextQueue = coalescePriwaQueuedMutation(
+      queue,
+      mutation("update", editedPoint),
+    );
+
+    expect(nextQueue).toHaveLength(1);
+    expect(nextQueue[0]).toMatchObject({
+      type: "create",
+      point: editedPoint,
+      status: "pending",
+    });
+  });
+
+  it("removes local-only records when they are deleted before sync", () => {
+    const queue = coalescePriwaQueuedMutation([], mutation("create"));
+    const nextQueue = coalescePriwaQueuedMutation(
+      queue,
+      mutation("delete", undefined),
+    );
+
+    expect(nextQueue).toEqual([]);
+  });
+
+  it("overlays queued updates onto cached points", () => {
+    const editedPoint = { ...basePoint, baumnr: "43" };
+    const queue = [mutation("update", editedPoint)];
+
+    expect(mergePriwaOfflinePoints([basePoint], queue)).toEqual([
+      expect.objectContaining({
+        id: "point-1",
+        baumnr: "43",
+        syncStatus: "pending",
+        syncOperation: "update",
+      }),
+    ]);
+  });
+
+  it("summarizes queue state for the field status badge", () => {
+    expect(
+      getPriwaSyncSummary([
+        mutation("update"),
+        {
+          ...mutation("create", { ...basePoint, id: "point-2" }),
+          status: "failed",
+        },
+      ]),
+    ).toEqual({
+      pending: 1,
+      syncing: 0,
+      failed: 1,
+      total: 2,
+    });
+  });
+});

--- a/frontend/src/components/PriwaField/priwaOfflineSync.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineSync.ts
@@ -1,0 +1,108 @@
+import type {
+  IPriwaPoint,
+  PriwaPointSyncOperation,
+  PriwaPointSyncStatus,
+} from "./types";
+import type {
+  IPriwaQueuedMutation,
+  PriwaQueuedMutationStatus,
+} from "./priwaOfflineStore";
+
+export interface IPriwaSyncSummary {
+  pending: number;
+  syncing: number;
+  failed: number;
+  total: number;
+}
+
+export const stripPriwaPointSyncState = (point: IPriwaPoint): IPriwaPoint => {
+  const { syncStatus, syncOperation, syncError, ...syncedPoint } = point;
+  void syncStatus;
+  void syncOperation;
+  void syncError;
+  return syncedPoint;
+};
+
+const toPointSyncStatus = (
+  status: PriwaQueuedMutationStatus,
+): PriwaPointSyncStatus => (status === "failed" ? "failed" : status);
+
+export const getPriwaSyncSummary = (
+  queue: IPriwaQueuedMutation[],
+): IPriwaSyncSummary => {
+  const pending = queue.filter((item) => item.status === "pending").length;
+  const syncing = queue.filter((item) => item.status === "syncing").length;
+  const failed = queue.filter((item) => item.status === "failed").length;
+
+  return {
+    pending,
+    syncing,
+    failed,
+    total: pending + syncing + failed,
+  };
+};
+
+export const coalescePriwaQueuedMutation = (
+  queue: IPriwaQueuedMutation[],
+  mutation: IPriwaQueuedMutation,
+) => {
+  const existing = queue.find((item) => item.pointId === mutation.pointId);
+  const remaining = queue.filter((item) => item.pointId !== mutation.pointId);
+
+  if (existing?.type === "create" && mutation.type === "delete") {
+    return remaining;
+  }
+
+  const type: PriwaPointSyncOperation =
+    existing?.type === "create" && mutation.type === "update"
+      ? "create"
+      : mutation.type;
+
+  return [
+    ...remaining,
+    {
+      ...existing,
+      ...mutation,
+      type,
+      queuedAt: existing?.queuedAt ?? mutation.queuedAt,
+      retryCount: existing?.retryCount ?? 0,
+      status: "pending" as const,
+      lastError: undefined,
+    },
+  ];
+};
+
+export const mergePriwaOfflinePoints = (
+  points: IPriwaPoint[],
+  queue: IPriwaQueuedMutation[],
+): IPriwaPoint[] => {
+  const merged = new Map<string, IPriwaPoint>(
+    points.map((point) => [
+      point.id,
+      {
+        ...stripPriwaPointSyncState(point),
+        syncStatus: "synced" as const,
+      },
+    ]),
+  );
+
+  queue.forEach((mutation) => {
+    if (mutation.type === "delete") {
+      merged.delete(mutation.pointId);
+      return;
+    }
+
+    if (!mutation.point) return;
+
+    merged.set(mutation.pointId, {
+      ...stripPriwaPointSyncState(mutation.point),
+      syncStatus: toPointSyncStatus(mutation.status),
+      syncOperation: mutation.type,
+      syncError: mutation.lastError,
+    });
+  });
+
+  return Array.from(merged.values()).sort((left, right) =>
+    right.capturedAt.localeCompare(left.capturedAt),
+  );
+};

--- a/frontend/src/components/PriwaField/priwaOfflineSync.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineSync.ts
@@ -88,6 +88,18 @@ export const mergePriwaOfflinePoints = (
 
   queue.forEach((mutation) => {
     if (mutation.type === "delete") {
+      if (mutation.status === "failed") {
+        const point = merged.get(mutation.pointId);
+        if (point) {
+          merged.set(mutation.pointId, {
+            ...point,
+            syncStatus: "failed",
+            syncOperation: "delete",
+            syncError: mutation.lastError,
+          });
+        }
+        return;
+      }
       merged.delete(mutation.pointId);
       return;
     }

--- a/frontend/src/components/PriwaField/types.ts
+++ b/frontend/src/components/PriwaField/types.ts
@@ -5,6 +5,8 @@ export interface IPriwaCoordinate {
 
 export type PriwaCoordinateSource = "qr" | "gps" | "map";
 export type PriwaGpsQuality = "ja" | "nein";
+export type PriwaPointSyncOperation = "create" | "update" | "delete";
+export type PriwaPointSyncStatus = "synced" | "pending" | "syncing" | "failed";
 export type PriwaObserverName =
   | "Sigi Huber"
   | "Martin Schade"
@@ -55,4 +57,7 @@ export interface IPriwaPoint extends IPriwaCoordinate {
   bhd?: number | null;
   fotoQrName?: string;
   rawQrValue?: string;
+  syncStatus?: PriwaPointSyncStatus;
+  syncOperation?: PriwaPointSyncOperation;
+  syncError?: string;
 }

--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
@@ -122,10 +122,49 @@ const pointToRow = (projectId: string, point: IPriwaPoint) => ({
   client_updated_at: new Date().toISOString(),
 });
 
-const priwaPointsQueryKey = (projectId: string | null | undefined) => [
+export const priwaPointsQueryKey = (projectId: string | null | undefined) => [
   "priwa-kaeferbaeume",
   projectId,
 ];
+
+export const fetchPriwaKaeferbaeume = async (projectId: string) => {
+  const { data, error } = await supabase
+    .from("priwa_kaeferbaeume")
+    .select(
+      "id, project_id, geom, location_source, is_exact_location, baumnr, fund, baumart, bm, bohrloch, harz, nadel, rinde, kv, name, datum, kom, raw_qr_value, created_at, updated_at, client_updated_at",
+    )
+    .eq("project_id", projectId)
+    .order("updated_at", { ascending: false });
+
+  if (error) throw error;
+
+  return ((data ?? []) as IPriwaKaeferbaumRow[])
+    .map(rowToPoint)
+    .filter((point): point is IPriwaPoint => point !== null);
+};
+
+export const upsertPriwaKaeferbaum = async (
+  projectId: string,
+  point: IPriwaPoint,
+) => {
+  const { error } = await supabase
+    .from("priwa_kaeferbaeume")
+    .upsert(pointToRow(projectId, point), { onConflict: "id" });
+
+  if (error) throw error;
+};
+
+export const softDeletePriwaKaeferbaum = async (
+  pointId: string,
+  deletedAt = new Date().toISOString(),
+) => {
+  const { error } = await supabase
+    .from("priwa_kaeferbaeume")
+    .update({ deleted_at: deletedAt })
+    .eq("id", pointId);
+
+  if (error) throw error;
+};
 
 export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
   const queryClient = useQueryClient();
@@ -135,20 +174,7 @@ export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
     enabled: !!projectId,
     queryFn: async () => {
       if (!projectId) return [];
-
-      const { data, error } = await supabase
-        .from("priwa_kaeferbaeume")
-        .select(
-          "id, project_id, geom, location_source, is_exact_location, baumnr, fund, baumart, bm, bohrloch, harz, nadel, rinde, kv, name, datum, kom, raw_qr_value, created_at, updated_at, client_updated_at",
-        )
-        .eq("project_id", projectId)
-        .order("updated_at", { ascending: false });
-
-      if (error) throw error;
-
-      return ((data ?? []) as IPriwaKaeferbaumRow[])
-        .map(rowToPoint)
-        .filter((point): point is IPriwaPoint => point !== null);
+      return fetchPriwaKaeferbaeume(projectId);
     },
     staleTime: 30 * 1000,
   });
@@ -162,12 +188,7 @@ export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
   const createPoint = useMutation({
     mutationFn: async (point: IPriwaPoint) => {
       if (!projectId) throw new Error("PRIWA project membership is required.");
-
-      const { error } = await supabase
-        .from("priwa_kaeferbaeume")
-        .insert(pointToRow(projectId, point));
-
-      if (error) throw error;
+      await upsertPriwaKaeferbaum(projectId, point);
     },
     onSuccess: invalidatePoints,
   });
@@ -175,25 +196,14 @@ export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
   const updatePoint = useMutation({
     mutationFn: async (point: IPriwaPoint) => {
       if (!projectId) throw new Error("PRIWA project membership is required.");
-
-      const { error } = await supabase
-        .from("priwa_kaeferbaeume")
-        .update(pointToRow(projectId, point))
-        .eq("id", point.id);
-
-      if (error) throw error;
+      await upsertPriwaKaeferbaum(projectId, point);
     },
     onSuccess: invalidatePoints,
   });
 
   const deletePoint = useMutation({
     mutationFn: async (pointId: string) => {
-      const { error } = await supabase
-        .from("priwa_kaeferbaeume")
-        .update({ deleted_at: new Date().toISOString() })
-        .eq("id", pointId);
-
-      if (error) throw error;
+      await softDeletePriwaKaeferbaum(pointId);
     },
     onSuccess: invalidatePoints,
   });

--- a/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.test.ts
@@ -169,4 +169,21 @@ describe("usePriwaOfflineKaeferbaeume", () => {
       ],
     );
   });
+
+  it("uses the local cache ahead of stale query data when both exist", async () => {
+    queryData = [{ ...basePoint, baumnr: "server-stale" }];
+    stateValues = [[{ ...basePoint, baumnr: "cache-fresh" }], [], false, false];
+    const { usePriwaOfflineKaeferbaeume } = await import(
+      "./usePriwaOfflineKaeferbaeume"
+    );
+
+    const result = usePriwaOfflineKaeferbaeume("project-1");
+
+    expect(result.points).toEqual([
+      expect.objectContaining({
+        id: "point-1",
+        baumnr: "cache-fresh",
+      }),
+    ]);
+  });
 });

--- a/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+import type { IPriwaPoint } from "./types";
+import type { IPriwaQueuedMutation } from "./priwaOfflineStore";
+
+const setStateSpy = vi.fn();
+const invalidateQueries = vi.fn();
+let stateValues: unknown[] = [];
+let isOnline = false;
+let queryData: IPriwaPoint[] | undefined;
+
+const basePoint: IPriwaPoint = {
+  id: "point-1",
+  lat: 48.456,
+  lon: 8.18,
+  baumnr: "42",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "ja",
+  bohrloch: "ja",
+  harz: "nein",
+  nadel: "grün",
+  rinde: "0%",
+  kv: "0%",
+  name: "Sigi Huber",
+  datum: "2026-05-19",
+  kom: "",
+  capturedAt: "2026-05-19T08:00:00.000Z",
+  coordinateSource: "qr",
+  gps: "ja",
+};
+
+const queuedUpdate: IPriwaQueuedMutation = {
+  id: "project-1:user-1:point-1",
+  projectId: "project-1",
+  userId: "user-1",
+  pointId: "point-1",
+  type: "update",
+  point: { ...basePoint, baumnr: "43" },
+  queuedAt: "2026-05-19T08:01:00.000Z",
+  updatedAt: "2026-05-19T08:01:00.000Z",
+  retryCount: 0,
+  status: "pending",
+};
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useCallback: (callback: unknown) => callback,
+    useEffect: vi.fn(),
+    useMemo: (factory: () => unknown) => factory(),
+    useRef: (value: unknown) => ({ current: value }),
+    useState: vi.fn((initialValue: unknown) => {
+      const value =
+        stateValues.length > 0
+          ? stateValues.shift()
+          : typeof initialValue === "function"
+            ? (initialValue as () => unknown)()
+            : initialValue;
+      return [value, setStateSpy];
+    }),
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(() => ({
+    data: queryData,
+    isLoading: false,
+    isRefetching: false,
+    error: null,
+  })),
+  useQueryClient: vi.fn(() => ({ invalidateQueries })),
+}));
+
+vi.mock("../../hooks/useAuthProvider", () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: "user-1" },
+  })),
+}));
+
+vi.mock("./usePriwaOfflineStatus", () => ({
+  usePriwaOfflineStatus: vi.fn(() => ({
+    isOnline,
+    serviceWorker: { status: "ready", errorMessage: null },
+  })),
+}));
+
+vi.mock("./usePriwaKaeferbaeume", () => ({
+  fetchPriwaKaeferbaeume: vi.fn(),
+  priwaPointsQueryKey: vi.fn((projectId) => ["priwa-kaeferbaeume", projectId]),
+  softDeletePriwaKaeferbaum: vi.fn(),
+  upsertPriwaKaeferbaum: vi.fn(),
+}));
+
+vi.mock("./priwaOfflineStore", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./priwaOfflineStore")>();
+  return {
+    ...actual,
+    loadCachedPriwaPoints: vi.fn(),
+    loadPriwaSyncQueue: vi.fn(),
+    saveCachedPriwaPoints: vi.fn(),
+    savePriwaSyncQueue: vi.fn(),
+  };
+});
+
+describe("usePriwaOfflineKaeferbaeume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stateValues = [];
+    isOnline = false;
+    queryData = undefined;
+  });
+
+  it("merges cached points with queued local edits", async () => {
+    stateValues = [[basePoint], [queuedUpdate], false, false];
+    const { usePriwaOfflineKaeferbaeume } = await import(
+      "./usePriwaOfflineKaeferbaeume"
+    );
+
+    const result = usePriwaOfflineKaeferbaeume("project-1");
+
+    expect(result.points).toEqual([
+      expect.objectContaining({
+        id: "point-1",
+        baumnr: "43",
+        syncStatus: "pending",
+        syncOperation: "update",
+      }),
+    ]);
+    expect(result.syncSummary).toEqual({
+      pending: 1,
+      syncing: 0,
+      failed: 0,
+      total: 1,
+    });
+  });
+
+  it("stores an offline create in the point cache and sync queue", async () => {
+    stateValues = [[], [], false, false];
+    const offlineStore = await import("./priwaOfflineStore");
+    (offlineStore.loadCachedPriwaPoints as Mock).mockResolvedValue([]);
+    (offlineStore.loadPriwaSyncQueue as Mock).mockResolvedValue([]);
+    const { usePriwaOfflineKaeferbaeume } = await import(
+      "./usePriwaOfflineKaeferbaeume"
+    );
+
+    const result = usePriwaOfflineKaeferbaeume("project-1");
+    await result.createPoint(basePoint);
+
+    expect(offlineStore.saveCachedPriwaPoints).toHaveBeenCalledWith(
+      "project-1",
+      [basePoint],
+    );
+    expect(offlineStore.savePriwaSyncQueue).toHaveBeenCalledWith(
+      "project-1",
+      "user-1",
+      [
+        expect.objectContaining({
+          projectId: "project-1",
+          userId: "user-1",
+          pointId: "point-1",
+          type: "create",
+          point: basePoint,
+          status: "pending",
+        }),
+      ],
+    );
+  });
+});

--- a/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.ts
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "../../hooks/useAuthProvider";
+import { usePriwaOfflineStatus } from "./usePriwaOfflineStatus";
+import type { IPriwaPoint, PriwaPointSyncOperation } from "./types";
+import {
+  createPriwaQueuedMutation,
+  loadCachedPriwaPoints,
+  loadPriwaSyncQueue,
+  saveCachedPriwaPoints,
+  savePriwaSyncQueue,
+  type IPriwaQueuedMutation,
+} from "./priwaOfflineStore";
+import {
+  coalescePriwaQueuedMutation,
+  getPriwaSyncSummary,
+  mergePriwaOfflinePoints,
+  stripPriwaPointSyncState,
+} from "./priwaOfflineSync";
+import {
+  fetchPriwaKaeferbaeume,
+  priwaPointsQueryKey,
+  softDeletePriwaKaeferbaum,
+  upsertPriwaKaeferbaum,
+} from "./usePriwaKaeferbaeume";
+
+const upsertLocalPoint = (points: IPriwaPoint[], point: IPriwaPoint) => {
+  const syncedPoint = stripPriwaPointSyncState(point);
+  return [
+    syncedPoint,
+    ...points.filter((existingPoint) => existingPoint.id !== point.id),
+  ].sort((left, right) => right.capturedAt.localeCompare(left.capturedAt));
+};
+
+const removeLocalPoint = (points: IPriwaPoint[], pointId: string) =>
+  points.filter((point) => point.id !== pointId);
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "PRIWA Synchronisation fehlgeschlagen.";
+
+export function usePriwaOfflineKaeferbaeume(
+  projectId: string | null | undefined,
+) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { isOnline } = usePriwaOfflineStatus();
+  const userId = user?.id ?? null;
+  const [cachedPoints, setCachedPoints] = useState<IPriwaPoint[]>([]);
+  const [queue, setQueue] = useState<IPriwaQueuedMutation[]>([]);
+  const [isLoadingOfflineState, setLoadingOfflineState] = useState(false);
+  const [isSyncingQueue, setSyncingQueue] = useState(false);
+  const syncPromiseRef = useRef<Promise<void> | null>(null);
+
+  const pointsQuery = useQuery({
+    queryKey: priwaPointsQueryKey(projectId),
+    enabled: !!projectId && isOnline,
+    queryFn: async () => {
+      if (!projectId) return [];
+      return fetchPriwaKaeferbaeume(projectId);
+    },
+    staleTime: 30 * 1000,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadOfflineState = async () => {
+      if (!projectId || !userId) {
+        setCachedPoints([]);
+        setQueue([]);
+        return;
+      }
+
+      setLoadingOfflineState(true);
+      try {
+        const [nextCachedPoints, nextQueue] = await Promise.all([
+          loadCachedPriwaPoints(projectId),
+          loadPriwaSyncQueue(projectId, userId),
+        ]);
+
+        if (!isMounted) return;
+
+        setCachedPoints(nextCachedPoints);
+        setQueue(nextQueue);
+      } finally {
+        if (isMounted) {
+          setLoadingOfflineState(false);
+        }
+      }
+    };
+
+    void loadOfflineState();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [projectId, userId]);
+
+  useEffect(() => {
+    if (!projectId || !pointsQuery.data) return;
+
+    const syncedPoints = pointsQuery.data.map(stripPriwaPointSyncState);
+    setCachedPoints(syncedPoints);
+    void saveCachedPriwaPoints(projectId, syncedPoints);
+  }, [pointsQuery.data, projectId]);
+
+  const persistQueue = useCallback(
+    async (nextQueue: IPriwaQueuedMutation[]) => {
+      if (!projectId || !userId) return;
+
+      setQueue(nextQueue);
+      await savePriwaSyncQueue(projectId, userId, nextQueue);
+    },
+    [projectId, userId],
+  );
+
+  const syncQueue = useCallback(async () => {
+    if (!projectId || !userId || !isOnline) return;
+
+    if (syncPromiseRef.current) {
+      await syncPromiseRef.current;
+      return;
+    }
+
+    syncPromiseRef.current = (async () => {
+      setSyncingQueue(true);
+      let currentQueue = await loadPriwaSyncQueue(projectId, userId);
+
+      for (const mutation of currentQueue) {
+        const syncingMutation = {
+          ...mutation,
+          status: "syncing" as const,
+          retryCount: mutation.retryCount + 1,
+          lastError: undefined,
+        };
+        currentQueue = currentQueue.map((item) =>
+          item.id === mutation.id ? syncingMutation : item,
+        );
+        await persistQueue(currentQueue);
+
+        try {
+          if (syncingMutation.type === "delete") {
+            await softDeletePriwaKaeferbaum(
+              syncingMutation.pointId,
+              syncingMutation.updatedAt,
+            );
+            setCachedPoints((points) =>
+              removeLocalPoint(points, syncingMutation.pointId),
+            );
+          } else if (syncingMutation.point) {
+            await upsertPriwaKaeferbaum(projectId, syncingMutation.point);
+            setCachedPoints((points) =>
+              upsertLocalPoint(points, syncingMutation.point as IPriwaPoint),
+            );
+          }
+
+          currentQueue = currentQueue.filter(
+            (item) => item.id !== syncingMutation.id,
+          );
+          await persistQueue(currentQueue);
+        } catch (error) {
+          currentQueue = currentQueue.map((item) =>
+            item.id === syncingMutation.id
+              ? {
+                  ...syncingMutation,
+                  status: "failed" as const,
+                  lastError: getErrorMessage(error),
+                }
+              : item,
+          );
+          await persistQueue(currentQueue);
+          break;
+        }
+      }
+
+      if (currentQueue.length === 0) {
+        await queryClient.invalidateQueries({
+          queryKey: priwaPointsQueryKey(projectId),
+        });
+      }
+    })().finally(() => {
+      setSyncingQueue(false);
+      syncPromiseRef.current = null;
+    });
+
+    await syncPromiseRef.current;
+  }, [isOnline, persistQueue, projectId, queryClient, userId]);
+
+  const enqueueMutation = useCallback(
+    async (
+      type: PriwaPointSyncOperation,
+      pointId: string,
+      point?: IPriwaPoint,
+    ) => {
+      if (!projectId || !userId) {
+        throw new Error("PRIWA project membership is required.");
+      }
+
+      const mutation = createPriwaQueuedMutation({
+        projectId,
+        userId,
+        type,
+        point,
+        pointId,
+      });
+      const [currentQueue, currentCachedPoints] = await Promise.all([
+        loadPriwaSyncQueue(projectId, userId),
+        loadCachedPriwaPoints(projectId),
+      ]);
+      const nextQueue = coalescePriwaQueuedMutation(currentQueue, mutation);
+
+      if (type === "delete") {
+        const nextCachedPoints = removeLocalPoint(currentCachedPoints, pointId);
+        setCachedPoints(nextCachedPoints);
+        await saveCachedPriwaPoints(projectId, nextCachedPoints);
+      } else if (point) {
+        const nextCachedPoints = upsertLocalPoint(currentCachedPoints, point);
+        setCachedPoints(nextCachedPoints);
+        await saveCachedPriwaPoints(projectId, nextCachedPoints);
+      }
+
+      await persistQueue(nextQueue);
+
+      if (isOnline) {
+        void syncQueue();
+      }
+    },
+    [isOnline, persistQueue, projectId, syncQueue, userId],
+  );
+
+  useEffect(() => {
+    if (!isOnline || queue.length === 0) return;
+    void syncQueue();
+  }, [isOnline, queue.length, syncQueue]);
+
+  const points = useMemo(
+    () =>
+      mergePriwaOfflinePoints(
+        pointsQuery.data ?? cachedPoints,
+        queue,
+      ),
+    [cachedPoints, pointsQuery.data, queue],
+  );
+  const syncSummary = useMemo(() => getPriwaSyncSummary(queue), [queue]);
+  const hasCachedPoints = cachedPoints.length > 0;
+
+  return {
+    points,
+    isLoading:
+      isLoadingOfflineState ||
+      (pointsQuery.isLoading && !hasCachedPoints && queue.length === 0),
+    isRefetching: pointsQuery.isRefetching || isSyncingQueue,
+    error: hasCachedPoints ? null : pointsQuery.error,
+    createPoint: (point: IPriwaPoint) =>
+      enqueueMutation("create", point.id, point),
+    updatePoint: (point: IPriwaPoint) =>
+      enqueueMutation("update", point.id, point),
+    deletePoint: (pointId: string) => enqueueMutation("delete", pointId),
+    isSaving: isSyncingQueue,
+    syncSummary,
+    syncNow: syncQueue,
+  };
+}

--- a/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaOfflineKaeferbaeume.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "../../hooks/useAuthProvider";
@@ -9,7 +9,6 @@ import {
   loadCachedPriwaPoints,
   loadPriwaSyncQueue,
   saveCachedPriwaPoints,
-  savePriwaSyncQueue,
   type IPriwaQueuedMutation,
 } from "./priwaOfflineStore";
 import {
@@ -18,12 +17,8 @@ import {
   mergePriwaOfflinePoints,
   stripPriwaPointSyncState,
 } from "./priwaOfflineSync";
-import {
-  fetchPriwaKaeferbaeume,
-  priwaPointsQueryKey,
-  softDeletePriwaKaeferbaum,
-  upsertPriwaKaeferbaum,
-} from "./usePriwaKaeferbaeume";
+import { fetchPriwaKaeferbaeume, priwaPointsQueryKey } from "./usePriwaKaeferbaeume";
+import { usePriwaSyncQueueRunner } from "./usePriwaSyncQueueRunner";
 
 const upsertLocalPoint = (points: IPriwaPoint[], point: IPriwaPoint) => {
   const syncedPoint = stripPriwaPointSyncState(point);
@@ -36,9 +31,6 @@ const upsertLocalPoint = (points: IPriwaPoint[], point: IPriwaPoint) => {
 const removeLocalPoint = (points: IPriwaPoint[], pointId: string) =>
   points.filter((point) => point.id !== pointId);
 
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : "PRIWA Synchronisation fehlgeschlagen.";
-
 export function usePriwaOfflineKaeferbaeume(
   projectId: string | null | undefined,
 ) {
@@ -49,8 +41,6 @@ export function usePriwaOfflineKaeferbaeume(
   const [cachedPoints, setCachedPoints] = useState<IPriwaPoint[]>([]);
   const [queue, setQueue] = useState<IPriwaQueuedMutation[]>([]);
   const [isLoadingOfflineState, setLoadingOfflineState] = useState(false);
-  const [isSyncingQueue, setSyncingQueue] = useState(false);
-  const syncPromiseRef = useRef<Promise<void> | null>(null);
 
   const pointsQuery = useQuery({
     queryKey: priwaPointsQueryKey(projectId),
@@ -83,6 +73,12 @@ export function usePriwaOfflineKaeferbaeume(
 
         setCachedPoints(nextCachedPoints);
         setQueue(nextQueue);
+      } catch (error) {
+        console.error("Failed to load PRIWA offline state", error);
+        if (!isMounted) return;
+
+        setCachedPoints([]);
+        setQueue([]);
       } finally {
         if (isMounted) {
           setLoadingOfflineState(false);
@@ -105,87 +101,30 @@ export function usePriwaOfflineKaeferbaeume(
     void saveCachedPriwaPoints(projectId, syncedPoints);
   }, [pointsQuery.data, projectId]);
 
-  const persistQueue = useCallback(
-    async (nextQueue: IPriwaQueuedMutation[]) => {
-      if (!projectId || !userId) return;
+  const onPointSynced = useCallback((point: IPriwaPoint) => {
+    setCachedPoints((points) => upsertLocalPoint(points, point));
+  }, []);
 
-      setQueue(nextQueue);
-      await savePriwaSyncQueue(projectId, userId, nextQueue);
-    },
-    [projectId, userId],
-  );
+  const onPointDeleted = useCallback((pointId: string) => {
+    setCachedPoints((points) => removeLocalPoint(points, pointId));
+  }, []);
 
-  const syncQueue = useCallback(async () => {
-    if (!projectId || !userId || !isOnline) return;
-
-    if (syncPromiseRef.current) {
-      await syncPromiseRef.current;
-      return;
-    }
-
-    syncPromiseRef.current = (async () => {
-      setSyncingQueue(true);
-      let currentQueue = await loadPriwaSyncQueue(projectId, userId);
-
-      for (const mutation of currentQueue) {
-        const syncingMutation = {
-          ...mutation,
-          status: "syncing" as const,
-          retryCount: mutation.retryCount + 1,
-          lastError: undefined,
-        };
-        currentQueue = currentQueue.map((item) =>
-          item.id === mutation.id ? syncingMutation : item,
-        );
-        await persistQueue(currentQueue);
-
-        try {
-          if (syncingMutation.type === "delete") {
-            await softDeletePriwaKaeferbaum(
-              syncingMutation.pointId,
-              syncingMutation.updatedAt,
-            );
-            setCachedPoints((points) =>
-              removeLocalPoint(points, syncingMutation.pointId),
-            );
-          } else if (syncingMutation.point) {
-            await upsertPriwaKaeferbaum(projectId, syncingMutation.point);
-            setCachedPoints((points) =>
-              upsertLocalPoint(points, syncingMutation.point as IPriwaPoint),
-            );
-          }
-
-          currentQueue = currentQueue.filter(
-            (item) => item.id !== syncingMutation.id,
-          );
-          await persistQueue(currentQueue);
-        } catch (error) {
-          currentQueue = currentQueue.map((item) =>
-            item.id === syncingMutation.id
-              ? {
-                  ...syncingMutation,
-                  status: "failed" as const,
-                  lastError: getErrorMessage(error),
-                }
-              : item,
-          );
-          await persistQueue(currentQueue);
-          break;
-        }
-      }
-
-      if (currentQueue.length === 0) {
-        await queryClient.invalidateQueries({
-          queryKey: priwaPointsQueryKey(projectId),
-        });
-      }
-    })().finally(() => {
-      setSyncingQueue(false);
-      syncPromiseRef.current = null;
+  const onQueueDrained = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: priwaPointsQueryKey(projectId),
     });
+  }, [projectId, queryClient]);
 
-    await syncPromiseRef.current;
-  }, [isOnline, persistQueue, projectId, queryClient, userId]);
+  const { isSyncingQueue, syncQueue, updateStoredQueue } =
+    usePriwaSyncQueueRunner({
+      projectId,
+      userId,
+      isOnline,
+      onQueueUpdated: setQueue,
+      onPointSynced,
+      onPointDeleted,
+      onQueueDrained,
+    });
 
   const enqueueMutation = useCallback(
     async (
@@ -204,11 +143,7 @@ export function usePriwaOfflineKaeferbaeume(
         point,
         pointId,
       });
-      const [currentQueue, currentCachedPoints] = await Promise.all([
-        loadPriwaSyncQueue(projectId, userId),
-        loadCachedPriwaPoints(projectId),
-      ]);
-      const nextQueue = coalescePriwaQueuedMutation(currentQueue, mutation);
+      const currentCachedPoints = await loadCachedPriwaPoints(projectId);
 
       if (type === "delete") {
         const nextCachedPoints = removeLocalPoint(currentCachedPoints, pointId);
@@ -220,13 +155,15 @@ export function usePriwaOfflineKaeferbaeume(
         await saveCachedPriwaPoints(projectId, nextCachedPoints);
       }
 
-      await persistQueue(nextQueue);
+      await updateStoredQueue((currentQueue) =>
+        coalescePriwaQueuedMutation(currentQueue, mutation),
+      );
 
       if (isOnline) {
         void syncQueue();
       }
     },
-    [isOnline, persistQueue, projectId, syncQueue, userId],
+    [isOnline, projectId, syncQueue, updateStoredQueue, userId],
   );
 
   useEffect(() => {
@@ -237,7 +174,7 @@ export function usePriwaOfflineKaeferbaeume(
   const points = useMemo(
     () =>
       mergePriwaOfflinePoints(
-        pointsQuery.data ?? cachedPoints,
+        cachedPoints.length > 0 ? cachedPoints : pointsQuery.data ?? [],
         queue,
       ),
     [cachedPoints, pointsQuery.data, queue],
@@ -252,10 +189,8 @@ export function usePriwaOfflineKaeferbaeume(
       (pointsQuery.isLoading && !hasCachedPoints && queue.length === 0),
     isRefetching: pointsQuery.isRefetching || isSyncingQueue,
     error: hasCachedPoints ? null : pointsQuery.error,
-    createPoint: (point: IPriwaPoint) =>
-      enqueueMutation("create", point.id, point),
-    updatePoint: (point: IPriwaPoint) =>
-      enqueueMutation("update", point.id, point),
+    createPoint: (point: IPriwaPoint) => enqueueMutation("create", point.id, point),
+    updatePoint: (point: IPriwaPoint) => enqueueMutation("update", point.id, point),
     deletePoint: (pointId: string) => enqueueMutation("delete", pointId),
     isSaving: isSyncingQueue,
     syncSummary,

--- a/frontend/src/components/PriwaField/usePriwaSyncQueueRunner.ts
+++ b/frontend/src/components/PriwaField/usePriwaSyncQueueRunner.ts
@@ -1,0 +1,155 @@
+import { useCallback, useRef, useState } from "react";
+
+import {
+  loadPriwaSyncQueue,
+  type IPriwaQueuedMutation,
+} from "./priwaOfflineStore";
+import { updatePriwaSyncQueue } from "./priwaOfflineQueue";
+import type { IPriwaPoint } from "./types";
+import {
+  softDeletePriwaKaeferbaum,
+  upsertPriwaKaeferbaum,
+} from "./usePriwaKaeferbaeume";
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "PRIWA Synchronisation fehlgeschlagen.";
+
+const hasQueueWork = (queue: IPriwaQueuedMutation[]) =>
+  queue.some((mutation) => mutation.status !== "syncing");
+
+interface IPriwaSyncQueueRunnerOptions {
+  projectId: string | null | undefined;
+  userId: string | null;
+  isOnline: boolean;
+  onQueueUpdated: (queue: IPriwaQueuedMutation[]) => void;
+  onPointSynced: (point: IPriwaPoint) => void;
+  onPointDeleted: (pointId: string) => void;
+  onQueueDrained: () => Promise<void>;
+}
+
+export function usePriwaSyncQueueRunner({
+  projectId,
+  userId,
+  isOnline,
+  onQueueUpdated,
+  onPointSynced,
+  onPointDeleted,
+  onQueueDrained,
+}: IPriwaSyncQueueRunnerOptions) {
+  const syncPromiseRef = useRef<Promise<void> | null>(null);
+  const [isSyncingQueue, setSyncingQueue] = useState(false);
+
+  const updateStoredQueue = useCallback(
+    async (
+      updater: (queue: IPriwaQueuedMutation[]) => IPriwaQueuedMutation[],
+    ) => {
+      if (!projectId || !userId) return [];
+
+      return updatePriwaSyncQueue(projectId, userId, updater, onQueueUpdated);
+    },
+    [onQueueUpdated, projectId, userId],
+  );
+
+  const syncQueue = useCallback(async () => {
+    if (!projectId || !userId || !isOnline) return;
+
+    if (syncPromiseRef.current) {
+      await syncPromiseRef.current;
+      const latestQueue = await loadPriwaSyncQueue(projectId, userId);
+      if (hasQueueWork(latestQueue)) {
+        await syncQueue();
+      }
+      return;
+    }
+
+    syncPromiseRef.current = (async () => {
+      setSyncingQueue(true);
+      let shouldContinue = true;
+
+      while (shouldContinue) {
+        const currentQueue = await loadPriwaSyncQueue(projectId, userId);
+        const mutation = currentQueue.find(
+          (item) => item.status !== "syncing",
+        );
+        if (!mutation) {
+          if (currentQueue.length === 0) {
+            await onQueueDrained();
+          }
+          shouldContinue = false;
+          break;
+        }
+
+        const syncingMutation = {
+          ...mutation,
+          status: "syncing" as const,
+          retryCount: mutation.retryCount + 1,
+          updatedAt: new Date().toISOString(),
+          lastError: undefined,
+        };
+        await updateStoredQueue((queue) =>
+          queue.map((item) =>
+            item.id === mutation.id && item.updatedAt === mutation.updatedAt
+              ? syncingMutation
+              : item,
+          ),
+        );
+
+        try {
+          if (syncingMutation.type === "delete") {
+            await softDeletePriwaKaeferbaum(
+              syncingMutation.pointId,
+              syncingMutation.updatedAt,
+            );
+            onPointDeleted(syncingMutation.pointId);
+          } else if (syncingMutation.point) {
+            await upsertPriwaKaeferbaum(projectId, syncingMutation.point);
+            onPointSynced(syncingMutation.point);
+          }
+
+          await updateStoredQueue((queue) =>
+            queue.filter(
+              (item) =>
+                item.id !== syncingMutation.id ||
+                item.updatedAt !== syncingMutation.updatedAt ||
+                item.status !== "syncing",
+            ),
+          );
+        } catch (error) {
+          await updateStoredQueue((queue) =>
+            queue.map((item) =>
+              item.id === syncingMutation.id &&
+              item.updatedAt === syncingMutation.updatedAt &&
+              item.status === "syncing"
+                ? {
+                    ...syncingMutation,
+                    status: "failed" as const,
+                    lastError: getErrorMessage(error),
+                  }
+                : item,
+            ),
+          );
+          break;
+        }
+      }
+    })().finally(() => {
+      setSyncingQueue(false);
+      syncPromiseRef.current = null;
+    });
+
+    await syncPromiseRef.current;
+  }, [
+    isOnline,
+    onPointDeleted,
+    onPointSynced,
+    onQueueDrained,
+    projectId,
+    updateStoredQueue,
+    userId,
+  ]);
+
+  return {
+    isSyncingQueue,
+    syncQueue,
+    updateStoredQueue,
+  };
+}

--- a/frontend/src/hooks/usePriwaProjectMemberships.ts
+++ b/frontend/src/hooks/usePriwaProjectMemberships.ts
@@ -2,6 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useAuth } from "./useAuthProvider";
 import { supabase } from "./useSupabase";
+import {
+  loadCachedPriwaMemberships,
+  saveCachedPriwaMemberships,
+} from "../components/PriwaField/priwaOfflineStore";
 
 export interface IPriwaProjectMembership {
   projectId: string;
@@ -30,6 +34,9 @@ interface IPriwaMembershipRow {
 const firstProject = (project: IPriwaMembershipRow["priwa_projects"]) =>
   Array.isArray(project) ? (project[0] ?? null) : project;
 
+const isBrowserOffline = () =>
+  typeof navigator !== "undefined" && !navigator.onLine;
+
 export function usePriwaProjectMemberships() {
   const { status, user } = useAuth();
 
@@ -37,26 +44,42 @@ export function usePriwaProjectMemberships() {
     queryKey: ["priwa-project-memberships", user?.id],
     enabled: status === "authenticated" && !!user?.id,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from("priwa_project_memberships")
-        .select("project_id, role, priwa_projects(id, slug, name)")
-        .order("created_at", { ascending: true });
+      if (!user?.id) return [];
 
-      if (error) throw error;
+      if (isBrowserOffline()) {
+        const cachedMemberships = await loadCachedPriwaMemberships(user.id);
+        if (cachedMemberships.length > 0) return cachedMemberships;
+      }
 
-      return ((data ?? []) as IPriwaMembershipRow[])
-        .map((membership) => {
-          const project = firstProject(membership.priwa_projects);
-          if (!project) return null;
+      try {
+        const { data, error } = await supabase
+          .from("priwa_project_memberships")
+          .select("project_id, role, priwa_projects(id, slug, name)")
+          .order("created_at", { ascending: true });
 
-          return {
-            projectId: membership.project_id,
-            projectName: project.name,
-            projectSlug: project.slug,
-            role: membership.role,
-          } satisfies IPriwaProjectMembership;
-        })
-        .filter((membership): membership is IPriwaProjectMembership => membership !== null);
+        if (error) throw error;
+
+        const memberships = ((data ?? []) as IPriwaMembershipRow[])
+          .map((membership) => {
+            const project = firstProject(membership.priwa_projects);
+            if (!project) return null;
+
+            return {
+              projectId: membership.project_id,
+              projectName: project.name,
+              projectSlug: project.slug,
+              role: membership.role,
+            } satisfies IPriwaProjectMembership;
+          })
+          .filter((membership): membership is IPriwaProjectMembership => membership !== null);
+
+        await saveCachedPriwaMemberships(user.id, memberships);
+        return memberships;
+      } catch (error) {
+        const cachedMemberships = await loadCachedPriwaMemberships(user.id);
+        if (cachedMemberships.length > 0) return cachedMemberships;
+        throw error;
+      }
     },
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -1,6 +1,6 @@
 import PriwaFieldMap from "../components/PriwaField/PriwaFieldMap";
 import { usePriwaOfflineStatus } from "../components/PriwaField/usePriwaOfflineStatus";
-import { usePriwaKaeferbaeume } from "../components/PriwaField/usePriwaKaeferbaeume";
+import { usePriwaOfflineKaeferbaeume } from "../components/PriwaField/usePriwaOfflineKaeferbaeume";
 import { usePriwaProjectMemberships } from "../hooks/usePriwaProjectMemberships";
 import { Alert, Button, Result, Spin } from "antd";
 
@@ -21,7 +21,9 @@ export default function PriwaField() {
     updatePoint,
     deletePoint,
     isSaving,
-  } = usePriwaKaeferbaeume(activeMembership?.projectId);
+    syncSummary,
+    syncNow,
+  } = usePriwaOfflineKaeferbaeume(activeMembership?.projectId);
 
   if (!isOnline && isLoadingMemberships) {
     return (
@@ -31,7 +33,7 @@ export default function PriwaField() {
           title="PRIWA Felddaten offline noch nicht verfügbar"
           subTitle={
             serviceWorker.status === "ready"
-              ? "Die App ist installiert und offline startbar. Projektmitgliedschaft, Punkte und Synchronisation werden aber erst im nächsten Offline-Daten-Schritt lokal gespeichert."
+              ? "Die App ist installiert und offline startbar. Bitte öffne PRIWA Field einmal online, damit Projekt und Punkte lokal verfügbar sind."
               : "Die App ist offline, bevor die Offline-Hülle vollständig vorbereitet wurde. Bitte öffne PRIWA Field einmal mit Internetverbindung."
           }
           extra={
@@ -94,6 +96,8 @@ export default function PriwaField() {
       onAddPoint={createPoint}
       onUpdatePoint={updatePoint}
       onDeletePoint={deletePoint}
+      syncSummary={syncSummary}
+      onSyncNow={syncNow}
     />
   );
 }


### PR DESCRIPTION
## Summary
- cache PRIWA project memberships and field points locally after an online load
- add a local create/update/delete sync queue with pending/syncing/failed state
- show local sync state in the field map, point list, and point layer styling

## Validation
- npm --prefix frontend test -- priwaOfflineSync usePriwaOfflineKaeferbaeume
- npm --prefix frontend test
- npm --prefix frontend run lint
- npm --prefix frontend run build
- scripts/lint-ast-grep.sh
- local Supabase + Chrome smoke: seed local project/member/point, prime online, reload with PRIWA REST blocked and navigator offline, create offline point, restore online, verify sync row in local Postgres

## Notes
- This keeps the PR focused on local field data and mutation sync. Conflict resolution and richer sync UX can follow after field feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds local persistence and a queued create/update/delete sync flow that affects how field points are stored and written back to Supabase; failures or edge cases could lead to missing/duplicated updates or confusing UI state.
> 
> **Overview**
> **Adds offline-first support for PRIWA Field points.** Project memberships and points are now cached in IndexedDB via `localforage`, and the field page switches to `usePriwaOfflineKaeferbaeume` to read from cache when offline.
> 
> **Introduces a create/update/delete sync queue.** Local edits enqueue `pending/syncing/failed` mutations, coalesce redundant operations, auto-sync when back online, and expose a `syncSummary` + `syncNow` API.
> 
> **Updates UI to surface sync state.** The map layer panel adds a “Jetzt synchronisieren” button, `PriwaOfflineStatus` shows queue state, the point list marks local/failed items and counts “lokal”, and map point styling adds a dashed ring for unsynced/failed points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7d131d3596a7fa5c6783b4e84e010da9aea4f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline-first PRIWA field editing with local caching and queued syncs; automatic syncing when online
  * UI shows sync summary and per-point sync badges (pending, syncing, failed) in lists and map
  * Manual "Sync Now" control in the map layer panel
  * Project memberships and points available offline after an initial online visit

* **UX**
  * Point editor auto-opens required "Baum" section and sets estimated-location based on input source

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->