### PR TITLE
feat(dataset-viewer): add audit button for auditors in layer control …

### DIFF
--- a/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetLayerControlPanel.tsx
@@ -3,6 +3,7 @@ import { Segmented, Slider, Checkbox, Button, Divider, Tooltip, Select } from "a
 import {
   FlagOutlined,
   EditOutlined,
+  AuditOutlined,
   WarningOutlined,
   CheckCircleOutlined,
   ExclamationCircleOutlined,
@@ -50,6 +51,7 @@ interface DatasetLayerControlPanelProps {
   onReportClick: () => void;
   onEditForestCover?: () => void;
   onEditDeadwood?: () => void;
+  onAuditClick?: () => void;
   isLoggedIn: boolean;
 }
 
@@ -108,6 +110,7 @@ const DatasetLayerControlPanel = ({
   onReportClick,
   onEditForestCover,
   onEditDeadwood,
+  onAuditClick,
   isLoggedIn,
 }: DatasetLayerControlPanelProps) => {
   const [showAttributions, setShowAttributions] = useState(false);
@@ -334,6 +337,17 @@ const DatasetLayerControlPanel = ({
               block
             >
               Edit deadwood cover
+            </Button>
+          )}
+
+          {canAudit && onAuditClick && (
+            <Button
+              size="small"
+              icon={<AuditOutlined />}
+              onClick={onAuditClick}
+              block
+            >
+              Audit dataset
             </Button>
           )}
 

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -414,6 +414,7 @@ export default function DatasetDetails() {
                 editing.handleStartEditing("forest_cover")
               }
               onEditDeadwood={() => editing.handleStartEditing("deadwood")}
+              onAuditClick={dataset ? () => navigate(`/dataset-audit/${dataset.id}`) : undefined}
               isLoggedIn={!!user}
             />
           </div>
@@ -552,6 +553,7 @@ export default function DatasetDetails() {
             onReportClick={() => setReportModalOpen(true)}
             onEditForestCover={() => editing.handleStartEditing("forest_cover")}
             onEditDeadwood={() => editing.handleStartEditing("deadwood")}
+            onAuditClick={dataset ? () => navigate(`/dataset-audit/${dataset.id}`) : undefined}
             isLoggedIn={!!user}
           />
         </div>


### PR DESCRIPTION
…panel

Adds an "Audit dataset" button below "Edit deadwood cover" that navigates to /dataset-audit/:id, visible only to users with canAudit permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Audit dataset" button to the dataset details page, allowing users to audit datasets directly from both desktop and mobile views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadwood-ai/deadtrees/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->