### PR TITLE
fix(frontend): update axios for security advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@tanstack/react-query": "^5.100.6",
         "@turf/turf": "^7.3.5",
         "antd": "^5.29.3",
-        "axios": "^1.15.2",
+        "axios": "^1.17.0",
         "canvas-confetti": "^1.9.4",
         "geotiff": "^2.1.3",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
@@ -5717,6 +5717,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5966,13 +5978,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -6858,7 +6871,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7904,6 +7916,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -8565,8 +8590,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "@tanstack/react-query": "^5.100.6",
     "@turf/turf": "^7.3.5",
     "antd": "^5.29.3",
-    "axios": "^1.15.2",
+    "axios": "^1.17.0",
     "canvas-confetti": "^1.9.4",
     "geotiff": "^2.1.3",
     "geotiff-geokeys-to-proj4": "^2024.4.13",


### PR DESCRIPTION
## Summary
- Update the frontend's direct `axios` dependency from `^1.15.2` to `^1.17.0`.
- Refresh `frontend/package-lock.json` so the installed runtime package resolves to `axios@1.17.0`.

## Why
GitHub reported multiple open Dependabot alerts for `axios` in `frontend/package-lock.json`. The active advisories are fixed by `axios >= 1.16.0`; this update moves the frontend to the current patched line.

## Regression review
- Axios usage is limited to frontend POST requests for upload chunking and polygon stats.
- The checked call sites use stable APIs: `axios.post`, `axios.isCancel`, `axios.isAxiosError`, upload progress, timeout, auth headers, and `AbortSignal`.
- Axios 1.16 release notes mention redirect/proxy security fixes, fetch/XHR abort fixes, and fetch-adapter body limit enforcement; none require app code changes for these browser POST call sites.

## Validation
- `npm --prefix frontend install`
- `npm --prefix frontend ls axios --depth=0` -> `axios@1.17.0`
- `npm --prefix frontend test` -> 16 files / 94 tests passed
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `git diff --check`
- `npm --prefix frontend audit --omit=dev --json` no longer reports `axios`; it still reports unrelated production advisories such as `fast-uri`, `postcss`, `protobufjs`, `react-router`, `ws`.

## Risk
Low. This is a dependency-only security bump with TypeScript, unit, lint, and production build coverage. Remaining audit findings are intentionally out of scope for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ops changes plus a targeted dependency security bump on limited axios call sites; no auth or production logic changes in app code.
> 
> **Overview**
> Adds a new **Operator Chat** runbook (`docs/playbooks/operator-chat.md`) that defines read-only monitoring for the main operator thread: git/repo contract, hourly micro-checks, daily platform checks, weekly reviews, token-efficient local state, data-factory health framing, Linear drift rules, Gmail/Zulip intake, and compact handoff to worker threads.
> 
> **`platform-status-check.md`** now states it covers platform health only and is the daily full check nested inside the broader Operator Chat cadence.
> 
> **Frontend:** bumps direct **`axios`** from `^1.15.2` to **`^1.17.0`** (lockfile resolves to 1.17.0), addressing Dependabot advisories fixed in `>=1.16.0`. Lockfile also picks up transitive **`https-proxy-agent`** / **`agent-base`** and adjusts **`debug`** / **`ms`** dev flags as part of the resolved tree—no application code changes; usage stays on upload chunk POSTs and polygon stats APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172ea1cfea4500d6d7df3ea727a557d1dd8f8e5e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->