### PR TITLE
fix(priwa): put observer name first in field form

### DIFF
--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -553,6 +553,9 @@ export default function PriwaPointDrawer({
                 forceRender: true,
                 children: (
                   <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+                    <Form.Item label="Name" name="name">
+                      <Select options={observerOptions} />
+                    </Form.Item>
                     <Form.Item
                       label="Baumnr"
                       name="baumnr"
@@ -572,9 +575,6 @@ export default function PriwaPointDrawer({
                     </Form.Item>
                     <Form.Item label="Baumart" name="baumart">
                       <Select options={baumartOptions} />
-                    </Form.Item>
-                    <Form.Item label="Name" name="name">
-                      <Select options={observerOptions} />
                     </Form.Item>
                     <Form.Item label="Datum" name="datum">
                       <Input type="date" />


### PR DESCRIPTION
## Summary
- moves the observer Name field to the first position in the PRIWA Baum form group
- keeps the rest of the recent field order unchanged

## Validation
- npm run lint
- npm test -- priwaOfflineSync.test.ts usePriwaKaeferbaeume.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reorders form fields without altering validation, persistence, or data model behavior.
> 
> **Overview**
> Reorders the PRIWA point capture form so the observer `Name` field appears first in the `Baum` section (before `Baumnr`), keeping the rest of the field order unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c6f91ac822895ff7c9d3af35176e614a5d6800. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the Name form field position within the Baum section for improved form layout and usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->