### PR TITLE
fix(priwa): allow offline delete sync under RLS

### DIFF
--- a/frontend/e2e-local/priwa-field-write-flows.spec.ts
+++ b/frontend/e2e-local/priwa-field-write-flows.spec.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { expect, test, type Page } from "@playwright/test";
+
+const localSupabaseUrl = "http://127.0.0.1:54321";
+
+const uniqueRunId = `${Date.now()}-${randomUUID()}`;
+const fieldUserEmail = `priwa-write-${uniqueRunId}@example.com`;
+const fieldUserPassword = `Priwa-${uniqueRunId}!`;
+const projectSlug = `priwa-e2e-${uniqueRunId}`;
+const projectName = "PRIWA Local E2E";
+const baumnr = `E2E-${uniqueRunId.slice(-12)}`;
+const updatedBaumnr = `${baumnr}-U`;
+
+let adminClient: SupabaseClient;
+let fieldUserId = "";
+let projectId = "";
+
+test.describe("PRIWA local field write flows", () => {
+  test.skip(
+    process.env.E2E_LOCAL_PRIWA_WRITE !== "1",
+    "Set E2E_LOCAL_PRIWA_WRITE=1 and start local Supabase before running this write suite.",
+  );
+
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async () => {
+    adminClient = createLocalSupabaseClient(
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    );
+
+    await expectLocalService(
+      `${localSupabaseUrl}/auth/v1/settings`,
+      "local Supabase",
+    );
+    await deleteAuthUsersByEmail(adminClient, fieldUserEmail);
+
+    const user = await createConfirmedUser(fieldUserEmail, fieldUserPassword);
+    fieldUserId = user.id;
+    projectId = await createPriwaProjectWithMembership(fieldUserId);
+  });
+
+  test.afterAll(async () => {
+    if (projectId) {
+      await adminClient
+        .from("priwa_kaeferbaeume")
+        .delete()
+        .eq("project_id", projectId);
+      await adminClient
+        .from("priwa_project_memberships")
+        .delete()
+        .eq("project_id", projectId);
+      await adminClient.from("priwa_projects").delete().eq("id", projectId);
+    }
+
+    await deleteAuthUsersByEmail(adminClient, fieldUserEmail);
+  });
+
+  test("offline create, update, and delete sync into local Supabase", async ({
+    context,
+    page,
+  }) => {
+    await signInFieldUser(page);
+    await expect(page.getByTestId("priwa-field-map")).toBeVisible();
+
+    await context.setOffline(true);
+    await waitForBrowserOnlineState(page, false);
+
+    await createMapEstimatedPoint(page, baumnr);
+    await expect(page.getByText(/1 ausstehend|Synchronisiert/i)).toBeVisible();
+
+    await context.setOffline(false);
+    await waitForBrowserOnlineState(page, true);
+    await waitForPointRow(baumnr, (row) => row.deleted_at === null);
+
+    await context.setOffline(true);
+    await editFirstPointBaumnr(page, updatedBaumnr);
+    await expect(page.getByText(/1 ausstehend|Synchronisiert/i)).toBeVisible();
+
+    await context.setOffline(false);
+    await waitForBrowserOnlineState(page, true);
+    await waitForPointRow(updatedBaumnr, (row) => row.deleted_at === null);
+
+    await context.setOffline(true);
+    await deleteFirstPoint(page);
+    await expect(page.getByText(/1 ausstehend|Synchronisiert/i)).toBeVisible();
+
+    await context.setOffline(false);
+    await waitForBrowserOnlineState(page, true);
+    const deletedRow = await waitForPointRow(updatedBaumnr, (row) => {
+      return row.deleted_at !== null && row.deleted_by === fieldUserId;
+    });
+    expect(deletedRow.updated_by).toBe(fieldUserId);
+  });
+});
+
+async function createMapEstimatedPoint(page: Page, pointBaumnr: string) {
+  await page.getByRole("button", { name: "Punkt aufnehmen" }).click();
+  await expect(page.getByText("Käferbaum aufnehmen")).toBeVisible();
+
+  await page.getByRole("button", { name: "Auf Karte setzen" }).click();
+  await page.getByRole("button", { name: "Punkt übernehmen" }).click();
+  await expect(page.getByText("Position gesetzt")).toBeVisible();
+
+  await page.getByText("Baum", { exact: true }).click();
+  await page.getByLabel("Baumnr").fill(pointBaumnr);
+  await page.getByRole("button", { name: "Schnellspeichern" }).click();
+  await expect(page.getByText("Käferbaum gespeichert")).toBeVisible();
+}
+
+async function editFirstPointBaumnr(page: Page, pointBaumnr: string) {
+  await page.getByRole("button", { name: "Punktliste öffnen" }).click();
+  await page.getByRole("button", { name: "Punkt bearbeiten" }).first().click();
+  await expect(page.getByText("Käferbaum bearbeiten")).toBeVisible();
+
+  await page.getByLabel("Baumnr").fill(pointBaumnr);
+  await page.getByRole("button", { name: "Aktualisieren" }).click();
+  await expect(page.getByText("Käferbaum aktualisiert")).toBeVisible();
+}
+
+async function deleteFirstPoint(page: Page) {
+  await page.getByRole("button", { name: "Punktliste öffnen" }).click();
+  await page.getByRole("button", { name: "Punkt bearbeiten" }).first().click();
+  await expect(page.getByText("Käferbaum bearbeiten")).toBeVisible();
+
+  await page.getByRole("button", { name: "Löschen" }).click();
+  await page
+    .getByRole("dialog", { name: "Käferbaum löschen?" })
+    .getByRole("button", { name: "Löschen" })
+    .click();
+  await expect(page.getByText("Käferbaum gelöscht")).toBeVisible();
+}
+
+async function signInFieldUser(page: Page) {
+  await page.goto("/sign-in?returnTo=/priwa-field");
+  await page.getByPlaceholder(/email/i).fill(fieldUserEmail);
+  await page.getByPlaceholder(/password/i).fill(fieldUserPassword);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expect(page).toHaveURL(/\/priwa-field$/, { timeout: 20_000 });
+}
+
+async function waitForBrowserOnlineState(page: Page, expectedOnline: boolean) {
+  await page.waitForFunction(
+    (online) => window.navigator.onLine === online,
+    expectedOnline,
+  );
+}
+
+async function createPriwaProjectWithMembership(userId: string) {
+  const { data: project, error: projectError } = await adminClient
+    .from("priwa_projects")
+    .insert({
+      slug: projectSlug,
+      name: projectName,
+    })
+    .select("id")
+    .single();
+
+  if (projectError || !project) {
+    throw projectError ?? new Error("Failed to create local PRIWA project");
+  }
+
+  const { error: membershipError } = await adminClient
+    .from("priwa_project_memberships")
+    .insert({
+      project_id: project.id,
+      user_id: userId,
+      role: "field_user",
+    });
+
+  if (membershipError) {
+    throw membershipError;
+  }
+
+  return project.id as string;
+}
+
+async function waitForPointRow(
+  expectedBaumnr: string,
+  predicate: (row: IPriwaPointRow) => boolean,
+) {
+  const deadline = Date.now() + 20_000;
+  let lastRows: IPriwaPointRow[] | null = null;
+
+  while (Date.now() < deadline) {
+    const { data, error } = await adminClient
+      .from("priwa_kaeferbaeume")
+      .select("id, baumnr, deleted_at, deleted_by, updated_by")
+      .eq("project_id", projectId)
+      .eq("baumnr", expectedBaumnr)
+      .order("updated_at", { ascending: false });
+
+    expect(error).toBeNull();
+    lastRows = (data ?? []) as IPriwaPointRow[];
+    const matchingRow = lastRows.find(predicate);
+    if (matchingRow) {
+      return matchingRow;
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for PRIWA point ${expectedBaumnr}; last rows: ${JSON.stringify(lastRows)}`,
+  );
+}
+
+async function expectLocalService(url: string, name: string) {
+  const response = await fetch(url).catch((error) => {
+    throw new Error(`${name} is not reachable at ${url}: ${String(error)}`);
+  });
+
+  if (!response.ok) {
+    throw new Error(`${name} returned ${response.status} for ${url}`);
+  }
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set for the local PRIWA write E2E suite.`);
+  }
+  return value;
+}
+
+function createLocalSupabaseClient(key: string) {
+  return createClient(localSupabaseUrl, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+async function createConfirmedUser(email: string, password: string) {
+  const { data, error } = await adminClient.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+
+  if (error || !data.user) {
+    throw error ?? new Error(`Failed to create local user ${email}`);
+  }
+
+  return data.user;
+}
+
+async function findAuthUserByEmail(client: SupabaseClient, email: string) {
+  for (let page = 1; page <= 10; page += 1) {
+    const { data, error } = await client.auth.admin.listUsers({
+      page,
+      perPage: 100,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const user = data.users.find((candidate) => candidate.email === email);
+    if (user) {
+      return user;
+    }
+
+    if (data.users.length < 100) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+async function deleteAuthUsersByEmail(client: SupabaseClient, email: string) {
+  let user = await findAuthUserByEmail(client, email);
+
+  while (user) {
+    const { error } = await client.auth.admin.deleteUser(user.id);
+    if (error) {
+      throw error;
+    }
+    user = await findAuthUserByEmail(client, email);
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+type IPriwaPointRow = {
+  id: string;
+  baumnr: string;
+  deleted_at: string | null;
+  deleted_by: string | null;
+  updated_by: string | null;
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test:e2e:local:audit:write": "bash ./scripts/run-local-auditor-write-e2e.sh",
     "test:e2e:local": "playwright test --config playwright.local.config.ts",
     "test:e2e:local:write": "bash ./scripts/run-local-write-e2e.sh",
+    "test:e2e:local:priwa:write": "bash ./scripts/run-local-priwa-write-e2e.sh",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/frontend/scripts/run-local-priwa-write-e2e.sh
+++ b/frontend/scripts/run-local-priwa-write-e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+
+ENV_FILE="$REPO_ROOT/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  ENV_FILE="$REPO_ROOT/.env.example"
+fi
+
+for key in SUPABASE_SERVICE_ROLE_KEY SUPABASE_ANON_KEY; do
+  value="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "$value" ]]; then
+    echo "Missing $key in $ENV_FILE; local PRIWA write E2E needs local Supabase keys." >&2
+    exit 1
+  fi
+  export "$key=$value"
+done
+
+export E2E_LOCAL_PRIWA_WRITE=1
+export PLAYWRIGHT_PORT="${PLAYWRIGHT_PORT:-5175}"
+
+cd "$FRONTEND_DIR"
+exec ./node_modules/.bin/playwright test --config playwright.local.config.ts e2e-local/priwa-field-write-flows.spec.ts

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -343,9 +343,7 @@ export default function PriwaFieldMap({
       </div>
       <div className="flex items-center justify-between gap-4">
         <div>
-          <div className="text-sm font-medium text-gray-900">
-            Drohnenlayer
-          </div>
+          <div className="text-sm font-medium text-gray-900">Drohnenlayer</div>
           <div className="text-xs text-gray-500">
             {isCogLoading
               ? "Lade Drohnenlayer..."
@@ -376,6 +374,7 @@ export default function PriwaFieldMap({
 
   return (
     <div
+      data-testid="priwa-field-map"
       className="relative h-full min-h-[100dvh] w-full overflow-hidden bg-neutral-950"
       onPointerDownCapture={requestDeferredOrientationPermission}
     >
@@ -440,7 +439,8 @@ export default function PriwaFieldMap({
               onClick={openNewPointDrawer}
               aria-label="Punkt aufnehmen"
               style={{
-                right: "max(20px, calc(env(safe-area-inset-right, 0px) + 20px))",
+                right:
+                  "max(20px, calc(env(safe-area-inset-right, 0px) + 20px))",
                 bottom:
                   "max(20px, calc(env(safe-area-inset-bottom, 0px) + 20px))",
               }}

--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const supabaseMock = vi.hoisted(() => {
-  const eq = vi.fn().mockResolvedValue({ error: null });
-  const update = vi.fn(() => ({ eq }));
-  const from = vi.fn(() => ({ update }));
+  const order = vi.fn().mockResolvedValue({ data: [], error: null });
+  const is = vi.fn(() => ({ order }));
+  const selectEq = vi.fn(() => ({ is }));
+  const select = vi.fn(() => ({ eq: selectEq }));
+  const updateEq = vi.fn().mockResolvedValue({ error: null });
+  const update = vi.fn(() => ({ eq: updateEq }));
+  const from = vi.fn(() => ({ select, update }));
 
-  return { eq, update, from };
+  return { from, is, order, select, selectEq, update, updateEq };
 });
 
 vi.mock("../../hooks/useSupabase", () => ({
@@ -17,11 +21,29 @@ vi.mock("../../hooks/useSupabase", () => ({
 describe("softDeletePriwaKaeferbaum", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    supabaseMock.eq.mockResolvedValue({ error: null });
+    supabaseMock.order.mockResolvedValue({ data: [], error: null });
+    supabaseMock.updateEq.mockResolvedValue({ error: null });
+  });
+
+  it("fetches only current-state PRIWA rows", async () => {
+    const { fetchPriwaKaeferbaeume } = await import("./usePriwaKaeferbaeume");
+
+    await fetchPriwaKaeferbaeume("project-1");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("priwa_kaeferbaeume");
+    expect(supabaseMock.selectEq).toHaveBeenCalledWith(
+      "project_id",
+      "project-1",
+    );
+    expect(supabaseMock.is).toHaveBeenCalledWith("deleted_at", null);
+    expect(supabaseMock.order).toHaveBeenCalledWith("updated_at", {
+      ascending: false,
+    });
   });
 
   it("sends the RLS-required actor columns when soft deleting", async () => {
-    const { softDeletePriwaKaeferbaum } = await import("./usePriwaKaeferbaeume");
+    const { softDeletePriwaKaeferbaum } =
+      await import("./usePriwaKaeferbaeume");
 
     await softDeletePriwaKaeferbaum(
       "point-1",
@@ -36,6 +58,6 @@ describe("softDeletePriwaKaeferbaum", () => {
       updated_by: "user-1",
       client_updated_at: "2026-05-20T07:15:00.000Z",
     });
-    expect(supabaseMock.eq).toHaveBeenCalledWith("id", "point-1");
+    expect(supabaseMock.updateEq).toHaveBeenCalledWith("id", "point-1");
   });
 });

--- a/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
+++ b/frontend/src/components/PriwaField/usePriwaKaeferbaeume.ts
@@ -135,6 +135,7 @@ export const fetchPriwaKaeferbaeume = async (projectId: string) => {
       "id, project_id, geom, location_source, is_exact_location, baumnr, fund, baumart, bm, bohrloch, harz, nadel, rinde, kv, name, datum, kom, raw_qr_value, created_at, updated_at, client_updated_at",
     )
     .eq("project_id", projectId)
+    .is("deleted_at", null)
     .order("updated_at", { ascending: false });
 
   if (error) throw error;

--- a/supabase/migrations/20260521083000_fix_priwa_soft_delete_rls.sql
+++ b/supabase/migrations/20260521083000_fix_priwa_soft_delete_rls.sql
@@ -1,0 +1,65 @@
+create or replace function public.priwa_set_kaeferbaum_actor_fields()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+    current_actor uuid := (select auth.uid());
+begin
+    if TG_OP = 'INSERT' then
+        if current_actor is not null then
+            NEW.created_by = coalesce(NEW.created_by, current_actor);
+            NEW.updated_by = coalesce(NEW.updated_by, current_actor);
+            if NEW.deleted_at is not null then
+                NEW.deleted_by = current_actor;
+            end if;
+        end if;
+
+        NEW.created_at = now();
+        NEW.updated_at = NEW.created_at;
+        return NEW;
+    end if;
+
+    NEW.id = OLD.id;
+    NEW.project_id = OLD.project_id;
+    NEW.created_at = OLD.created_at;
+    NEW.created_by = OLD.created_by;
+    NEW.updated_at = now();
+
+    if current_actor is not null then
+        NEW.updated_by = current_actor;
+
+        if NEW.deleted_at is null then
+            NEW.deleted_by = null;
+        elsif OLD.deleted_at is null then
+            NEW.deleted_by = current_actor;
+        end if;
+    end if;
+
+    return NEW;
+end;
+$$;
+
+drop policy if exists "PRIWA members can read active kaeferbaeume"
+on "public"."priwa_kaeferbaeume";
+
+create policy "PRIWA members can read kaeferbaeume"
+on "public"."priwa_kaeferbaeume"
+as permissive
+for select
+to authenticated
+using (public.priwa_is_project_member(project_id));
+
+drop policy if exists "PRIWA members can update kaeferbaeume"
+on "public"."priwa_kaeferbaeume";
+
+create policy "PRIWA members can update kaeferbaeume"
+on "public"."priwa_kaeferbaeume"
+as permissive
+for update
+to authenticated
+using (
+    deleted_at is null
+    and public.priwa_is_project_member(project_id)
+)
+with check (public.priwa_is_project_member(project_id));


### PR DESCRIPTION
## Summary
- fix PRIWA kaeferbaum RLS so member soft-deletes can sync while still limiting updates to active project-member rows
- force soft-delete actor fields in the trigger and keep frontend fetches scoped to current-state rows
- add a local Supabase-backed Playwright flow for offline create, update, and delete sync

## Validation
- npm test -- usePriwaKaeferbaeume.test.ts usePriwaOfflineKaeferbaeume.test.ts priwaOfflineSync.test.ts
- npm run test:e2e:local:priwa:write
- npm run lint
- npm run build
- applied the new migration to local Supabase and verified an authenticated soft-delete probe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates database RLS policies and trigger behavior for `priwa_kaeferbaeume`, which can affect authorization and data visibility if misconfigured, though changes are scoped to PRIWA tables and validated by added tests.
> 
> **Overview**
> **Fixes PRIWA offline soft-delete syncing under RLS.** A new Supabase migration adjusts `priwa_kaeferbaeume` RLS: project members can `SELECT` all rows, but can only `UPDATE` rows where `deleted_at IS NULL`, and the `priwa_set_kaeferbaum_actor_fields` trigger now enforces/maintains `created_by`/`updated_by`/`deleted_by` semantics during inserts and soft-deletes.
> 
> On the frontend, `fetchPriwaKaeferbaeume` now filters out soft-deleted rows (`.is('deleted_at', null)`), tests are updated to assert the new query shape, and the PRIWA field map adds a `data-testid` to support a new local Supabase-backed Playwright E2E suite for offline create/update/delete sync (plus a new `test:e2e:local:priwa:write` script + runner).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c839b6150c21cde030950f63e26f1956880f4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->