### PR TITLE
fix(processor): requeue stale tasks instead of marking as error

### DIFF
--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -71,7 +71,8 @@ class DevCommands:
 		cmd = self._compose_cmd(action)
 		if flags:
 			cmd.extend(flags)
-		cmd.append('--remove-orphans')
+		if not services:
+			cmd.append('--remove-orphans')
 		if services:
 			cmd.extend(services)
 		return cmd

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -16,20 +16,25 @@ server {
     listen [::]:80 default_server;
     client_max_body_size 10G;
 
+    # Resolve api-test at request time so nginx starts even when api-test is not running
+    # (e.g. processor-only test runs). Docker's embedded DNS is always at 127.0.0.11.
+    resolver 127.0.0.11 valid=5s;
+
     index =401;
     # root /data;
 
 
     location /api/v1 {
         rewrite  ^/api/v1/?(.*)$ /$1 break;
-        proxy_pass http://api-test:8017;
-        
+        set $api_backend "api-test:8017";
+        proxy_pass http://$api_backend;
+
         # Standard proxy headers
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
+
         # Required for Swagger UI websockets
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -39,7 +44,8 @@ server {
 
     location = /_prepackaged_download_auth {
         internal;
-        proxy_pass http://api-test:8017/prepackaged/grants/validate;
+        set $api_backend "api-test:8017";
+        proxy_pass http://$api_backend/prepackaged/grants/validate;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
         proxy_set_header X-Original-URI $request_uri;

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -38,6 +38,7 @@ COPY ./shared /app/shared
 
 # Copy pytest configuration for custom marks
 COPY pytest.ini /app/pytest.ini
+COPY .dockerignore /app/.dockerignore
 
 # Copy entrypoint script and make it executable
 COPY processor/entrypoint.sh /entrypoint.sh

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -1,4 +1,5 @@
 import shutil
+import docker
 from pathlib import Path
 from processor.src.process_geotiff import process_geotiff
 from processor.src.process_odm import process_odm
@@ -18,6 +19,33 @@ from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandl
 
 # Initialize logger with proper cleanup
 logger = UnifiedLogger(__name__)
+
+
+def _kill_dangling_dataset_resources(dataset_id: int):
+	"""Kill any running containers and remove volumes left over from an interrupted job."""
+	try:
+		client = docker.from_env()
+		label_filter = f'dt_dataset_id={dataset_id}'
+
+		containers = client.containers.list(all=True, filters={'label': label_filter})
+		for c in containers:
+			try:
+				if c.status == 'running':
+					c.stop(timeout=10)
+				c.remove(force=True)
+				logger.info(f'Removed dangling container {c.short_id} for dataset {dataset_id}')
+			except Exception as e:
+				logger.warning(f'Failed to remove dangling container {c.short_id} for dataset {dataset_id}: {e}')
+
+		volumes = client.volumes.list(filters={'label': label_filter})
+		for v in volumes:
+			try:
+				v.remove()
+				logger.info(f'Removed dangling volume {v.name} for dataset {dataset_id}')
+			except Exception as e:
+				logger.warning(f'Failed to remove dangling volume {v.name} for dataset {dataset_id}: {e}')
+	except Exception as e:
+		logger.warning(f'Error during dangling resource cleanup for dataset {dataset_id}: {e}')
 logger.add_supabase_handler(SupabaseHandler())
 
 # Maps each task type to its corresponding is_*_done flag and human-readable stage name.
@@ -499,11 +527,12 @@ def background_process():
 				status_resp = client.table(settings.statuses_table) \
 					.select('*').eq('dataset_id', active_task.dataset_id).execute()
 
-			should_mark_error = True
+			_kill_dangling_dataset_resources(active_task.dataset_id)
+
 			if status_resp.data:
 				status = status_resp.data[0]
-				completed = get_completed_stages(status)
 				if are_requested_stages_complete(status, active_task.task_types):
+					# All stages finished — just remove the stale queue row.
 					logger.info(
 						f'Removing stale completed queue task {active_task.id} for dataset {active_task.dataset_id}',
 						LogContext(
@@ -513,44 +542,32 @@ def background_process():
 							token=token,
 						),
 					)
-					should_mark_error = False
-					crashed_stage = 'completed'
-					error_msg = ''
-				elif status['current_status'] != 'idle':
-					crashed_stage = detect_crashed_stage(status, active_task.task_types)
-					error_msg = f'Processing container crashed during {crashed_stage}. Completed: {completed}'
-				elif completed:
-					crashed_stage = detect_crashed_stage(status, active_task.task_types)
-					error_msg = f'Processing container crashed after completing {completed} and before starting {crashed_stage}.'
-				else:
-					crashed_stage = 'startup'
-					error_msg = 'Processing container crashed before the first stage status update.'
-			else:
-				crashed_stage = 'unknown'
-				error_msg = 'Processing container crashed and no status row was available for recovery.'
+					with use_client(token) as client:
+						client.table(settings.queue_table).delete().eq('id', active_task.id).execute()
+					continue
 
-			if should_mark_error:
-				update_status(
-					token,
+			# Incomplete job — reset for retry rather than marking as error.
+			# Deployments and clean restarts interrupt jobs without any fault in the
+			# data or code; treating them as errors creates noise and requires manual
+			# re-queuing. The task is left in the queue with is_processing=False so
+			# it will be picked up again on the next processor run.
+			logger.info(
+				f'Re-queuing interrupted task {active_task.id} for dataset {active_task.dataset_id}',
+				LogContext(
+					category=LogCategory.PROCESS,
 					dataset_id=active_task.dataset_id,
-					current_status=StatusEnum.idle,
-					has_error=True,
-					error_message=error_msg,
-				)
-
-				try:
-					create_processing_failure_issue(
-						token=token,
-						dataset_id=active_task.dataset_id,
-						stage=crashed_stage,
-						error_message=error_msg,
-					)
-				except Exception as linear_error:
-					logger.warning(f'Failed to create Linear issue for stale active task: {linear_error}')
-
+					user_id=active_task.user_id,
+					token=token,
+				),
+			)
 			with use_client(token) as client:
-				client.table(settings.queue_table).delete().eq('id', active_task.id).execute()
-			continue
+				client.table(settings.statuses_table).update({
+					'current_status': StatusEnum.idle.value,
+					'has_error': False,
+					'error_message': None,
+				}).eq('dataset_id', active_task.dataset_id).execute()
+				client.table(settings.queue_table).update({'is_processing': False}).eq('id', active_task.id).execute()
+			return  # defer processing of re-queued task to the next cron run
 
 		task = get_next_task(token)
 		if task is None:

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -602,32 +602,32 @@ def crashed_dataset_task(test_processor_user, auth_token):
 					client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
 
 
-def test_background_process_detects_crashed_dataset(crashed_dataset_task, auth_token):
-	"""Test that background_process detects a crashed dataset, marks it as errored,
-	and removes it from the queue."""
+def test_background_process_requeues_interrupted_dataset(crashed_dataset_task, auth_token, monkeypatch):
+	"""Interrupted tasks (processor restarted mid-job) are re-queued rather than
+	marked as errors, so deployments don't require manual re-queuing."""
+	monkeypatch.setattr(processor_module, '_kill_dangling_dataset_resources', lambda dataset_id: None)
+
 	dataset_id = crashed_dataset_task['dataset_id']
 
-	# Run the background process -- should detect the crash and clear it
 	background_process()
 
 	with use_client(auth_token) as client:
-		# Task should be removed from queue
 		queue_response = (
 			client.table(settings.queue_table).select('*')
 			.eq('id', crashed_dataset_task['task_id']).execute()
 		)
-		assert len(queue_response.data) == 0, 'Crashed task should be removed from queue'
+		assert len(queue_response.data) == 1, 'Interrupted task should remain in queue for retry'
+		assert queue_response.data[0]['is_processing'] is False, 'Task should be reset to is_processing=False'
 
-		# Status should be marked as errored with current_status back to idle
 		status_response = (
 			client.table(settings.statuses_table).select('*')
 			.eq('dataset_id', dataset_id).execute()
 		)
 		assert len(status_response.data) == 1
 		status = status_response.data[0]
-		assert status['has_error'] is True, 'Status should have has_error=True'
+		assert status['has_error'] is False, 'Interrupted task should not be marked as error'
 		assert status['current_status'] == 'idle', 'Status should be reset to idle'
-		assert 'deadwood_segmentation' in status['error_message'], 'Error should mention crashed stage'
+		assert status['error_message'] is None, 'Error message should be cleared'
 
 
 @pytest.fixture
@@ -681,10 +681,13 @@ def stale_active_task_without_stage_update(test_processor_user, auth_token):
 					client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
 
 
-def test_background_process_detects_stale_active_task_without_stage_update(
-	stale_active_task_without_stage_update, auth_token
+def test_background_process_requeues_stale_task_without_stage_update(
+	stale_active_task_without_stage_update, auth_token, monkeypatch
 ):
-	"""Test that background_process clears a stale active queue row even if status stayed idle."""
+	"""A stale task that never wrote a stage update (processor killed at startup) is
+	re-queued rather than marked as error."""
+	monkeypatch.setattr(processor_module, '_kill_dangling_dataset_resources', lambda dataset_id: None)
+
 	dataset_id = stale_active_task_without_stage_update['dataset_id']
 
 	background_process()
@@ -694,7 +697,8 @@ def test_background_process_detects_stale_active_task_without_stage_update(
 			client.table(settings.queue_table).select('*')
 			.eq('id', stale_active_task_without_stage_update['task_id']).execute()
 		)
-		assert len(queue_response.data) == 0, 'Stale active task should be removed from queue'
+		assert len(queue_response.data) == 1, 'Task should remain in queue for retry'
+		assert queue_response.data[0]['is_processing'] is False, 'Task should be reset to is_processing=False'
 
 		status_response = (
 			client.table(settings.statuses_table).select('*')
@@ -702,9 +706,9 @@ def test_background_process_detects_stale_active_task_without_stage_update(
 		)
 		assert len(status_response.data) == 1
 		status = status_response.data[0]
-		assert status['has_error'] is True, 'Status should have has_error=True'
-		assert status['current_status'] == 'idle', 'Status should remain/reset to idle'
-		assert 'before the first stage status update' in status['error_message']
+		assert status['has_error'] is False, 'Task should not be marked as error'
+		assert status['current_status'] == 'idle'
+		assert status['error_message'] is None
 
 
 @pytest.fixture
@@ -763,8 +767,7 @@ def test_background_process_removes_stale_completed_active_task_without_marking_
 	stale_completed_active_task, auth_token, monkeypatch
 ):
 	"""Completed tasks should not be reclassified as crashes during stale queue recovery."""
-	issue_calls = []
-	monkeypatch.setattr(processor_module, 'create_processing_failure_issue', lambda **kwargs: issue_calls.append(kwargs))
+	monkeypatch.setattr(processor_module, '_kill_dangling_dataset_resources', lambda dataset_id: None)
 
 	dataset_id = stale_completed_active_task['dataset_id']
 
@@ -785,4 +788,16 @@ def test_background_process_removes_stale_completed_active_task_without_marking_
 		status = status_response.data[0]
 		assert status['has_error'] is False, 'Completed stale task should not be marked as errored'
 		assert status['current_status'] == 'idle', 'Completed status should remain idle'
-		assert issue_calls == [], 'Completed stale tasks should not create failure issues'
+
+
+def test_kill_dangling_resources_called_on_stale_task_recovery(crashed_dataset_task, monkeypatch):
+	"""_kill_dangling_dataset_resources is called with the correct dataset_id when
+	a stale active task is found, so orphaned containers and volumes are cleaned up."""
+	killed_ids = []
+	monkeypatch.setattr(processor_module, '_kill_dangling_dataset_resources', lambda dataset_id: killed_ids.append(dataset_id))
+
+	background_process()
+
+	assert crashed_dataset_task['dataset_id'] in killed_ids, (
+		'_kill_dangling_dataset_resources should be called with the stale task dataset_id'
+	)


### PR DESCRIPTION
Interrupted tasks (OOM kills, deployments) are now reset with is_processing=False and deferred to the next cron run rather than being marked as errors, since restarts are not data faults.

Also fixes nginx startup when api-test is not running (processor-only test runs) by deferring DNS resolution to request time, and copies .dockerignore into the processor test container so test_dockerignore passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Processing jobs that are interrupted or stalled are now requeued for retry instead of being marked as errors.
- Enhanced cleanup of orphaned Docker resources and containers associated with stale processing tasks.
- Improved API backend routing resolution for increased reliability.
- Refined container orchestration command handling for better resource cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->