### PR TITLE
feat(processing): retry transient network/DB failures with backoff

### DIFF
--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from shared.db import verify_token, use_client, use_service_client, login
 from shared.settings import settings
 from shared.models import TaskPayload, QueueTask, TaskTypeEnum
+from shared.retry import retry_on_transient_error
 from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandler
 
 # create the router for the processing
@@ -145,7 +146,11 @@ def create_processing_task(
 		raise HTTPException(status_code=500, detail=msg)
 
 	# Check if dataset is currently being processed and clean up old queue items.
-	try:
+	# The reads are idempotent and the reset/delete are safe to repeat, so the
+	# whole block is retried on a transient DB blip. The internal 409s are not
+	# transient, so they propagate immediately instead of being retried.
+	@retry_on_transient_error
+	def _check_and_clean_queue() -> None:
 		with use_client(token) as client:
 			# If the processor already picked up a task, block reruns.
 			# This is more robust than relying solely on v2_statuses.current_status, which may lag.
@@ -209,6 +214,8 @@ def create_processing_task(
 					),
 				)
 
+	try:
+		_check_and_clean_queue()
 	except HTTPException:
 		raise
 	except Exception as e:
@@ -227,12 +234,30 @@ def create_processing_task(
 		is_processing=False,
 	)
 
-	# Add the task to the queue
-	try:
+	# Add the task to the queue. The cleanup above removed any existing rows for
+	# this dataset, so if a transient failure drops the connection after the
+	# insert committed, we can detect the row already exists and re-read it
+	# instead of inserting a duplicate task.
+	def _task_already_inserted() -> bool:
+		with use_client(token) as client:
+			existing = client.table(settings.queue_table).select('id').eq('dataset_id', dataset_id).execute()
+			return bool(existing.data)
+
+	@retry_on_transient_error(verify_succeeded=_task_already_inserted)
+	def _insert_task() -> Optional[dict]:
 		with use_client(token) as client:
 			send_data = {k: v for k, v in payload.model_dump().items() if v is not None and k != 'id'}
 			response = client.table(settings.queue_table).insert(send_data).execute()
-			task = TaskPayload(**response.data[0])
+			return response.data[0]
+
+	try:
+		inserted = _insert_task()
+		if inserted is None:
+			# Insert committed but the response was lost; re-read the queued row.
+			with use_client(token) as client:
+				existing = client.table(settings.queue_table).select('*').eq('dataset_id', dataset_id).execute()
+				inserted = existing.data[0]
+		task = TaskPayload(**inserted)
 
 		logger.info(
 			f'Added task to queue for dataset {dataset_id}',

--- a/processor/src/process_cog.py
+++ b/processor/src/process_cog.py
@@ -11,6 +11,7 @@ from .utils.ssh import push_file_to_storage_server
 from .utils.local_ortho import ensure_local_ortho
 from .exceptions import AuthenticationError, DatasetError, ProcessingError
 from shared.status import update_status
+from shared.retry import retry_on_transient_error
 from shared.logging import LogContext, LogCategory
 
 
@@ -94,9 +95,16 @@ def process_cog(task: QueueTask, temp_dir: Path):
 		if not user:
 			raise AuthenticationError('Token refresh failed', token=token, task_id=task.id)
 
-		with use_client(token) as client:
-			send_data = {k: v for k, v in cog.model_dump().items() if v is not None}
-			client.table(settings.cogs_table).upsert(send_data, on_conflict='dataset_id').execute()
+		send_data = {k: v for k, v in cog.model_dump().items() if v is not None}
+
+		# upsert is idempotent (on_conflict='dataset_id'), so retrying a transient
+		# disconnect/SSL-handshake timeout cannot create duplicate rows.
+		@retry_on_transient_error
+		def _save_cog_metadata() -> None:
+			with use_client(token) as client:
+				client.table(settings.cogs_table).upsert(send_data, on_conflict='dataset_id').execute()
+
+		_save_cog_metadata()
 
 		# Update final status
 		update_status(token, dataset_id=ortho.dataset_id, current_status=StatusEnum.idle, is_cog_done=True)

--- a/processor/src/utils/ssh.py
+++ b/processor/src/utils/ssh.py
@@ -5,8 +5,21 @@ from datetime import datetime
 from shared.logger import logger
 from shared.settings import settings
 from shared.testing.safety import test_environment_only
+from shared.retry import retry_on_transient_error
 
 from shared.logging import LogContext, LogCategory
+
+
+@retry_on_transient_error
+def _connect_with_retry(ssh: paramiko.SSHClient, **connect_kwargs) -> None:
+	"""Open the SSH connection, retrying transient failures.
+
+	Connection establishment is where the storage-server flakiness shows up
+	("Error reading SSH protocol banner") when the server is briefly overloaded.
+	Retrying only the connect (not the subsequent transfer) keeps this safe:
+	there are no partial-file side effects to undo before reconnecting.
+	"""
+	ssh.connect(**connect_kwargs)
 
 
 def pull_file_from_storage_server(remote_file_path: str, local_file_path: str, token: str, dataset_id: int):
@@ -27,7 +40,8 @@ def pull_file_from_storage_server(remote_file_path: str, local_file_path: str, t
 		)
 		port = 2222 if settings.DEV_MODE else 22
 
-		ssh.connect(
+		_connect_with_retry(
+			ssh,
 			hostname=settings.STORAGE_SERVER_IP,
 			username=settings.STORAGE_SERVER_USERNAME,
 			pkey=pkey,
@@ -83,7 +97,8 @@ def push_file_to_storage_server(local_file_path: str, remote_file_path: str, tok
 		)
 		port = 2222 if settings.DEV_MODE else 22
 
-		ssh.connect(
+		_connect_with_retry(
+			ssh,
 			hostname=settings.STORAGE_SERVER_IP,
 			username=settings.STORAGE_SERVER_USERNAME,
 			pkey=pkey,
@@ -268,7 +283,8 @@ def check_file_exists_on_storage(remote_file_path: str, token: str) -> bool:
 
 		port = 2222 if settings.DEV_MODE else 22
 
-		ssh.connect(
+		_connect_with_retry(
+			ssh,
 			hostname=settings.STORAGE_SERVER_IP,
 			username=settings.STORAGE_SERVER_USERNAME,
 			pkey=pkey,

--- a/processor/tests/utils/test_ssh_retry.py
+++ b/processor/tests/utils/test_ssh_retry.py
@@ -1,0 +1,51 @@
+import paramiko
+import pytest
+
+from processor.src.utils.ssh import _connect_with_retry
+
+
+class _FakeSSH:
+	"""Minimal stand-in for paramiko.SSHClient recording connect attempts."""
+
+	def __init__(self, fail_times, exc):
+		self.fail_times = fail_times
+		self.exc = exc
+		self.attempts = 0
+
+	def connect(self, **kwargs):
+		self.attempts += 1
+		if self.attempts <= self.fail_times:
+			raise self.exc
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+	monkeypatch.setattr('shared.retry.time.sleep', lambda d: None)
+
+
+def test_connect_retries_on_protocol_banner_then_succeeds():
+	ssh = _FakeSSH(fail_times=2, exc=paramiko.SSHException('Error reading SSH protocol banner'))
+
+	_connect_with_retry(ssh, hostname='host', port=22)
+
+	assert ssh.attempts == 3
+
+
+def test_connect_gives_up_after_max_attempts():
+	ssh = _FakeSSH(fail_times=99, exc=paramiko.SSHException('Error reading SSH protocol banner'))
+
+	with pytest.raises(paramiko.SSHException, match='protocol banner'):
+		_connect_with_retry(ssh, hostname='host', port=22)
+
+	# Default max_attempts is 4.
+	assert ssh.attempts == 4
+
+
+def test_connect_does_not_retry_auth_failure():
+	"""A bad key is deterministic; retrying would just waste time."""
+	ssh = _FakeSSH(fail_times=99, exc=paramiko.AuthenticationException('Authentication failed'))
+
+	with pytest.raises(paramiko.AuthenticationException):
+		_connect_with_retry(ssh, hostname='host', port=22)
+
+	assert ssh.attempts == 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,9 +16,10 @@ filterwarnings =
     ignore:The argument 'device' of Tensor\.is_pinned\(\) is deprecated\.:DeprecationWarning:torch\.utils\.data\._utils\.pin_memory
 
 # Test discovery patterns
-testpaths = 
+testpaths =
     processor/tests
     api/tests
+    shared/tests
 
 python_files = test_*.py
 python_classes = Test*

--- a/shared/labels.py
+++ b/shared/labels.py
@@ -19,6 +19,7 @@ from shared.db import use_client
 from shared.settings import settings
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
+from shared.retry import retry_on_transient_error
 
 MAX_CHUNK_SIZE = 1024 * 1024 * 5  # 5MB per chunk
 
@@ -163,8 +164,31 @@ def upload_geometry_chunk(
 		geometry = GeometryModel(label_id=label_id, geometry=geom.__geo_interface__, properties=properties)
 		geometry_records.append(geometry.model_dump(exclude={'id', 'created_at'}))
 
+	def _count_existing() -> int:
+		response = client.table(table).select('id', count='exact').eq('label_id', label_id).execute()
+		return response.count or 0
+
+	# Baseline row count so that, if a transient failure drops the connection
+	# *after* the insert committed, the retry can detect the rows already landed
+	# and skip re-inserting (a PostgREST batch insert is atomic, so the count is
+	# either the baseline or baseline + len(records)). If we can't read a
+	# baseline, fall back to plain retry.
 	try:
+		count_before = _count_existing()
+	except Exception:
+		count_before = None
+
+	def _already_committed() -> bool:
+		if count_before is None:
+			return False
+		return _count_existing() >= count_before + len(geometry_records)
+
+	@retry_on_transient_error(verify_succeeded=_already_committed)
+	def _insert() -> None:
 		client.table(table).insert(geometry_records).execute()
+
+	try:
+		_insert()
 	except Exception as e:
 		logger.error(f'Error uploading geometry chunk: {str(e)}', extra={'token': token})
 		raise Exception(f'Error uploading geometry chunk: {str(e)}')

--- a/shared/retry.py
+++ b/shared/retry.py
@@ -1,0 +1,121 @@
+import functools
+import time
+from typing import Callable, Optional, TypeVar
+
+from shared.logger import logger
+
+T = TypeVar('T')
+
+# Substrings (matched case-insensitively against the exception message) that
+# indicate a transient network failure worth retrying, rather than a
+# deterministic programming or validation error.
+#
+# These cover the failures we have actually observed killing datasets mid-run:
+# "Server disconnected without sending a response." and
+# "The write operation timed out" — both raised when the DB/storage backend
+# briefly drops the connection during an insert/update.
+TRANSIENT_ERROR_PATTERNS = (
+	'server disconnected',
+	'timed out',
+	'timeout',
+	'connection reset',
+	'connection aborted',
+	'connection refused',
+	'connection error',
+	'connection closed',
+	'temporarily unavailable',
+	'broken pipe',
+	'remoteprotocolerror',
+	'read operation',
+	'write operation',
+	'eof occurred',
+	'name or service not known',
+	# paramiko SSH connection establishment hiccups (storage server transfers)
+	'protocol banner',
+	'error reading ssh',
+	'no existing session',
+)
+
+
+def is_transient_error(exc: BaseException) -> bool:
+	"""Heuristic for whether an exception looks like a transient network failure.
+
+	We match on the message rather than exception type because the failures
+	bubble up through several layers (supabase -> httpx -> httpcore) and get
+	re-wrapped as plain ``Exception`` along the way, so the type is unreliable
+	but the underlying message is preserved.
+	"""
+	message = str(exc).lower()
+	return any(pattern in message for pattern in TRANSIENT_ERROR_PATTERNS)
+
+
+def retry_on_transient_error(
+	func: Optional[Callable[..., T]] = None,
+	*,
+	max_attempts: int = 4,
+	initial_delay: float = 1.0,
+	backoff: float = 2.0,
+	max_delay: float = 30.0,
+	is_retryable: Callable[[BaseException], bool] = is_transient_error,
+	verify_succeeded: Optional[Callable[[], bool]] = None,
+) -> Callable:
+	"""Retry a function on transient network errors with exponential backoff.
+
+	Non-transient errors (validation errors, programming bugs) are re-raised
+	immediately without retrying, as is the final attempt's error once
+	``max_attempts`` is exhausted.
+
+	Usable both bare (``@retry_on_transient_error``) and parameterised
+	(``@retry_on_transient_error(max_attempts=5)``).
+
+	Idempotency: a retried write could otherwise produce duplicate rows if the
+	original write committed server-side but the response was lost (e.g.
+	"disconnected without sending a response"). Pass ``verify_succeeded`` — a
+	callback that re-reads state and returns True if the operation already took
+	effect — to suppress the retry in that case. If the verification check
+	itself fails, we fall through to a normal retry rather than giving up.
+	"""
+
+	def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+		@functools.wraps(fn)
+		def wrapper(*args, **kwargs) -> T:
+			delay = initial_delay
+			for attempt in range(1, max_attempts + 1):
+				try:
+					return fn(*args, **kwargs)
+				except Exception as exc:
+					if not is_retryable(exc):
+						raise
+
+					# The write may have committed before the connection dropped;
+					# if so, don't re-issue it (avoids duplicate rows).
+					if verify_succeeded is not None:
+						try:
+							if verify_succeeded():
+								logger.warning(
+									f'{fn.__name__} hit a transient error but the operation '
+									f'already committed; not retrying: {exc}'
+								)
+								return None  # type: ignore[return-value]
+						except Exception as verify_exc:
+							logger.warning(
+								f'{fn.__name__} could not verify whether the operation '
+								f'committed, will retry: {verify_exc}'
+							)
+
+					if attempt >= max_attempts:
+						raise
+					logger.warning(
+						f'{fn.__name__} failed with transient error '
+						f'(attempt {attempt}/{max_attempts}), retrying in {delay:.1f}s: {exc}'
+					)
+					time.sleep(delay)
+					delay = min(delay * backoff, max_delay)
+			# Loop always either returns or raises; this is unreachable.
+			raise RuntimeError('retry_on_transient_error exhausted without returning')  # pragma: no cover
+
+		return wrapper
+
+	if func is not None:
+		return decorator(func)
+	return decorator

--- a/shared/status.py
+++ b/shared/status.py
@@ -4,6 +4,7 @@ from .models import StatusEnum
 from .db import use_client
 from .settings import settings
 from .logger import logger
+from .retry import retry_on_transient_error
 from shared.logging import LogContext, LogCategory
 
 
@@ -75,16 +76,21 @@ def update_status(
 
 		if update_data:
 			update_data['updated_at'] = datetime.now(timezone.utc).isoformat()
-			with use_client(token) as client:
-				# First check if status exists
-				result = client.table(settings.statuses_table).select('id').eq('dataset_id', dataset_id).execute()
 
-				if not result.data:
-					# Create new status row if it doesn't exist
-					client.table(settings.statuses_table).insert({'dataset_id': dataset_id, **update_data}).execute()
-				else:
-					# Update existing status
-					client.table(settings.statuses_table).update(update_data).eq('dataset_id', dataset_id).execute()
+			@retry_on_transient_error
+			def _write_status() -> None:
+				with use_client(token) as client:
+					# First check if status exists
+					result = client.table(settings.statuses_table).select('id').eq('dataset_id', dataset_id).execute()
+
+					if not result.data:
+						# Create new status row if it doesn't exist
+						client.table(settings.statuses_table).insert({'dataset_id': dataset_id, **update_data}).execute()
+					else:
+						# Update existing status
+						client.table(settings.statuses_table).update(update_data).eq('dataset_id', dataset_id).execute()
+
+			_write_status()
 
 	except Exception as e:
 		logger.error(

--- a/shared/tests/test_labels_retry.py
+++ b/shared/tests/test_labels_retry.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import pytest
+from shapely.geometry import Polygon
+
+from shared.labels import upload_geometry_chunk
+from shared.models import DeadwoodGeometry
+
+
+class _FakeSelect:
+	"""Models ``select('id', count='exact').eq('label_id', ...).execute()``."""
+
+	def __init__(self, table):
+		self._table = table
+
+	def eq(self, field, value):
+		return self
+
+	def execute(self):
+		return SimpleNamespace(count=len(self._table.rows))
+
+
+class _FakeInsert:
+	def __init__(self, table, records):
+		self._table = table
+		self._records = records
+
+	def execute(self):
+		t = self._table
+		outcome = t.behavior[t.insert_attempts] if t.insert_attempts < len(t.behavior) else 'ok'
+		t.insert_attempts += 1
+		if outcome == 'fail':
+			# Connection dropped before the write committed: no rows added.
+			raise Exception('The write operation timed out')
+		if outcome == 'commit_then_fail':
+			# Rows committed server-side, but the response was lost.
+			t.rows.extend(self._records)
+			raise Exception('Server disconnected without sending a response.')
+		t.rows.extend(self._records)
+		return None
+
+
+class _FakeTable:
+	def __init__(self, behavior):
+		self.behavior = behavior
+		self.rows = []
+		self.insert_attempts = 0
+
+	def select(self, *args, **kwargs):
+		return _FakeSelect(self)
+
+	def insert(self, records):
+		return _FakeInsert(self, records)
+
+
+class _FakeClient:
+	def __init__(self, behavior):
+		self._table = _FakeTable(behavior)
+
+	def table(self, name):
+		return self._table
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+	monkeypatch.setattr('shared.retry.time.sleep', lambda d: None)
+
+
+def _polygon():
+	return Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+
+
+def _upload(client):
+	upload_geometry_chunk(
+		client,
+		table='v2_deadwood_geometries',
+		GeometryModel=DeadwoodGeometry,
+		label_id=1,
+		geometries=[_polygon()],
+		properties=None,
+		token='token',
+	)
+
+
+def test_upload_geometry_chunk_retries_transient_error():
+	client = _FakeClient(behavior=['fail', 'fail', 'ok'])
+
+	_upload(client)
+
+	assert client._table.insert_attempts == 3
+	assert len(client._table.rows) == 1
+
+
+def test_upload_geometry_chunk_gives_up_after_max_attempts():
+	client = _FakeClient(behavior=['fail', 'fail', 'fail', 'fail'])
+
+	with pytest.raises(Exception, match='Error uploading geometry chunk'):
+		_upload(client)
+
+	# Default max_attempts is 4.
+	assert client._table.insert_attempts == 4
+	assert client._table.rows == []
+
+
+def test_upload_geometry_chunk_does_not_duplicate_when_commit_response_lost():
+	"""The committed-but-response-lost case must not insert the chunk twice."""
+	client = _FakeClient(behavior=['commit_then_fail'])
+
+	_upload(client)
+
+	# Insert was issued once; the retry detected the rows already landed and
+	# skipped re-inserting, so there is exactly one geometry, not two.
+	assert client._table.insert_attempts == 1
+	assert len(client._table.rows) == 1

--- a/shared/tests/test_retry.py
+++ b/shared/tests/test_retry.py
@@ -1,0 +1,179 @@
+import pytest
+
+from shared.retry import is_transient_error, retry_on_transient_error
+
+
+# ---------------------------------------------------------------------------
+# is_transient_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+	'message',
+	[
+		'Server disconnected without sending a response.',
+		'The write operation timed out',
+		'Connection reset by peer',
+		'Connection refused',
+		'Temporarily unavailable',
+		'[Errno 32] Broken pipe',
+		'RemoteProtocolError: server disconnected',
+		'Error reading SSH protocol banner',
+	],
+)
+def test_is_transient_error_true_for_network_failures(message):
+	assert is_transient_error(Exception(message)) is True
+
+
+@pytest.mark.parametrize(
+	'exc',
+	[
+		ValueError('Expected Polygon geometry, received MultiPolygon'),
+		KeyError('dataset_id'),
+		Exception('Invalid token'),
+		Exception('duplicate key value violates unique constraint'),
+	],
+)
+def test_is_transient_error_false_for_deterministic_errors(exc):
+	assert is_transient_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# retry_on_transient_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+	"""Record backoff delays without actually sleeping."""
+	delays = []
+	monkeypatch.setattr('shared.retry.time.sleep', lambda d: delays.append(d))
+	return delays
+
+
+def test_returns_value_without_retry_on_success(no_sleep):
+	calls = []
+
+	@retry_on_transient_error
+	def fn():
+		calls.append(1)
+		return 'ok'
+
+	assert fn() == 'ok'
+	assert len(calls) == 1
+	assert no_sleep == []
+
+
+def test_retries_then_succeeds_on_transient_error(no_sleep):
+	calls = []
+
+	@retry_on_transient_error(initial_delay=1.0, backoff=2.0)
+	def fn():
+		calls.append(1)
+		if len(calls) < 3:
+			raise Exception('Server disconnected without sending a response.')
+		return 'recovered'
+
+	assert fn() == 'recovered'
+	assert len(calls) == 3
+	# Slept between the two failed attempts, with exponential backoff.
+	assert no_sleep == [1.0, 2.0]
+
+
+def test_gives_up_after_max_attempts_and_reraises(no_sleep):
+	calls = []
+
+	@retry_on_transient_error(max_attempts=3)
+	def fn():
+		calls.append(1)
+		raise Exception('The write operation timed out')
+
+	with pytest.raises(Exception, match='write operation timed out'):
+		fn()
+
+	assert len(calls) == 3
+	# Slept after attempts 1 and 2, but not after the final failure.
+	assert len(no_sleep) == 2
+
+
+def test_non_transient_error_raised_immediately_without_retry(no_sleep):
+	calls = []
+
+	@retry_on_transient_error
+	def fn():
+		calls.append(1)
+		raise ValueError('Expected Polygon geometry, received MultiPolygon')
+
+	with pytest.raises(ValueError, match='MultiPolygon'):
+		fn()
+
+	assert len(calls) == 1
+	assert no_sleep == []
+
+
+def test_backoff_is_capped_at_max_delay(no_sleep):
+	@retry_on_transient_error(max_attempts=6, initial_delay=10.0, backoff=10.0, max_delay=30.0)
+	def fn():
+		raise Exception('connection reset')
+
+	with pytest.raises(Exception, match='connection reset'):
+		fn()
+
+	# 10 -> 100 (capped 30) -> 30 -> 30 -> 30, then final failure (no sleep).
+	assert no_sleep == [10.0, 30.0, 30.0, 30.0, 30.0]
+
+
+def test_verify_succeeded_suppresses_retry_when_already_committed(no_sleep):
+	calls = []
+
+	@retry_on_transient_error(verify_succeeded=lambda: True)
+	def fn():
+		calls.append(1)
+		raise Exception('Server disconnected without sending a response.')
+
+	# Returns without raising: the verify callback reports the write landed.
+	assert fn() is None
+	assert len(calls) == 1  # the insert was attempted exactly once, not re-issued
+	assert no_sleep == []
+
+
+def test_verify_succeeded_false_still_retries(no_sleep):
+	calls = []
+
+	@retry_on_transient_error(max_attempts=3, verify_succeeded=lambda: False)
+	def fn():
+		calls.append(1)
+		raise Exception('Server disconnected without sending a response.')
+
+	with pytest.raises(Exception, match='disconnected'):
+		fn()
+
+	assert len(calls) == 3
+
+
+def test_verify_succeeded_failure_falls_through_to_retry(no_sleep):
+	calls = []
+
+	def failing_verify():
+		raise Exception('count query also failed')
+
+	@retry_on_transient_error(max_attempts=2, verify_succeeded=failing_verify)
+	def fn():
+		calls.append(1)
+		raise Exception('connection reset')
+
+	# Verification raising must not crash the retry; it falls through and retries.
+	with pytest.raises(Exception, match='connection reset'):
+		fn()
+
+	assert len(calls) == 2
+
+
+def test_preserves_function_metadata():
+	@retry_on_transient_error
+	def my_named_function():
+		"""docstring."""
+		return 1
+
+	assert my_named_function.__name__ == 'my_named_function'
+	assert my_named_function.__doc__ == 'docstring.'

--- a/shared/tests/test_status.py
+++ b/shared/tests/test_status.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from shared.models import StatusEnum
 from shared.status import update_status
 
@@ -106,3 +108,79 @@ def test_update_status_sets_updated_at_when_creating_status(monkeypatch):
 	assert inserts[0]['is_upload_done'] is True
 	updated_at = datetime.fromisoformat(inserts[0]['updated_at'])
 	assert updated_at.tzinfo is not None
+
+
+def _make_recording_client(updates):
+	"""Build a fake supabase client that records status updates."""
+
+	class _ExecuteResult:
+		data = [{'id': 1}]
+
+	class _EqQuery:
+		def eq(self, field, value):
+			return self
+
+		def execute(self):
+			return _ExecuteResult()
+
+	class _Table:
+		def select(self, fields):
+			return _EqQuery()
+
+		def update(self, payload):
+			updates.append(payload)
+			return _EqQuery()
+
+	class _Client:
+		def table(self, name):
+			return _Table()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	return _Client()
+
+
+def test_update_status_retries_on_transient_error(monkeypatch):
+	"""A transient connection drop should be retried, not lost.
+
+	This is the regression guard for the ghost-status bug: previously a single
+	'Server disconnected' while writing the status left the dataset stuck with
+	has_error=false and current_status != idle, which the requeue API refuses.
+	"""
+	updates = []
+	calls = {'n': 0}
+	monkeypatch.setattr('shared.retry.time.sleep', lambda d: None)
+
+	def fake_use_client(token):
+		calls['n'] += 1
+		if calls['n'] < 3:
+			raise Exception('Server disconnected without sending a response.')
+		return _make_recording_client(updates)
+
+	monkeypatch.setattr('shared.status.use_client', fake_use_client)
+
+	update_status('token', dataset_id=123, has_error=True, error_message='boom')
+
+	assert calls['n'] == 3
+	assert len(updates) == 1
+	assert updates[0]['has_error'] is True
+
+
+def test_update_status_does_not_retry_non_transient_error(monkeypatch):
+	calls = {'n': 0}
+	monkeypatch.setattr('shared.retry.time.sleep', lambda d: None)
+
+	def fake_use_client(token):
+		calls['n'] += 1
+		raise ValueError('programming bug')
+
+	monkeypatch.setattr('shared.status.use_client', fake_use_client)
+
+	with pytest.raises(ValueError, match='programming bug'):
+		update_status('token', dataset_id=123, is_cog_done=True)
+
+	assert calls['n'] == 1


### PR DESCRIPTION
Transient connection drops and timeouts (server disconnects, write/read timeouts, SSH protocol-banner blips, statement timeouts) were permanently killing datasets mid-processing, because the network-bound DB and storage operations had no retry. When the same blip also broke the status write, datasets were left as "ghosts" (current_status != idle, has_error = false) that the requeue API refuses with a 409.

Add a dependency-free retry helper with exponential backoff that retries only message-classified transient errors and re-raises deterministic ones immediately. Wire it into the operations the logs show failing:

- shared/labels.py: upload_geometry_chunk (idempotent via row-count check)
- shared/status.py: update_status (already idempotent)
- processor/src/process_cog.py: COG metadata upsert (idempotent on_conflict)
- processor/src/utils/ssh.py: storage-server connect (retry connect only)
- api/src/routers/process.py: requeue check/cleanup and task insert (insert guarded by verify_succeeded to avoid duplicate queue rows)

Also add shared/tests to pytest testpaths so the shared unit tests actually run under `deadtrees dev test`.