### PR TITLE
fix(processor): restrict TCD container NVIDIA capabilities to compute…

### DIFF
--- a/processor/src/treecover_segmentation_oam_tcd/predict_treecover.py
+++ b/processor/src/treecover_segmentation_oam_tcd/predict_treecover.py
@@ -289,7 +289,7 @@ def _run_tcd_pipeline_container(volume_name: str, dataset_id: int, token: str) -
 				runtime='nvidia',
 				environment={
 					'NVIDIA_VISIBLE_DEVICES': 'all',
-					'NVIDIA_DRIVER_CAPABILITIES': 'all',
+					'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility',
 				},
 				labels={
 					**resource_labels,


### PR DESCRIPTION
…,utility

The NVIDIA container runtime tries to bind-mount /usr/bin/nvidia-cuda-mps-control from the host when NVIDIA_DRIVER_CAPABILITIES includes 'all' (which implies the 'mps' capability). After a host-side NVIDIA driver update on 2026-05-22 that removed this binary, every TCD segmentation job failed to start its GPU container and silently fell back to CPU — affecting 27 datasets over 4 days.

docker-compose.processor.yaml was already fixed in 600d8c9; this applies the same change to the programmatic Docker container spawn in predict_treecover.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GPU container environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->