### PR TITLE
fix(processor): refresh JWT after long-running inference before DB wr…

### DIFF
--- a/processor/src/deadwood_segmentation_v1_moehring/predict_deadwood.py
+++ b/processor/src/deadwood_segmentation_v1_moehring/predict_deadwood.py
@@ -3,6 +3,8 @@ from shared.logger import logger
 from shared.logging import LogContext, LogCategory
 from shared.models import LabelDataEnum
 from shared.labels import delete_model_prediction_labels
+from shared.db import login
+from shared.settings import settings
 from .inference import DeadwoodInference
 from ..exceptions import ProcessingError
 import rasterio
@@ -41,6 +43,11 @@ def predict_deadwood(dataset_id: int, file_path: Path, user_id: str, token: str)
 			LogContext(category=LogCategory.DEADWOOD, dataset_id=dataset_id, user_id=user_id, token=token),
 		)
 		polygons = deadwood_model.inference_deadwood(str(file_path))
+
+		# Inference can run longer than the JWT lifetime (~1h), which would make the
+		# subsequent label delete/write fail with PGRST303 'JWT expired'. Refresh the
+		# token now that the long-running work is done and DB writes are imminent.
+		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 
 		if len(polygons) == 0:
 			logger.warning(

--- a/processor/src/deadwood_treecover_combined_v2/predict_combined.py
+++ b/processor/src/deadwood_treecover_combined_v2/predict_combined.py
@@ -5,6 +5,8 @@ import rasterio
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
 from shared.models import COMBINED_MODEL_CHECKPOINT_NAME, COMBINED_MODEL_CONFIG, COMBINED_MODEL_MODULE, LabelDataEnum
+from shared.db import login
+from shared.settings import settings
 
 from ..exceptions import ProcessingError
 from ..utils.prediction_labels import create_versioned_model_prediction_label
@@ -34,6 +36,11 @@ def predict_combined(dataset_id: int, file_path: Path, user_id: str, token: str)
         deadwood_polygons, treecover_polygons = model.inference(str(file_path))
         if forest_cover_stats := model.simplification_stats.get('forest_cover'):
             log('Applied topology-preserving forest cover simplification during inference', **forest_cover_stats)
+
+        # Inference can run longer than the JWT lifetime (~1h), which would make the
+        # subsequent label delete/write fail with PGRST303 'JWT expired'. Refresh the
+        # token now that the long-running work is done and DB writes are imminent.
+        token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 
         with rasterio.open(str(file_path)) as src:
             src_crs = src.crs

--- a/processor/src/process_treecover_segmentation.py
+++ b/processor/src/process_treecover_segmentation.py
@@ -125,5 +125,10 @@ def process_treecover_segmentation(task: QueueTask, token: str, temp_dir: Path):
 				extra={'error': str(e)},
 			),
 		)
+		# Re-login to avoid using an expired token during error handling. The TCD
+		# container can run for hours, so the token captured at task start is often
+		# expired by the time we get here; without this the status write itself fails
+		# with 'JWT expired', masking the real error and leaving has_error unset.
+		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 		update_status(token, dataset_id=ortho.dataset_id, has_error=True, error_message=str(e))
 		raise ProcessingError(str(e), task_type='treecover_segmentation', task_id=task.id, dataset_id=ortho.dataset_id)


### PR DESCRIPTION
…ites

Segmentation tasks captured a Supabase JWT (~1h TTL) before running GPU inference / the TCD container, then reused it for the post-inference label delete/write. On large orthos the work outlasts the token, so the DB write failed with PGRST303 'JWT expired'.

- predict_deadwood / predict_combined: re-login right after inference, before the label delete/write.
- process_treecover_segmentation: re-login before the error-path update_status. The TCD container can run for hours; without this the status write itself failed with 'JWT expired', masking the real error and leaving has_error unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced reliability of long-running deadwood and tree cover segmentation processes by preventing database connection timeouts that could interrupt operations or prevent proper error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->