### PR TITLE
feat(audit): remove hardcoded legacy dataset ID limit

### DIFF
--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -268,12 +268,6 @@ function DatasetAuditInner() {
 		setSearchParams(params, { replace: true });
 	}, [activeTab, statusFilter, biomeFilter, countryFilter, auditorFilter, contributorFilter, hasFlagsFilter, idFilter, setSearchParams]);
 
-	// Minimum dataset ID for auditing
-	const MIN_AUDIT_DATASET_ID = 2559;
-	const hasAboveMinId = useMemo(() => {
-		return (datasets || []).some((d) => d.id > MIN_AUDIT_DATASET_ID);
-	}, [datasets]);
-
 	// Create maps for quick lookup
 	const auditMap = useMemo(() => {
 		if (!audits) return new Map<number, DatasetAuditUserInfo>();
@@ -366,12 +360,6 @@ function DatasetAuditInner() {
 		if (!datasets) return [];
 
 		let filtered = datasets;
-
-		// Apply minimum ID filter only for core audit workflow tabs.
-		// Edits & Flags and Reference should include legacy dataset IDs.
-		if ((activeTab === "pending" || activeTab === "completed") && hasAboveMinId) {
-			filtered = filtered.filter((dataset) => dataset.id > MIN_AUDIT_DATASET_ID);
-		}
 
 		// Tab-based filtering
 		if (activeTab === "pending") {
@@ -498,7 +486,6 @@ function DatasetAuditInner() {
 		correctionsMap,
 		contributorMap,
 		flaggedAgg,
-		hasAboveMinId,
 		referenceDatasetIds,
 	]);
 
@@ -571,15 +558,13 @@ function DatasetAuditInner() {
 	// Compute counts for tabs
 	const pendingCount = useMemo(() => {
 		if (!datasets) return 0;
-		const base = hasAboveMinId ? datasets.filter((d) => d.id > MIN_AUDIT_DATASET_ID) : datasets;
-		return base.filter((d) => !d.is_audited && isProcessingComplete(d)).length;
-	}, [datasets, hasAboveMinId]);
+		return datasets.filter((d) => !d.is_audited && isProcessingComplete(d)).length;
+	}, [datasets]);
 
 	const completedCount = useMemo(() => {
 		if (!datasets) return 0;
-		const base = hasAboveMinId ? datasets.filter((d) => d.id > MIN_AUDIT_DATASET_ID) : datasets;
-		return base.filter((d) => d.is_audited).length;
-	}, [datasets, hasAboveMinId]);
+		return datasets.filter((d) => d.is_audited).length;
+	}, [datasets]);
 
 	const referenceCount = useMemo(() => {
 		if (!datasets) return 0;


### PR DESCRIPTION
Datasets with id <= 2559 were blocked from the audit queue pending migration of their pre-existing audit statuses. Migration is now ready so the filter is no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated Dataset Audit page to display all datasets without ID-based filtering restrictions, ensuring complete visibility of pending and completed audits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->