### PR TITLE
fix(priwa): include actor on soft delete sync

### DIFF
--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const supabaseMock = vi.hoisted(() => {
+  const eq = vi.fn().mockResolvedValue({ error: null });
+  const update = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ update }));
+
+  return { eq, update, from };
+});
+
+vi.mock("../../hooks/useSupabase", () => ({
+  supabase: {
+    from: supabaseMock.from,
+  },
+}));
+
+describe("softDeletePriwaKaeferbaum", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabaseMock.eq.mockResolvedValue({ error: null });
+  });
+
+  it("sends the RLS-required actor columns when soft deleting", async () => {
+    const { softDeletePriwaKaeferbaum } = await import("./usePriwaKaeferbaeume");
+
+    await softDeletePriwaKaeferbaum(
+      "point-1",
+      "user-1",
+      "2026-05-20T07:15:00.000Z",
+    );
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("priwa_kaeferbaeume");
+    expect(supabaseMock.update).toHaveBeenCalledWith({
+      deleted_at: "2026-05-20T07:15:00.000Z",
+      deleted_by: "user-1",
+      updated_by: "user-1",
+      client_updated_at: "2026-05-20T07:15:00.000Z",
+    });
+    expect(supabaseMock.eq).toHaveBeenCalledWith("id", "point-1");
+  });
+});

--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { supabase } from "../../hooks/useSupabase";
+import { useAuth } from "../../hooks/useAuthProvider";
 import type { IPriwaPoint, PriwaCoordinateSource } from "./types";
 
 type PriwaDbLocationSource = "qr_exact" | "gps_estimated" | "map_estimated";
@@ -156,11 +157,17 @@ export const upsertPriwaKaeferbaum = async (
 
 export const softDeletePriwaKaeferbaum = async (
   pointId: string,
+  userId: string,
   deletedAt = new Date().toISOString(),
 ) => {
   const { error } = await supabase
     .from("priwa_kaeferbaeume")
-    .update({ deleted_at: deletedAt })
+    .update({
+      deleted_at: deletedAt,
+      deleted_by: userId,
+      updated_by: userId,
+      client_updated_at: deletedAt,
+    })
     .eq("id", pointId);
 
   if (error) throw error;
@@ -168,6 +175,8 @@ export const softDeletePriwaKaeferbaum = async (
 
 export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
 
   const pointsQuery = useQuery({
     queryKey: priwaPointsQueryKey(projectId),
@@ -203,7 +212,8 @@ export function usePriwaKaeferbaeume(projectId: string | null | undefined) {
 
   const deletePoint = useMutation({
     mutationFn: async (pointId: string) => {
-      await softDeletePriwaKaeferbaum(pointId);
+      if (!userId) throw new Error("PRIWA user session is required.");
+      await softDeletePriwaKaeferbaum(pointId, userId);
     },
     onSuccess: invalidatePoints,
   });

--- a/frontend/src/components/PriwaField/usePriwaSyncQueueRunner.ts
+++ b/frontend/src/components/PriwaField/usePriwaSyncQueueRunner.ts
@@ -98,6 +98,7 @@ export function usePriwaSyncQueueRunner({
           if (syncingMutation.type === "delete") {
             await softDeletePriwaKaeferbaum(
               syncingMutation.pointId,
+              userId,
               syncingMutation.updatedAt,
             );
             onPointDeleted(syncingMutation.pointId);


### PR DESCRIPTION
## Summary
- Include the current user id as `deleted_by` and `updated_by` when PRIWA points are soft-deleted.
- Pass the queued sync user id through the offline delete sync path.
- Add a focused unit test for the Supabase soft-delete payload.

## Why
Live validation found that deleting a synced PRIWA point showed `Käferbaum gelöscht` locally, but the queued delete failed against RLS and the production row stayed active. The RLS policy requires the deleting actor to be present when `deleted_at` is set.

## Validation
- `npm test -- src/components/PriwaField/usePriwaKaeferbaeume.test.ts src/components/PriwaField/usePriwaOfflineKaeferbaeume.test.ts src/components/PriwaField/priwaOfflineSync.test.ts`
- `npm run build`
- `npm run lint`

## Notes
- The previously created live test row was not manually changed in this PR; Janusch said he will delete it after the fix is deployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PRIWA delete mutations to include user actor metadata required by RLS and threads `userId` through both online and queued/offline delete sync paths; risk is moderate because it affects production write semantics for deletions.
> 
> **Overview**
> Fixes PRIWA point soft-deletes to satisfy RLS by sending actor metadata alongside `deleted_at`.
> 
> `softDeletePriwaKaeferbaum` now requires a `userId` and updates `deleted_by`, `updated_by`, and `client_updated_at`; `usePriwaKaeferbaeume` pulls the current session via `useAuth` and blocks deletes without a user. Offline/queued delete sync (`usePriwaSyncQueueRunner`) now passes the queued `userId` into the delete call.
> 
> Adds a focused Vitest unit test asserting the Supabase update payload for soft deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a83c15c5ada240c01f6b4ff2a6a88eec7575ea8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deletion operations now include user attribution tracking, recording who performed each deletion and when for improved auditability.

* **Tests**
  * Added test coverage for soft delete operations to ensure proper tracking of user and timestamp data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->