### PR TITLE
refactor(priwa): split map layers and offline controls

### DIFF
--- a/frontend/e2e-local/priwa-field-write-flows.spec.ts
+++ b/frontend/e2e-local/priwa-field-write-flows.spec.ts
@@ -146,7 +146,11 @@ async function expectOfflineBasemapControl(page: Page) {
   await expect(page.getByText("Luftbild", { exact: true })).toBeVisible();
   await page.getByText("Karte", { exact: true }).click();
   await expect(page.locator(".ol-layer").first()).toBeVisible();
-  await expect(page.getByText("Basiskarte offline")).toBeVisible();
+  await expect(page.getByText("Offline-Karten")).toBeHidden();
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "Offline-Karten speichern" }).click();
+  await expect(page.getByText("Offline-Karten")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Ausschnitt + Umgebung speichern" }),
   ).toBeVisible();

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -16,8 +16,6 @@ import {
   DownloadOutlined,
   EnvironmentOutlined,
   PlusOutlined,
-  SlidersOutlined,
-  SyncOutlined,
   UnorderedListOutlined,
 } from "@ant-design/icons";
 import "ol/ol.css";
@@ -58,6 +56,28 @@ import type {
 
 const FIELD_CENTER: [number, number] = [8.18013, 48.45596];
 type PriwaBaseLayer = "aerial" | "topographic";
+
+function MapLayersIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.8}
+    >
+      <path d="M9 18.5 3.5 16V5.5L9 8v10.5Z" />
+      <path d="m9 8 6-2.5 5.5 2.5v10.5L15 16l-6 2.5" />
+      <path d="M15 5.5V16" />
+      <path d="M6.2 10.2 9 11.5l3-1.25 3 1.25 2.8-1.2" opacity={0.55} />
+    </svg>
+  );
+}
 
 interface PriwaFieldMapProps {
   points: IPriwaPoint[];
@@ -393,7 +413,6 @@ export default function PriwaFieldMap({
     },
     [onDeletePoint],
   );
-  const hasPendingSync = (syncSummary?.total ?? 0) > 0;
   const basemapCachePercent =
     basemapCacheState.total > 0
       ? Math.round(
@@ -424,7 +443,7 @@ export default function PriwaFieldMap({
   }, [clearOfflineBasemapArea]);
 
   const layerPanel = (
-    <div className="w-64 space-y-3">
+    <div className="w-56 space-y-3">
       <div>
         <Typography.Text strong>Layer</Typography.Text>
         <div className="text-xs text-gray-500">
@@ -458,83 +477,91 @@ export default function PriwaFieldMap({
           </div>
         </div>
         <Switch
-          checked={isCogVisible}
+          checked={!!cogPath && isCogVisible}
           disabled={!cogPath}
           onChange={setCogVisible}
         />
       </div>
-      <div className="border-t border-slate-200 pt-3">
-        <div className="mb-2">
-          <div className="text-sm font-medium text-gray-900">
-            Basiskarte offline
-          </div>
-          <div className="text-xs text-gray-500">
-            Speichert den aktuellen Ausschnitt plus Umgebung. Online geladene
-            Luftbild- und Kartenkacheln bleiben zusätzlich offline verfügbar.
-          </div>
-        </div>
-        {offlineBasemapArea && (
-          <div className="mb-2 rounded-md border border-emerald-100 bg-emerald-50 px-2 py-1.5 text-xs text-emerald-900">
-            {offlineBasemapArea.cachedTileCount} Kacheln · Zoom{" "}
-            {offlineBasemapArea.minZoom}-{offlineBasemapArea.maxZoom} ·{" "}
-            {offlineBasemapArea.areaKm2.toFixed(2)} km²
-          </div>
-        )}
-        <Button
-          block
-          size="small"
-          type={offlineBasemapArea ? "default" : "primary"}
-          icon={<DownloadOutlined />}
-          loading={basemapCacheState.isCaching}
-          disabled={!isOfflineBasemapSupported}
-          onClick={() => void handleCacheBasemapArea()}
-        >
-          Ausschnitt + Umgebung speichern
-        </Button>
-        {basemapCacheState.isCaching && (
-          <Progress
-            className="mt-2"
-            percent={basemapCachePercent}
-            size="small"
-            status={basemapCacheState.failed > 0 ? "exception" : "active"}
-          />
-        )}
-        {basemapCacheState.errorMessage && (
-          <div className="mt-1 text-xs text-red-600">
-            {basemapCacheState.errorMessage}
-          </div>
-        )}
-        {offlineBasemapArea && (
-          <Button
-            block
-            className="mt-2"
-            size="small"
-            icon={<DeleteOutlined />}
-            disabled={basemapCacheState.isCaching}
-            onClick={() => void handleClearBasemapArea()}
-          >
-            Bereich entfernen
-          </Button>
-        )}
-        {!isOfflineBasemapSupported && (
-          <div className="mt-1 text-xs text-amber-700">
-            Dieser Browser unterstützt den Offline-Kartenspeicher nicht.
-          </div>
-        )}
-      </div>
-      <div className="border-t border-slate-200 pt-3">
-        <Button
-          block
-          size="small"
-          icon={<SyncOutlined spin={!!syncSummary?.syncing} />}
-          disabled={!hasPendingSync || !onSyncNow}
-          onClick={() => void onSyncNow?.()}
-        >
-          Jetzt synchronisieren
-        </Button>
-      </div>
     </div>
   );
+
+  const offlineMapPanel = (
+    <div className="w-64 space-y-3">
+      <div>
+        <Typography.Text strong>Offline-Karten</Typography.Text>
+        <div className="mt-1 text-xs text-gray-500">
+          Speichert den aktuellen Ausschnitt plus Umgebung für Luftbild und
+          Karte.
+        </div>
+      </div>
+      {offlineBasemapArea && (
+        <div className="rounded-md border border-emerald-100 bg-emerald-50 px-2 py-1.5 text-xs text-emerald-900">
+          {offlineBasemapArea.cachedTileCount} Kacheln · Zoom{" "}
+          {offlineBasemapArea.minZoom}-{offlineBasemapArea.maxZoom} ·{" "}
+          {offlineBasemapArea.areaKm2.toFixed(2)} km²
+        </div>
+      )}
+      <Button
+        block
+        size="small"
+        type={offlineBasemapArea ? "default" : "primary"}
+        icon={<DownloadOutlined />}
+        loading={basemapCacheState.isCaching}
+        disabled={!isOfflineBasemapSupported}
+        onClick={() => void handleCacheBasemapArea()}
+      >
+        Ausschnitt + Umgebung speichern
+      </Button>
+      {basemapCacheState.isCaching && (
+        <Progress
+          percent={basemapCachePercent}
+          size="small"
+          status={basemapCacheState.failed > 0 ? "exception" : "active"}
+        />
+      )}
+      {basemapCacheState.errorMessage && (
+        <div className="text-xs text-red-600">
+          {basemapCacheState.errorMessage}
+        </div>
+      )}
+      {offlineBasemapArea && (
+        <Button
+          block
+          danger
+          size="small"
+          icon={<DeleteOutlined />}
+          disabled={basemapCacheState.isCaching}
+          onClick={() => void handleClearBasemapArea()}
+        >
+          Bereich entfernen
+        </Button>
+      )}
+      {!isOfflineBasemapSupported && (
+        <div className="text-xs text-amber-700">
+          Dieser Browser unterstützt den Offline-Kartenspeicher nicht.
+        </div>
+      )}
+      {offlineBasemapArea && (
+        <div className="text-xs text-gray-500">
+          Die Umrisslinie auf der Karte zeigt den gespeicherten Bereich.
+        </div>
+      )}
+    </div>
+  );
+
+  const offlineMapButtonTitle = offlineBasemapArea
+    ? "Offline-Karten verwalten"
+    : "Offline-Karten speichern";
+
+  const offlineMapButtonIcon = basemapCacheState.isCaching ? (
+    <DownloadOutlined spin />
+  ) : (
+    <DownloadOutlined />
+  );
+
+  const offlineMapButtonClassName = offlineBasemapArea
+    ? "pointer-events-auto border-emerald-600 text-emerald-700 shadow-md"
+    : "pointer-events-auto shadow-md";
 
   return (
     <div
@@ -573,8 +600,22 @@ export default function PriwaFieldMap({
                 className="pointer-events-auto shadow-md"
                 shape="circle"
                 size="large"
-                icon={<SlidersOutlined />}
+                icon={<MapLayersIcon />}
                 aria-label="Layer auswählen"
+              />
+            </Popover>
+            <Popover
+              trigger="click"
+              placement="rightTop"
+              content={offlineMapPanel}
+            >
+              <Button
+                className={offlineMapButtonClassName}
+                type={offlineBasemapArea ? "primary" : "default"}
+                shape="circle"
+                size="large"
+                icon={offlineMapButtonIcon}
+                aria-label={offlineMapButtonTitle}
               />
             </Popover>
             <Tooltip title={pointListToggleLabel}>
@@ -596,7 +637,6 @@ export default function PriwaFieldMap({
           {!isPointListOpen && !isDrawerOpen && (
             <FloatButton
               className="priwa-add-point-fab"
-              type="primary"
               shape="circle"
               icon={<PlusOutlined />}
               tooltip={{ title: "Punkt aufnehmen", placement: "left" }}
@@ -649,7 +689,10 @@ export default function PriwaFieldMap({
               {locationHintLabel}
             </div>
           )}
-          <PriwaOfflineStatus syncSummary={syncSummary} />
+          <PriwaOfflineStatus
+            syncSummary={syncSummary}
+            onSyncNow={onSyncNow}
+          />
         </div>
       )}
 

--- a/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
+++ b/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
@@ -1,5 +1,5 @@
 import { CloudSyncOutlined, DisconnectOutlined } from "@ant-design/icons";
-import { Tag, Tooltip } from "antd";
+import { Button, Popover, Tag, Tooltip, Typography } from "antd";
 
 import { getPriwaOfflineStatusView } from "./priwaOfflineStatusView";
 import type { IPriwaSyncSummary } from "./priwaOfflineSync";
@@ -7,6 +7,7 @@ import { usePriwaOfflineStatus } from "./usePriwaOfflineStatus";
 
 interface PriwaOfflineStatusProps {
   syncSummary?: IPriwaSyncSummary;
+  onSyncNow?: () => Promise<void>;
 }
 
 const getSyncLabel = (syncSummary?: IPriwaSyncSummary) => {
@@ -18,6 +19,7 @@ const getSyncLabel = (syncSummary?: IPriwaSyncSummary) => {
 
 export default function PriwaOfflineStatus({
   syncSummary,
+  onSyncNow,
 }: PriwaOfflineStatusProps) {
   const { isOnline, serviceWorker } = usePriwaOfflineStatus();
   const statusView = getPriwaOfflineStatusView(
@@ -37,16 +39,55 @@ export default function PriwaOfflineStatus({
     (syncSummary && syncSummary.total > 0
       ? `${syncSummary.pending} ausstehend, ${syncSummary.syncing} wird synchronisiert, ${syncSummary.failed} fehlgeschlagen`
       : statusView.label);
+  const hasSyncWork = (syncSummary?.total ?? 0) > 0;
+  const statusTag = (
+    <Tag
+      className="pointer-events-auto m-0 rounded-md border-0 px-2.5 py-1 text-xs font-medium shadow-sm"
+      color={color}
+      icon={isOnline ? <CloudSyncOutlined /> : <DisconnectOutlined />}
+    >
+      {label}
+    </Tag>
+  );
+
+  if (!hasSyncWork && !serviceWorker.errorMessage) {
+    return <Tooltip title={tooltipTitle}>{statusTag}</Tooltip>;
+  }
 
   return (
-    <Tooltip title={tooltipTitle}>
-      <Tag
-        className="pointer-events-auto m-0 rounded-md border-0 px-2.5 py-1 text-xs font-medium shadow-sm"
-        color={color}
-        icon={isOnline ? <CloudSyncOutlined /> : <DisconnectOutlined />}
+    <Popover
+      trigger="click"
+      placement="bottomRight"
+      content={
+        <div className="w-60 space-y-3">
+          <div>
+            <Typography.Text strong>Syncstatus</Typography.Text>
+            <div className="mt-1 text-xs text-gray-500">{tooltipTitle}</div>
+          </div>
+          {serviceWorker.errorMessage && (
+            <div className="rounded-md bg-red-50 px-2 py-1.5 text-xs text-red-700">
+              {serviceWorker.errorMessage}
+            </div>
+          )}
+          <Button
+            block
+            size="small"
+            icon={<CloudSyncOutlined spin={!!syncSummary?.syncing} />}
+            disabled={!hasSyncWork || !onSyncNow}
+            onClick={() => void onSyncNow?.()}
+          >
+            Jetzt synchronisieren
+          </Button>
+        </div>
+      }
+    >
+      <button
+        type="button"
+        className="pointer-events-auto border-0 bg-transparent p-0"
+        aria-label="Offline- und Syncstatus anzeigen"
       >
-        {label}
-      </Tag>
-    </Tooltip>
+        {statusTag}
+      </button>
+    </Popover>
   );
 }

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -536,6 +536,10 @@ export default function PriwaPointDrawer({
             }
           }}
         >
+          <Form.Item label="Name" name="name">
+            <Select options={observerOptions} />
+          </Form.Item>
+
           <Collapse
             ghost
             size="small"
@@ -553,9 +557,6 @@ export default function PriwaPointDrawer({
                 forceRender: true,
                 children: (
                   <div className="grid grid-cols-1 gap-x-2 sm:grid-cols-2">
-                    <Form.Item label="Name" name="name">
-                      <Select options={observerOptions} />
-                    </Form.Item>
                     <Form.Item
                       label="Baumnr"
                       name="baumnr"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -284,6 +284,21 @@
 .priwa-add-point-fab {
   width: 52px !important;
   height: 52px !important;
+  color: #2d6b3f !important;
+  box-shadow:
+    0 8px 24px rgb(15 23 42 / 18%),
+    0 2px 6px rgb(15 23 42 / 14%) !important;
+}
+
+.priwa-add-point-fab .ant-float-btn-body {
+  background: #ffffff !important;
+  border: 1px solid rgb(226 232 240) !important;
+}
+
+.priwa-add-point-fab:hover .ant-float-btn-body,
+.priwa-add-point-fab:focus-visible .ant-float-btn-body {
+  background: #f8fafc !important;
+  border-color: #2d6b3f !important;
 }
 
 .priwa-add-point-fab .ant-float-btn-body,
@@ -306,4 +321,5 @@
 
 .priwa-add-point-fab .anticon {
   font-size: 20px;
+  color: #2d6b3f !important;
 }


### PR DESCRIPTION
## Summary
- keeps the layer button focused on map appearance only: Luftbild, Karte, and optional Drohnenlayer
- moves offline basemap storage into its own map button and popover
- moves manual sync retry into the offline/sync status badge popover
- updates the local PRIWA write smoke to assert the split controls

## Validation
- npm run lint
- npm test -- priwaOfflineBasemap.test.ts priwaOfflineStatus.test.ts priwaOfflineSync.test.ts usePriwaKaeferbaeume.test.ts
- npm run build
- npm run test:e2e:local:priwa:write

## Notes
- This PR is stacked on PR #364: https://github.com/Deadwood-ai/deadtrees/pull/364 so the diff stays focused. After #364 merges, retarget this PR to main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that reshuffles existing offline basemap and sync controls; main risk is regressions in field-map interactions and e2e selectors due to changed popovers/buttons.
> 
> **Overview**
> Separates the PRIWA field map controls: the *Layer* popover now only covers basemap selection and the optional drone overlay, while offline basemap caching/removal moves to a new dedicated **Offline-Karten** button + popover (with progress/error display and saved-area hints).
> 
> Moves the manual “Jetzt synchronisieren” action out of the map controls and into `PriwaOfflineStatus` via a clickable status badge popover that can show sync details and trigger `onSyncNow`.
> 
> Updates the local Playwright write-flow smoke test to assert the new split controls and button labels (layer popover no longer contains offline map UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73894588be165b564076686a05cddd82152dd1de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->