### PR TITLE
Feat/map dataset v2 selector

### DIFF
--- a/api/src/routers/dte_stats.py
+++ b/api/src/routers/dte_stats.py
@@ -45,9 +45,12 @@ PIXEL_AREA_MERCATOR_M2 = PIXEL_SIZE_MERCATOR * PIXEL_SIZE_MERCATOR  # ~365.16 m�
 TREE_COVER_THRESHOLD = 0.10  # 10% — captures sparse forests and open canopy
 DEADWOOD_THRESHOLD = 0.50    # 50% — high confidence for standing deadwood
 
-# COG filename pattern
+# COG filename patterns per model version
 COG_PATTERN = re.compile(
 	r"run_v1004_v1000_crop_half_fold_None_checkpoint_199_(deadwood|forest)_(\d{4})\.cog\.tif"
+)
+COG_PATTERN_V2 = re.compile(
+	r"run_v2004_seasonal_filter_fold_None_epoch_3_(deadwood|forest)_(\d{4})\.cog\.tif"
 )
 
 
@@ -64,6 +67,10 @@ class PolygonStatsRequest(BaseModel):
 				"coordinates": [[[10.64, 51.77], [10.70, 51.77], [10.70, 51.80], [10.64, 51.80], [10.64, 51.77]]]
 			}
 		}
+	)
+	model_version: str = Field(
+		default="v1",
+		description="Model version to use for statistics ('v1' or 'v2')",
 	)
 
 
@@ -124,9 +131,9 @@ def compute_geodesic_area_km2(geojson_polygon: dict) -> float:
 	return abs(area_m2) / 1_000_000
 
 
-def discover_available_cogs(maps_dir: Path) -> dict[str, dict[int, Path]]:
+def discover_available_cogs(maps_dir: Path, pattern: re.Pattern = COG_PATTERN) -> dict[str, dict[int, Path]]:
 	"""
-	Scan the dte_maps directory and return available COGs grouped by type and year.
+	Scan a dte_maps directory and return available COGs grouped by type and year.
 	Returns: {"deadwood": {2020: Path(...), ...}, "forest": {2020: Path(...), ...}}
 	"""
 	result: dict[str, dict[int, Path]] = {"deadwood": {}, "forest": {}}
@@ -136,7 +143,7 @@ def discover_available_cogs(maps_dir: Path) -> dict[str, dict[int, Path]]:
 		return result
 
 	for f in maps_dir.iterdir():
-		m = COG_PATTERN.match(f.name)
+		m = pattern.match(f.name)
 		if m:
 			cog_type = m.group(1)
 			year = int(m.group(2))
@@ -296,9 +303,13 @@ def get_polygon_stats(request: PolygonStatsRequest):
 	if area_km2 < 0.0001:
 		raise HTTPException(status_code=400, detail="Polygon is too small")
 
-	# Discover available COGs
-	maps_dir = settings.dte_maps_path
-	cog_map = discover_available_cogs(maps_dir)
+	# Discover available COGs for the requested model version
+	if request.model_version == "v2":
+		maps_dir = settings.dte_maps_v2_path
+		cog_map = discover_available_cogs(maps_dir, COG_PATTERN_V2)
+	else:
+		maps_dir = settings.dte_maps_path
+		cog_map = discover_available_cogs(maps_dir, COG_PATTERN)
 
 	all_years = sorted(set(list(cog_map["deadwood"].keys()) + list(cog_map["forest"].keys())))
 

--- a/api/src/routers/dte_stats.py
+++ b/api/src/routers/dte_stats.py
@@ -11,7 +11,7 @@ import math
 import re
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import numpy as np
 import rasterio
@@ -68,7 +68,7 @@ class PolygonStatsRequest(BaseModel):
 			}
 		}
 	)
-	model_version: str = Field(
+	model_version: Literal["v1", "v2"] = Field(
 		default="v1",
 		description="Model version to use for statistics ('v1' or 'v2')",
 	)

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -898,7 +898,10 @@ const DeadtreesMap = () => {
     const source = flagsLayerRef.current.getSource();
     if (source) {
       source.clear();
-      mapFlags.forEach((flag: IMapFlag) => {
+      const visibleFlags = mapFlags.filter(
+        (f) => !f.model_version || f.model_version === effectiveModelVersion,
+      );
+      visibleFlags.forEach((flag: IMapFlag) => {
         const [minLon, minLat, maxLon, maxLat] = flag.bbox;
         // Create polygon from bbox in EPSG:3857
         const extent = transformExtent(
@@ -925,7 +928,7 @@ const DeadtreesMap = () => {
         source.addFeature(feature);
       });
     }
-  }, [mapFlags, user, getFlagStyle]);
+  }, [mapFlags, user, getFlagStyle, effectiveModelVersion]);
 
   // Toggle flags layer visibility
   useEffect(() => {
@@ -1157,6 +1160,7 @@ const DeadtreesMap = () => {
         bbox: pendingFlagBbox,
         description: flagDescription.trim(),
         year: selectedYear,
+        model_version: effectiveModelVersion,
       });
       message.success("Flag added successfully");
       setFlagModalOpen(false);
@@ -1166,7 +1170,7 @@ const DeadtreesMap = () => {
       message.error("Failed to add flag");
       console.error(error);
     }
-  }, [pendingFlagBbox, flagDescription, selectedYear, createFlagMutation]);
+  }, [pendingFlagBbox, flagDescription, selectedYear, effectiveModelVersion, createFlagMutation]);
 
   // Cancel flag modal
   const handleFlagCancel = useCallback(() => {

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -38,6 +38,7 @@ import getPixelValueOfCoordinate from "../../utils/getPixelValueOfCoordinate";
 import {
   getDeadwoodCOGUrl,
   getForestCOGUrl,
+  type MapModelVersion,
 } from "../../utils/getDeadwoodCOGUrl";
 import {
   createOpenFreeMapLibertyLayerGroup,
@@ -121,52 +122,55 @@ interface KompasTracker {
 }
 
 // Helper to create GeoTIFF source for deadwood
-const createDeadwoodSource = (year: string) => {
+const createDeadwoodSource = (year: string, version: MapModelVersion) => {
   return new GeoTIFF({
-    sources: [{ url: getDeadwoodCOGUrl(year), bands: [1], min: 0, max: 255 }],
+    sources: [{ url: getDeadwoodCOGUrl(year, version), bands: [1], min: 0, max: 255 }],
     normalize: true,
     interpolate: false,
   });
 };
 
 // Helper to create GeoTIFF source for forest
-const createForestSource = (year: string) => {
+const createForestSource = (year: string, version: MapModelVersion) => {
   return new GeoTIFF({
-    sources: [{ url: getForestCOGUrl(year), bands: [1], min: 0, max: 255 }],
+    sources: [{ url: getForestCOGUrl(year, version), bands: [1], min: 0, max: 255 }],
     normalize: true,
     interpolate: false,
   });
 };
 
-// Source caches - persist across renders to reuse already-loaded sources
+// Source caches - keyed by `${version}-${year}` to persist across renders
 const deadwoodSourceCache: Record<string, GeoTIFF> = {};
 const forestSourceCache: Record<string, GeoTIFF> = {};
 
 // Get or create cached deadwood source
-const getCachedDeadwoodSource = (year: string): GeoTIFF => {
-  if (!deadwoodSourceCache[year]) {
-    console.debug(`[Cache] Creating new deadwood source for ${year}`);
-    deadwoodSourceCache[year] = createDeadwoodSource(year);
+const getCachedDeadwoodSource = (year: string, version: MapModelVersion): GeoTIFF => {
+  const key = `${version}-${year}`;
+  if (!deadwoodSourceCache[key]) {
+    console.debug(`[Cache] Creating new deadwood source for ${version}/${year}`);
+    deadwoodSourceCache[key] = createDeadwoodSource(year, version);
   } else {
-    console.debug(`[Cache] Reusing cached deadwood source for ${year}`);
+    console.debug(`[Cache] Reusing cached deadwood source for ${version}/${year}`);
   }
-  return deadwoodSourceCache[year];
+  return deadwoodSourceCache[key];
 };
 
 // Get or create cached forest source
-const getCachedForestSource = (year: string): GeoTIFF => {
-  if (!forestSourceCache[year]) {
-    console.debug(`[Cache] Creating new forest source for ${year}`);
-    forestSourceCache[year] = createForestSource(year);
+const getCachedForestSource = (year: string, version: MapModelVersion): GeoTIFF => {
+  const key = `${version}-${year}`;
+  if (!forestSourceCache[key]) {
+    console.debug(`[Cache] Creating new forest source for ${version}/${year}`);
+    forestSourceCache[key] = createForestSource(year, version);
   } else {
-    console.debug(`[Cache] Reusing cached forest source for ${year}`);
+    console.debug(`[Cache] Reusing cached forest source for ${version}/${year}`);
   }
-  return forestSourceCache[year];
+  return forestSourceCache[key];
 };
 
 const DeadtreesMap = () => {
   const [map, setMap] = useState<Map | null>(null);
   const [selectedYear, setSelectedYear] = useState<string>("2025");
+  const [modelVersion, setModelVersion] = useState<MapModelVersion>("v2");
   const [bounds, setBounds] = useState<number[]>([]);
   const [sliderValue, setSliderValue] = useState<number>(1);
   const mapContainer = useRef<HTMLDivElement | null>(null);
@@ -224,7 +228,7 @@ const DeadtreesMap = () => {
     useState(false);
 
   // Polygon analysis (drawing + stats)
-  const polygonAnalysis = usePolygonAnalysis(mapRef);
+  const polygonAnalysis = usePolygonAnalysis(mapRef, modelVersion);
 
   // Wayback imagery state - using debounced location-based query
   // Default to a recent Wayback release (31144 = 2024) for immediate satellite display
@@ -434,11 +438,11 @@ const DeadtreesMap = () => {
         const [deadwoodResult, forestResult] = await Promise.all([
           getPixelValueOfCoordinate({
             coordinates: event.coordinate,
-            cogUrl: getDeadwoodCOGUrl(year),
+            cogUrl: getDeadwoodCOGUrl(year, modelVersion),
           }),
           getPixelValueOfCoordinate({
             coordinates: event.coordinate,
-            cogUrl: getForestCOGUrl(year),
+            cogUrl: getForestCOGUrl(year, modelVersion),
           }),
         ]);
 
@@ -520,7 +524,7 @@ const DeadtreesMap = () => {
         setClickedValues({ forestPct, deadwoodPct });
       }
     },
-    [showDeadwood, showForest],
+    [showDeadwood, showForest, modelVersion],
   );
 
   useEffect(() => {
@@ -544,7 +548,7 @@ const DeadtreesMap = () => {
       // Create only 2 layers - one for forest, one for deadwood (for current year)
       // Forest layer: Light green → Dark green gradient based on cover intensity
       const forestLayer = new TileLayerWebGL({
-        source: getCachedForestSource(selectedYear),
+        source: getCachedForestSource(selectedYear, modelVersion),
         className: "forest-layer",
         style: {
           color: [
@@ -574,7 +578,7 @@ const DeadtreesMap = () => {
       // Deadwood layer: selective yellow spectrum with enhanced visibility for high values
       // Low values are more transparent, high values are more visible
       const deadwoodLayer = new TileLayerWebGL({
-        source: getCachedDeadwoodSource(selectedYear),
+        source: getCachedDeadwoodSource(selectedYear, modelVersion),
         className: "deadwood-layer",
         visible: true, // Both layers visible by default
         style: {
@@ -776,19 +780,19 @@ const DeadtreesMap = () => {
         }
       };
     }
-  }, [selectedYear, isDrawingFlag, polygonAnalysis.isDrawing, handleClick]);
+  }, [selectedYear, modelVersion, isDrawingFlag, polygonAnalysis.isDrawing, handleClick]);
 
-  // Update sources when year changes (use cached sources for instant switching)
+  // Update sources when year or model version changes (use cached sources for instant switching)
   useEffect(() => {
     if (forestLayerRef.current && deadwoodLayerRef.current) {
       // Use cached sources - instant if already loaded
-      forestLayerRef.current.setSource(getCachedForestSource(selectedYear));
-      deadwoodLayerRef.current.setSource(getCachedDeadwoodSource(selectedYear));
+      forestLayerRef.current.setSource(getCachedForestSource(selectedYear, modelVersion));
+      deadwoodLayerRef.current.setSource(getCachedDeadwoodSource(selectedYear, modelVersion));
       // Maintain visibility state after source update
       forestLayerRef.current.setVisible(showForest);
       deadwoodLayerRef.current.setVisible(showDeadwood);
     }
-  }, [selectedYear, showForest, showDeadwood]);
+  }, [selectedYear, modelVersion, showForest, showDeadwood]);
 
   // Initialize Wayback style and auto-select best imagery when items first load
   useEffect(() => {
@@ -1405,6 +1409,8 @@ const DeadtreesMap = () => {
             flagsCount={mapFlags.length}
             clickedValues={clickedValues}
             variant="floating-card"
+            modelVersion={modelVersion}
+            onModelVersionChange={setModelVersion}
           />
         </div>
 
@@ -1574,6 +1580,8 @@ const DeadtreesMap = () => {
               flagsCount={mapFlags.length}
               clickedValues={clickedValues}
               variant="drawer-sheet"
+              modelVersion={modelVersion}
+              onModelVersionChange={setModelVersion}
             />
           </div>
         </Drawer>

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -875,11 +875,12 @@ const DeadtreesMap = () => {
           if (feature) {
             const flagId = feature.get("flagId");
             const description = feature.get("description");
+            const year = feature.get("year");
             const popupElement = flagHoverOverlayRef.current.getElement();
             if (popupElement) {
               popupElement.innerHTML = `
               <div style="font-family: system-ui, sans-serif;">
-                <div style="font-weight: 600; color: ${mapColors.flag.stroke}; margin-bottom: 4px;">Flag #${flagId}</div>
+                <div style="font-weight: 600; color: ${mapColors.flag.stroke}; margin-bottom: 4px;">Flag #${flagId}${year ? ` · ${year}` : ""}</div>
                 <div style="color: ${palette.neutral[800]}; line-height: 1.4;">${description}</div>
               </div>
             `;
@@ -921,6 +922,7 @@ const DeadtreesMap = () => {
         const feature = new Feature({ geometry: polygon });
         feature.set("flagId", flag.id);
         feature.set("description", flag.description);
+        feature.set("year", flag.year ?? null);
         // Store center for point rendering
         const centerX = (extent[0] + extent[2]) / 2;
         const centerY = (extent[1] + extent[3]) / 2;

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -52,6 +52,7 @@ import YearImagerySelector from "./YearImagerySelector";
 import PolygonStatsModal from "./PolygonStatsModal";
 import { useDatasetMap } from "../../hooks/useDatasetMapProvider";
 import { useAuth } from "../../hooks/useAuthProvider";
+import { useCanAudit } from "../../hooks/useUserPrivileges";
 import { useMapFlags, useCreateMapFlag } from "../../hooks/useMapFlags";
 import { useWaybackItemsDebounced } from "../../hooks/useWaybackItems";
 import { usePolygonAnalysis } from "../../hooks/usePolygonAnalysis";
@@ -227,8 +228,13 @@ const DeadtreesMap = () => {
   const [deadwoodWarningModalOpen, setDeadwoodWarningModalOpen] =
     useState(false);
 
+  // Auth privilege — needed before polygonAnalysis so effectiveModelVersion is available
+  const { canAudit } = useCanAudit();
+  // Non-auditors are locked to v1; auditors can freely switch
+  const effectiveModelVersion: MapModelVersion = canAudit ? modelVersion : "v1";
+
   // Polygon analysis (drawing + stats)
-  const polygonAnalysis = usePolygonAnalysis(mapRef, modelVersion);
+  const polygonAnalysis = usePolygonAnalysis(mapRef, effectiveModelVersion);
 
   // Wayback imagery state - using debounced location-based query
   // Default to a recent Wayback release (31144 = 2024) for immediate satellite display
@@ -438,11 +444,11 @@ const DeadtreesMap = () => {
         const [deadwoodResult, forestResult] = await Promise.all([
           getPixelValueOfCoordinate({
             coordinates: event.coordinate,
-            cogUrl: getDeadwoodCOGUrl(year, modelVersion),
+            cogUrl: getDeadwoodCOGUrl(year, effectiveModelVersion),
           }),
           getPixelValueOfCoordinate({
             coordinates: event.coordinate,
-            cogUrl: getForestCOGUrl(year, modelVersion),
+            cogUrl: getForestCOGUrl(year, effectiveModelVersion),
           }),
         ]);
 
@@ -524,7 +530,7 @@ const DeadtreesMap = () => {
         setClickedValues({ forestPct, deadwoodPct });
       }
     },
-    [showDeadwood, showForest, modelVersion],
+    [showDeadwood, showForest, effectiveModelVersion],
   );
 
   useEffect(() => {
@@ -548,7 +554,7 @@ const DeadtreesMap = () => {
       // Create only 2 layers - one for forest, one for deadwood (for current year)
       // Forest layer: Light green → Dark green gradient based on cover intensity
       const forestLayer = new TileLayerWebGL({
-        source: getCachedForestSource(selectedYear, modelVersion),
+        source: getCachedForestSource(selectedYear, effectiveModelVersion),
         className: "forest-layer",
         style: {
           color: [
@@ -578,7 +584,7 @@ const DeadtreesMap = () => {
       // Deadwood layer: selective yellow spectrum with enhanced visibility for high values
       // Low values are more transparent, high values are more visible
       const deadwoodLayer = new TileLayerWebGL({
-        source: getCachedDeadwoodSource(selectedYear, modelVersion),
+        source: getCachedDeadwoodSource(selectedYear, effectiveModelVersion),
         className: "deadwood-layer",
         visible: true, // Both layers visible by default
         style: {
@@ -780,19 +786,19 @@ const DeadtreesMap = () => {
         }
       };
     }
-  }, [selectedYear, modelVersion, isDrawingFlag, polygonAnalysis.isDrawing, handleClick]);
+  }, [selectedYear, effectiveModelVersion, isDrawingFlag, polygonAnalysis.isDrawing, handleClick]);
 
   // Update sources when year or model version changes (use cached sources for instant switching)
   useEffect(() => {
     if (forestLayerRef.current && deadwoodLayerRef.current) {
       // Use cached sources - instant if already loaded
-      forestLayerRef.current.setSource(getCachedForestSource(selectedYear, modelVersion));
-      deadwoodLayerRef.current.setSource(getCachedDeadwoodSource(selectedYear, modelVersion));
+      forestLayerRef.current.setSource(getCachedForestSource(selectedYear, effectiveModelVersion));
+      deadwoodLayerRef.current.setSource(getCachedDeadwoodSource(selectedYear, effectiveModelVersion));
       // Maintain visibility state after source update
       forestLayerRef.current.setVisible(showForest);
       deadwoodLayerRef.current.setVisible(showDeadwood);
     }
-  }, [selectedYear, modelVersion, showForest, showDeadwood]);
+  }, [selectedYear, effectiveModelVersion, showForest, showDeadwood]);
 
   // Initialize Wayback style and auto-select best imagery when items first load
   useEffect(() => {
@@ -1410,7 +1416,7 @@ const DeadtreesMap = () => {
             clickedValues={clickedValues}
             variant="floating-card"
             modelVersion={modelVersion}
-            onModelVersionChange={setModelVersion}
+            onModelVersionChange={canAudit ? setModelVersion : undefined}
           />
         </div>
 
@@ -1581,7 +1587,7 @@ const DeadtreesMap = () => {
               clickedValues={clickedValues}
               variant="drawer-sheet"
               modelVersion={modelVersion}
-              onModelVersionChange={setModelVersion}
+              onModelVersionChange={canAudit ? setModelVersion : undefined}
             />
           </div>
         </Drawer>

--- a/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
+++ b/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
@@ -5,6 +5,7 @@ import { mapColors } from "../../theme/mapColors";
 import { palette } from "../../theme/palette";
 import MapLegend from "./MapLegend";
 import { standingDeadwoodLayerExplanation } from "../../utils/standingDeadwoodInfo";
+import type { MapModelVersion } from "../../utils/getDeadwoodCOGUrl";
 
 interface LayerControlPanelProps {
   // Basemap
@@ -35,6 +36,9 @@ interface LayerControlPanelProps {
     deadwoodPct: number;
   } | null;
   variant?: "floating-card" | "drawer-sheet";
+  // Model version
+  modelVersion?: MapModelVersion;
+  onModelVersionChange?: (version: MapModelVersion) => void;
 }
 
 // Basemap options: Streets and Satellite
@@ -64,6 +68,8 @@ const LayerControlPanel = ({
   flagsCount,
   clickedValues = null,
   variant = "floating-card",
+  modelVersion = "v2",
+  onModelVersionChange,
 }: LayerControlPanelProps) => {
   const [showAttributions, setShowAttributions] = useState(false);
   const [showLegend, setShowLegend] = useState(false);
@@ -110,6 +116,23 @@ const LayerControlPanel = ({
           </Tooltip>
         </div>
       </div>
+
+      {onModelVersionChange && (
+        <>
+          <Divider className="my-2.5" />
+          <div className="mb-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500">Dataset Version</div>
+          <Segmented
+            size="small"
+            block
+            value={modelVersion}
+            onChange={(value) => onModelVersionChange(value as MapModelVersion)}
+            options={[
+              { value: "v1", label: "v1" },
+              { value: "v2", label: "v2" },
+            ]}
+          />
+        </>
+      )}
 
       <Divider className="my-2.5" />
 

--- a/frontend/src/hooks/useMapFlags.ts
+++ b/frontend/src/hooks/useMapFlags.ts
@@ -46,6 +46,7 @@ export function useCreateMapFlag() {
           description: input.description,
           category: input.category ?? "other",
           year: input.year ?? null,
+          model_version: input.model_version ?? null,
         })
         .select("*")
         .single();

--- a/frontend/src/hooks/usePolygonAnalysis.ts
+++ b/frontend/src/hooks/usePolygonAnalysis.ts
@@ -313,6 +313,7 @@ export function usePolygonAnalysis(mapRef: React.MutableRefObject<Map | null>, m
     stats,
     resetDrawingState,
     removeDrawInteraction,
+    modelVersion,
   ]);
 
   const cancelDrawing = useCallback(() => {

--- a/frontend/src/hooks/usePolygonAnalysis.ts
+++ b/frontend/src/hooks/usePolygonAnalysis.ts
@@ -68,7 +68,7 @@ function getAreaColor(areaKm2: number): {
 // Hook
 // ---------------------------------------------------------------------------
 
-export function usePolygonAnalysis(mapRef: React.MutableRefObject<Map | null>) {
+export function usePolygonAnalysis(mapRef: React.MutableRefObject<Map | null>, modelVersion?: string) {
   // ---- state ----
   const [isDrawing, setIsDrawing] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -291,7 +291,7 @@ export function usePolygonAnalysis(mapRef: React.MutableRefObject<Map | null>) {
           coordinates: [coords4326],
         };
         setModalOpen(true);
-        stats.fetchStats(geoJsonPolygon);
+        stats.fetchStats(geoJsonPolygon, modelVersion);
       }
 
       resetDrawingState();

--- a/frontend/src/hooks/usePolygonStats.ts
+++ b/frontend/src/hooks/usePolygonStats.ts
@@ -29,7 +29,7 @@ export function usePolygonStats() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchStats = async (polygon: GeoJSON.Polygon) => {
+  const fetchStats = async (polygon: GeoJSON.Polygon, modelVersion?: string) => {
     setLoading(true);
     setError(null);
     setData(null);
@@ -39,7 +39,7 @@ export function usePolygonStats() {
       console.debug("[PolygonStats] Polygon:", JSON.stringify(polygon));
       const response = await axios.post<PolygonStatsResponse>(
         `${Settings.API_URL}/dte-stats/polygon`,
-        { polygon },
+        { polygon, model_version: modelVersion ?? "v1" },
       );
       console.debug("[PolygonStats] Response:", JSON.stringify(response.data));
       setData(response.data);

--- a/frontend/src/types/mapFlags.ts
+++ b/frontend/src/types/mapFlags.ts
@@ -7,6 +7,7 @@ export interface IMapFlag {
   description: string;
   category: MapFlagCategory;
   year?: string | null;
+  model_version?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -16,5 +17,6 @@ export interface CreateMapFlagInput {
   description: string;
   category?: MapFlagCategory;
   year?: string;
+  model_version?: string;
 }
 

--- a/frontend/src/utils/getDeadwoodCOGUrl.tsx
+++ b/frontend/src/utils/getDeadwoodCOGUrl.tsx
@@ -9,6 +9,7 @@ const V2_DEADWOOD_PREFIX = "run_v2004_seasonal_filter_fold_None_epoch_3_deadwood
 const V2_FOREST_PREFIX = "run_v2004_seasonal_filter_fold_None_epoch_3_forest_";
 
 export const getDeadwoodCOGUrl = (year: string | null, version: MapModelVersion = "v1") => {
+  if (!year || year.trim() === "") throw new Error("Invalid year for Deadwood COG URL");
   if (version === "v2") {
     return `${V2_BASE_URL}${V2_DEADWOOD_PREFIX}${year}.cog.tif`;
   }
@@ -16,6 +17,7 @@ export const getDeadwoodCOGUrl = (year: string | null, version: MapModelVersion 
 };
 
 export const getForestCOGUrl = (year: string | null, version: MapModelVersion = "v1") => {
+  if (!year || year.trim() === "") throw new Error("Invalid year for Forest COG URL");
   if (version === "v2") {
     return `${V2_BASE_URL}${V2_FOREST_PREFIX}${year}.cog.tif`;
   }

--- a/frontend/src/utils/getDeadwoodCOGUrl.tsx
+++ b/frontend/src/utils/getDeadwoodCOGUrl.tsx
@@ -1,11 +1,25 @@
-const baseUrl = "https://data2.deadtrees.earth/assets/v1/dte_maps/";
+export type MapModelVersion = "v1" | "v2";
 
-export const getDeadwoodCOGUrl = (year: string | null) => {
-  return `${baseUrl}run_v1004_v1000_crop_half_fold_None_checkpoint_199_deadwood_${year}.cog.tif`;
+const V1_BASE_URL = "https://data2.deadtrees.earth/assets/v1/dte_maps/";
+const V2_BASE_URL = "https://data2.deadtrees.earth/assets/v1/dte_maps_v2/";
+
+const V1_DEADWOOD_PREFIX = "run_v1004_v1000_crop_half_fold_None_checkpoint_199_deadwood_";
+const V1_FOREST_PREFIX = "run_v1004_v1000_crop_half_fold_None_checkpoint_199_forest_";
+const V2_DEADWOOD_PREFIX = "run_v2004_seasonal_filter_fold_None_epoch_3_deadwood_";
+const V2_FOREST_PREFIX = "run_v2004_seasonal_filter_fold_None_epoch_3_forest_";
+
+export const getDeadwoodCOGUrl = (year: string | null, version: MapModelVersion = "v1") => {
+  if (version === "v2") {
+    return `${V2_BASE_URL}${V2_DEADWOOD_PREFIX}${year}.cog.tif`;
+  }
+  return `${V1_BASE_URL}${V1_DEADWOOD_PREFIX}${year}.cog.tif`;
 };
 
-export const getForestCOGUrl = (year: string | null) => {
-  return `${baseUrl}run_v1004_v1000_crop_half_fold_None_checkpoint_199_forest_${year}.cog.tif`;
+export const getForestCOGUrl = (year: string | null, version: MapModelVersion = "v1") => {
+  if (version === "v2") {
+    return `${V2_BASE_URL}${V2_FOREST_PREFIX}${year}.cog.tif`;
+  }
+  return `${V1_BASE_URL}${V1_FOREST_PREFIX}${year}.cog.tif`;
 };
 
 // Default export for backwards compatibility

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -25,8 +25,8 @@ server {
 
 
     location /api/v1 {
-        rewrite  ^/api/v1/?(.*)$ /$1 break;
         set $api_backend "api-test:8017";
+        rewrite  ^/api/v1/?(.*)$ /$1 break;
         proxy_pass http://$api_backend;
 
         # Standard proxy headers

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
 
 	# DTE maps (deadwood/forest cover COGs)
 	DTE_MAPS_PATH: str = '/data/assets/dte_maps'
+	DTE_MAPS_V2_PATH: str = '/data/assets/dte_maps_v2'
 
 	# directly specify the locations for several files
 	ARCHIVE_DIR: str = 'archive'
@@ -243,6 +244,10 @@ class Settings(BaseSettings):
 	@property
 	def dte_maps_path(self) -> Path:
 		return Path(self.DTE_MAPS_PATH)
+
+	@property
+	def dte_maps_v2_path(self) -> Path:
+		return Path(self.DTE_MAPS_V2_PATH)
 
 	@property
 	def _tables(self) -> dict:

--- a/supabase/migrations/20260602000000_add-model-version-to-map-flags.sql
+++ b/supabase/migrations/20260602000000_add-model-version-to-map-flags.sql
@@ -1,0 +1,6 @@
+alter table "public"."map_flags"
+  add column "model_version" text default 'v1';
+
+update "public"."map_flags"
+  set "model_version" = 'v1'
+  where "model_version" is null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can select dataset/model version (v1 or v2) for deadwood analysis; non-auditors are restricted to v1 while auditors may choose v2. Dataset version selector added to layer controls.
* **Bug Fixes / Improvements**
  * Polygon statistics and map click analysis now honor the chosen model version and support the v2 dataset.
* **Chores**
  * Server/config updated to support and serve the v2 dataset path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->