### PR TITLE
fix(processor): support high-bit thumbnail inputs

### DIFF
--- a/processor/src/thumbnail/thumbnail.py
+++ b/processor/src/thumbnail/thumbnail.py
@@ -7,6 +7,32 @@ from shared.logger import logger
 from shared.logging import LogContext, LogCategory
 
 
+def _to_uint8_rgb(rgb_array: np.ndarray, valid_mask: np.ndarray | None = None) -> np.ndarray:
+	if rgb_array.dtype == np.uint8:
+		return rgb_array
+
+	rgb_float = rgb_array.astype(np.float32, copy=False)
+	finite_mask = np.isfinite(rgb_float)
+	if valid_mask is not None:
+		finite_mask &= valid_mask[np.newaxis, :, :]
+	finite_values = rgb_float[finite_mask]
+	if finite_values.size == 0:
+		return np.zeros(rgb_array.shape, dtype=np.uint8)
+
+	min_value = float(finite_values.min())
+	max_value = float(finite_values.max())
+	if max_value == min_value:
+		fill_value = 255 if max_value > 0 else 0
+		return np.full(rgb_array.shape, fill_value, dtype=np.uint8)
+
+	lower, upper = np.percentile(finite_values, [2, 98])
+	if upper <= lower:
+		lower, upper = min_value, max_value
+
+	scaled = (rgb_float - lower) * (255.0 / (upper - lower))
+	return np.clip(scaled, 0, 255).astype(np.uint8)
+
+
 def calculate_thumbnail(
 	tiff_file_path: str,
 	thumbnail_file_path: str,
@@ -51,6 +77,8 @@ def calculate_thumbnail(
 				alpha = data[3]
 			else:
 				alpha = src.read_masks(1, out_shape=(out_height, out_width), resampling=Resampling.nearest)
+
+			rgb_array = _to_uint8_rgb(rgb_array, valid_mask=alpha > 0)
 
 			# Create white background where alpha is 0
 			for band in rgb_array:

--- a/processor/tests/conftest.py
+++ b/processor/tests/conftest.py
@@ -162,7 +162,7 @@ def test_dataset_for_processing(auth_token, test_file, test_processor_user):
 
 # @test_environment_only
 @pytest.fixture(autouse=True)
-def cleanup_storage(request, auth_token):
+def cleanup_storage(request):
 	"""Clean up storage before and after each test"""
 	# Most unit tests don't touch SSH storage paths; skipping this saves a lot of time.
 	if (
@@ -173,7 +173,7 @@ def cleanup_storage(request, auth_token):
 		yield
 		return
 
-	token = auth_token
+	token = request.getfixturevalue('auth_token')
 
 	# Paths to clean
 	paths = [

--- a/processor/tests/test_thumbnail.py
+++ b/processor/tests/test_thumbnail.py
@@ -1,0 +1,76 @@
+import numpy as np
+from PIL import Image
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from processor.src.thumbnail.thumbnail import _to_uint8_rgb, calculate_thumbnail
+
+
+@pytest.mark.unit
+def test_calculate_thumbnail_accepts_uint16_rgb_geotiff(tmp_path):
+	input_path = tmp_path / 'uint16_rgb.tif'
+	output_path = tmp_path / 'thumbnail.jpg'
+
+	width = 32
+	height = 32
+	gradient = np.linspace(0, 1024, width * height, dtype=np.uint16).reshape(height, width)
+	data = np.stack([gradient, np.flipud(gradient), np.full_like(gradient, 512)])
+
+	with rasterio.open(
+		input_path,
+		'w',
+		driver='GTiff',
+		height=height,
+		width=width,
+		count=3,
+		dtype='uint16',
+		transform=from_origin(10, 10, 1, 1),
+	) as dataset:
+		dataset.write(data)
+
+	calculate_thumbnail(str(input_path), str(output_path), size=(16, 16), dataset_id=10388)
+
+	with Image.open(output_path) as thumbnail:
+		pixels = np.asarray(thumbnail)
+		assert thumbnail.mode == 'RGB'
+		assert thumbnail.size == (16, 16)
+		assert pixels.max() > pixels.min()
+		assert pixels.mean() > 0
+
+
+@pytest.mark.unit
+def test_uint16_rgb_scaling_ignores_masked_nodata_pixels():
+	rgb = np.full((3, 4, 4), 65535, dtype=np.uint16)
+	valid_mask = np.zeros((4, 4), dtype=bool)
+	valid_mask[1:3, 1:3] = True
+	rgb[:, 1:3, 1:3] = np.array(
+		[
+			[[0, 256], [512, 1024]],
+			[[1024, 512], [256, 0]],
+			[[128, 256], [512, 768]],
+		],
+		dtype=np.uint16,
+	)
+
+	converted = _to_uint8_rgb(rgb, valid_mask=valid_mask)
+
+	assert converted[:, 1:3, 1:3].max() > 200
+
+
+@pytest.mark.unit
+def test_non_uint8_rgb_scaling_stretches_normalized_float_values():
+	rgb = np.array(
+		[
+			[[0.0, 0.25], [0.5, 1.0]],
+			[[1.0, 0.5], [0.25, 0.0]],
+			[[0.125, 0.25], [0.5, 0.75]],
+		],
+		dtype=np.float32,
+	)
+
+	converted = _to_uint8_rgb(rgb)
+
+	assert converted.dtype == np.uint8
+	assert converted.max() > 200
+	assert converted.min() < 10

--- a/shared/testing/fixtures.py
+++ b/shared/testing/fixtures.py
@@ -7,9 +7,37 @@ import shutil
 from .safety import test_environment_only
 
 
+# These fixtures force DB setup even if a test is marked unit. Unmarked tests
+# keep the historical default and get DB setup; only pure unit-test sessions skip
+# Supabase setup.
+DATABASE_FIXTURES = frozenset(
+	{
+		'auth_token',
+		'test_user',
+		'test_user2',
+		'datasets_with_mixed_access',
+	}
+)
+
+
+def _session_needs_database(request) -> bool:
+	return any(
+		item.get_closest_marker('integration') is not None
+		or item.get_closest_marker('slow') is not None
+		or item.get_closest_marker('comprehensive') is not None
+		or DATABASE_FIXTURES.intersection(item.fixturenames)
+		or item.get_closest_marker('unit') is None
+		for item in request.session.items
+	)
+
+
 @pytest.fixture(scope='session', autouse=True)
-def test_processor_user():
+def test_processor_user(request):
 	"""Create the processor user in the database if it doesn't exist and clean up after tests"""
+	if not _session_needs_database(request):
+		yield None
+		return
+
 	supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_KEY)
 	user_id = None
 
@@ -85,8 +113,12 @@ def test_file():
 
 # @test_environment_only
 @pytest.fixture(scope='session', autouse=True)
-def cleanup_database(auth_token):
+def cleanup_database(request):
 	"""Clean up database tables after all tests"""
+	if not _session_needs_database(request):
+		yield
+		return
+
 	yield
 
 	processor_token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)


### PR DESCRIPTION
## Summary
- scale non-uint8 thumbnail inputs to displayable uint8 before PIL conversion
- ignore masked/nodata pixels when computing thumbnail stretch
- let pure unit-test sessions skip Supabase setup while preserving DB setup for unmarked tests

## Validation
- processor-image focused test: 3 passed
- git diff --check
- autoreview panel: Codex medium + Claude medium clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thumbnail display scaling and test-only fixture gating; no auth or data-path behavior changes in production beyond correct uint8 conversion for non-uint8 rasters.
> 
> **Overview**
> Fixes thumbnail generation for **non-uint8** GeoTIFF RGB (e.g. uint16) by adding `_to_uint8_rgb`, which percentile-stretches finite pixels to 0–255 and **excludes masked/nodata** pixels from the stretch before PIL/JPEG output.
> 
> Adds **unit tests** for uint16 GeoTIFF end-to-end, masked nodata scaling, and float inputs.
> 
> **Test harness:** pure `@pytest.mark.unit` sessions skip session-scoped Supabase processor-user setup and DB cleanup; integration/slow/comprehensive tests and tests that request DB fixtures still get full setup. Processor `cleanup_storage` resolves `auth_token` lazily so unit tests avoid auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca68576b09788614886af093d0b69a7052749d87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thumbnail generation to properly scale and handle RGB data from various GeoTIFF formats, ensuring consistent output regardless of input data type.
  * Enhanced invalid pixel handling in thumbnail processing for more accurate results.

* **Tests**
  * Added comprehensive test coverage for thumbnail generation and RGB scaling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->