### PR TITLE
fix(cli): move compose down into cleanup and add -T to run_dev exec

### DIFF
--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -509,6 +509,9 @@ class DevCommands:
 		except Exception as e:
 			print(f'⚠ Cleanup error: {str(e)}')
 
+		print('Stopping Docker compose stack...')
+		self._run_command(self._compose_lifecycle_cmd('down'), check=False)
+
 	def start(self, force_rebuild: bool = False, services: Optional[List[str]] = None):
 		"""Start the shared test environment, optionally scoped to a subset of services."""
 		selected_services = self._normalize_services(services) or self._get_compose_services()
@@ -665,6 +668,7 @@ class DevCommands:
 					'-f',
 					self.test_compose_file,
 					'exec',
+					'-T',
 					'processor-test',
 					'python',
 					# '-m',


### PR DESCRIPTION
_cleanup_development_environment now tears down the compose stack itself so all callers (cleanup(), signal handler, exception path) consistently bring services down without relying on the caller to do it.

Also adds -T to the continuous processor exec in run_dev, matching the non-TTY pattern already used in _compose_exec_args — prevents hangs when run without an attached terminal.