### PR TITLE
fix(processing): require geotiff for downstream reruns

### DIFF
--- a/api/src/routers/process.py
+++ b/api/src/routers/process.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from shared.db import verify_token, use_client, use_service_client, login
 from shared.settings import settings
 from shared.models import TaskPayload, QueueTask, TaskTypeEnum
+from shared.processing_tasks import downstream_tasks_missing_geotiff, format_missing_geotiff_error
 from shared.retry import retry_on_transient_error
 from shared.logging import LogContext, LogCategory, UnifiedLogger, SupabaseHandler
 
@@ -125,6 +126,24 @@ def create_processing_task(
 			),
 		)
 		raise HTTPException(status_code=400, detail=f'Invalid task type: {str(e)}')
+
+	downstream_without_geotiff = downstream_tasks_missing_geotiff(validated_task_types)
+	if downstream_without_geotiff:
+		detail = format_missing_geotiff_error(downstream_without_geotiff)
+		logger.warning(
+			'Rejected processing request missing geotiff dependency',
+			LogContext(
+				category=LogCategory.ADD_PROCESS,
+				user_id=user.id,
+				dataset_id=dataset_id,
+				token=token,
+				extra={
+					'task_types': request.task_types,
+					'missing_geotiff_for': [task_type.value for task_type in downstream_without_geotiff],
+				},
+			),
+		)
+		raise HTTPException(status_code=400, detail=detail)
 
 	# Load the dataset info with the caller's token before any privileged write.
 	try:

--- a/api/tests/routers/test_process.py
+++ b/api/tests/routers/test_process.py
@@ -66,7 +66,7 @@ def test_create_processing_task(test_dataset, auth_token):
 	"""Test creating a new processing task for a dataset"""
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['cog', 'thumbnail']},
+		json={'task_types': ['geotiff', 'cog', 'thumbnail']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 
@@ -74,6 +74,7 @@ def test_create_processing_task(test_dataset, auth_token):
 	data = response.json()
 
 	assert data['dataset_id'] == test_dataset
+	assert 'geotiff' in data['task_types']
 	assert 'cog' in data['task_types']
 	assert 'thumbnail' in data['task_types']
 	assert not data['is_processing']
@@ -82,8 +83,24 @@ def test_create_processing_task(test_dataset, auth_token):
 		response = supabaseClient.table(settings.queue_table).select('*').eq('dataset_id', test_dataset).execute()
 		assert len(response.data) == 1
 		assert response.data[0]['dataset_id'] == test_dataset
+		assert 'geotiff' in response.data[0]['task_types']
 		assert 'cog' in response.data[0]['task_types']
 		assert 'thumbnail' in response.data[0]['task_types']
+
+
+def test_create_processing_task_rejects_downstream_without_geotiff(test_dataset, auth_token):
+	"""Downstream raster/model stages require geotiff in the same transient processing job."""
+	response = client.put(
+		f'/datasets/{test_dataset}/process',
+		json={'task_types': ['thumbnail', 'deadwood_treecover_combined_v2']},
+		headers={'Authorization': f'Bearer {auth_token}'},
+	)
+
+	assert response.status_code == 400
+	detail = response.json()['detail']
+	assert 'require geotiff in the same processing request' in detail
+	assert 'thumbnail' in detail
+	assert 'deadwood_treecover_combined_v2' in detail
 
 
 def test_create_processing_task_unauthorized(test_dataset):
@@ -100,7 +117,7 @@ def test_create_processing_task_invalid_dataset(auth_token):
 	"""Test process creation for non-existent dataset"""
 	response = client.put(
 		'/datasets/99999/process',
-		json={'task_types': ['cog', 'thumbnail']},
+		json={'task_types': ['geotiff', 'cog', 'thumbnail']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 	assert response.status_code == 404
@@ -120,18 +137,19 @@ def test_create_processing_task_accepts_legacy_task_type_aliases(test_dataset, a
 	"""Legacy task names should continue to enqueue their v1 task equivalents."""
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['deadwood', 'treecover']},
+		json={'task_types': ['geotiff', 'deadwood', 'treecover']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 
 	assert response.status_code == 200
 	data = response.json()
+	assert 'geotiff' in data['task_types']
 	assert 'deadwood_v1' in data['task_types']
 	assert 'treecover_v1' in data['task_types']
 
 	with use_client(auth_token) as supabaseClient:
 		response = supabaseClient.table(settings.queue_table).select('*').eq('dataset_id', test_dataset).execute()
-		assert response.data[0]['task_types'] == ['deadwood_v1', 'treecover_v1']
+		assert response.data[0]['task_types'] == ['geotiff', 'deadwood_v1', 'treecover_v1']
 
 
 # Priority tests added from test_process_priority.py
@@ -249,7 +267,7 @@ def test_rerun_removes_old_queue_items(test_dataset, auth_token):
 	# Create initial task
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['cog', 'thumbnail'], 'priority': 2},
+		json={'task_types': ['geotiff', 'cog', 'thumbnail'], 'priority': 2},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 	assert response.status_code == 200
@@ -290,7 +308,7 @@ def test_rerun_blocks_active_processing(test_dataset, auth_token, test_user):
 		task_data = {
 			'dataset_id': test_dataset,
 			'user_id': test_user,
-			'task_types': ['cog', 'thumbnail'],
+			'task_types': ['geotiff', 'cog', 'thumbnail'],
 			'priority': 2,
 			'is_processing': True,  # Already being processed
 		}
@@ -320,7 +338,7 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 	# Create initial task
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['cog']},
+		json={'task_types': ['geotiff', 'cog']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 	assert response.status_code == 200
@@ -334,6 +352,7 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 				'has_error': True,
 				'error_message': 'Simulated processing failure',
 				'current_status': StatusEnum.idle,
+				'is_ortho_done': True,
 				'is_cog_done': True,
 				'is_thumbnail_done': True,
 				'is_metadata_done': True,
@@ -343,7 +362,7 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 	# Rerun should succeed (removes old task, adds new one)
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['cog', 'thumbnail', 'metadata'], 'priority': 1},
+		json={'task_types': ['geotiff', 'cog', 'thumbnail', 'metadata'], 'priority': 1},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 	assert response.status_code == 200
@@ -355,6 +374,7 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 		response = supabaseClient.table(settings.queue_table).select('*').eq('dataset_id', test_dataset).execute()
 		assert len(response.data) == 1
 		assert response.data[0]['id'] == second_task_id
+		assert 'geotiff' in response.data[0]['task_types']
 		assert 'cog' in response.data[0]['task_types']
 		assert 'thumbnail' in response.data[0]['task_types']
 		assert 'metadata' in response.data[0]['task_types']
@@ -366,6 +386,7 @@ def test_rerun_succeeds_after_failed_processing(test_dataset, auth_token):
 		assert status['has_error'] is False
 		assert status['error_message'] is None
 		assert status['current_status'] == StatusEnum.idle
+		assert status['is_ortho_done'] is False
 		assert status['is_cog_done'] is False
 		assert status['is_thumbnail_done'] is False
 		assert status['is_metadata_done'] is False
@@ -412,7 +433,7 @@ def test_failed_status_reset_zero_rows_does_not_enqueue(test_dataset, auth_token
 
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['cog']},
+		json={'task_types': ['geotiff', 'cog']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 
@@ -437,6 +458,7 @@ def test_rerun_combined_task_resets_only_combined_prediction_flag(test_dataset, 
 				'has_error': True,
 				'error_message': 'Simulated combined processing failure',
 				'current_status': StatusEnum.idle,
+				'is_ortho_done': True,
 				'is_deadwood_done': True,
 				'is_forest_cover_done': True,
 				'is_combined_model_done': True,
@@ -445,7 +467,7 @@ def test_rerun_combined_task_resets_only_combined_prediction_flag(test_dataset, 
 
 	response = client.put(
 		f'/datasets/{test_dataset}/process',
-		json={'task_types': ['deadwood_treecover_combined_v2']},
+		json={'task_types': ['geotiff', 'deadwood_treecover_combined_v2']},
 		headers={'Authorization': f'Bearer {auth_token}'},
 	)
 
@@ -456,6 +478,7 @@ def test_rerun_combined_task_resets_only_combined_prediction_flag(test_dataset, 
 		status = response.data[0]
 		assert status['has_error'] is False
 		assert status['error_message'] is None
+		assert status['is_ortho_done'] is False
 		assert status['is_deadwood_done'] is True
 		assert status['is_forest_cover_done'] is True
 		assert status['is_combined_model_done'] is False
@@ -471,7 +494,7 @@ def test_rerun_multiple_old_queue_items(test_dataset, auth_token, test_user):
 			task_data = {
 				'dataset_id': test_dataset,
 				'user_id': test_user,  # Use test_user fixture instead of auth call
-				'task_types': ['cog'],
+				'task_types': ['geotiff', 'cog'],
 				'priority': 2,
 				'is_processing': False,
 			}

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -7,6 +7,7 @@ from shared.models import QueueTask, TaskTypeEnum, StatusEnum
 from shared.settings import settings
 from shared.db import use_client, login, login_verified, verify_token
 from shared.status import update_status
+from shared.processing_tasks import downstream_tasks_missing_geotiff, format_missing_geotiff_error
 from .process_thumbnail import process_thumbnail
 from .process_cog import process_cog
 from .process_deadwood_segmentation import process_deadwood_segmentation
@@ -249,6 +250,23 @@ def process_task(task: QueueTask, token: str):
 		shutil.rmtree(settings.processing_path, ignore_errors=True)
 
 	try:
+		downstream_without_geotiff = downstream_tasks_missing_geotiff(task.task_types)
+		if downstream_without_geotiff:
+			error_message = format_missing_geotiff_error(downstream_without_geotiff)
+			update_status(
+				token,
+				dataset_id=task.dataset_id,
+				current_status=StatusEnum.idle,
+				has_error=True,
+				error_message=error_message,
+			)
+			raise ProcessingError(
+				error_message,
+				task_type='geotiff_dependency',
+				task_id=task.id,
+				dataset_id=task.dataset_id,
+			)
+
 		# Process ODM first if it's in the list (generates orthomosaic for ZIP uploads)
 		if TaskTypeEnum.odm_processing in task.task_types:
 			try:

--- a/processor/tests/test_process_task_validation.py
+++ b/processor/tests/test_process_task_validation.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+
+import pytest
+
+import processor.src.processor as processor_module
+from processor.src.processor import process_task
+from shared.models import QueueTask, StatusEnum, TaskTypeEnum
+from shared.processing_tasks import format_missing_geotiff_error
+from shared.settings import settings
+
+
+# Keep these overrides local to this unit-test module. Processor conftest autouse
+# fixtures normally prepare Supabase and SSH storage, but this guard is pure
+# queue/status orchestration and should stay runnable without live services.
+@pytest.fixture(scope='session', autouse=True)
+def test_processor_user():
+	yield None
+
+
+@pytest.fixture(scope='session')
+def auth_token():
+	return 'processor-token'
+
+
+@pytest.fixture(scope='session', autouse=True)
+def cleanup_database():
+	yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_storage():
+	yield
+
+
+@pytest.mark.unit
+def test_process_task_rejects_downstream_without_geotiff(monkeypatch):
+	"""Processor fails fast for manually inserted unsafe queue rows."""
+	task = QueueTask(
+		id=124,
+		dataset_id=457,
+		user_id='test-user',
+		task_types=[TaskTypeEnum.thumbnail],
+		priority=1,
+		is_processing=False,
+		current_position=1,
+		estimated_time=0.0,
+	)
+	status_updates = []
+	queue_updates = []
+	deleted_task_ids = []
+
+	class _DeleteQuery:
+		def eq(self, field, value):
+			assert field == 'id'
+			deleted_task_ids.append(value)
+			return self
+
+		def execute(self):
+			return None
+
+	class _UpdateQuery:
+		def __init__(self, payload):
+			self.payload = payload
+
+		def eq(self, field, value):
+			assert field == 'id'
+			queue_updates.append((value, self.payload))
+			return self
+
+		def execute(self):
+			return None
+
+	class _TableQuery:
+		def update(self, payload):
+			return _UpdateQuery(payload)
+
+		def delete(self):
+			return _DeleteQuery()
+
+	class _FakeClient:
+		def table(self, name):
+			assert name == settings.queue_table
+			return _TableQuery()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	def _record_status_update(*args, **kwargs):
+		status_updates.append(kwargs)
+		return SimpleNamespace(data=[])
+
+	monkeypatch.setattr(processor_module, 'verify_token', lambda token: {'id': 'processor-user'})
+	monkeypatch.setattr(processor_module, 'login', lambda username, password: 'delete-token')
+	monkeypatch.setattr(processor_module, 'use_client', lambda token: _FakeClient())
+	monkeypatch.setattr(processor_module, 'update_status', _record_status_update)
+	monkeypatch.setattr(processor_module, 'create_processing_failure_issue', lambda **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'info', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'error', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'warning', lambda *args, **kwargs: None)
+
+	with pytest.raises(processor_module.ProcessingError) as exc_info:
+		process_task(task, 'initial-token')
+
+	assert 'require geotiff in the same processing request' in str(exc_info.value)
+	assert queue_updates == [(task.id, {'is_processing': True})]
+	assert deleted_task_ids == [task.id]
+	expected_error = format_missing_geotiff_error((TaskTypeEnum.thumbnail,))
+	assert status_updates == [
+		{
+			'dataset_id': task.dataset_id,
+			'current_status': StatusEnum.idle,
+			'has_error': True,
+			'error_message': expected_error,
+		}
+	]

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -146,7 +146,6 @@ def test_process_task_success_path_with_refresh(monkeypatch):
 	assert processing_updates == [task.id]
 	assert deleted_task_ids == [task.id]
 
-
 def test_pipeline_stage_map_is_stable_and_ordered():
 	"""
 	Locks down the pipeline stage ordering used for crash detection and reporting.

--- a/shared/processing_tasks.py
+++ b/shared/processing_tasks.py
@@ -1,0 +1,28 @@
+from shared.models import TaskTypeEnum
+
+
+TASKS_REQUIRING_STANDARDIZED_ORTHO = frozenset(
+	{
+		TaskTypeEnum.cog,
+		TaskTypeEnum.thumbnail,
+		TaskTypeEnum.deadwood_v1,
+		TaskTypeEnum.treecover_v1,
+		TaskTypeEnum.deadwood_treecover_combined_v2,
+	}
+)
+
+
+def downstream_tasks_missing_geotiff(task_types: list[TaskTypeEnum]) -> tuple[TaskTypeEnum, ...]:
+	"""Return downstream tasks that are unsafe without geotiff in the same job."""
+	if TaskTypeEnum.geotiff in task_types:
+		return ()
+	return tuple(task_type for task_type in task_types if task_type in TASKS_REQUIRING_STANDARDIZED_ORTHO)
+
+
+def format_missing_geotiff_error(task_types: tuple[TaskTypeEnum, ...]) -> str:
+	task_names = ', '.join(task_type.value for task_type in task_types)
+	return (
+		'Downstream processing stages require geotiff in the same processing request '
+		'because standardized orthos are transient and are not stored durably. '
+		f'Add geotiff before rerunning: {task_names}.'
+	)

--- a/shared/tests/test_processing_tasks.py
+++ b/shared/tests/test_processing_tasks.py
@@ -1,0 +1,30 @@
+from shared.models import TaskTypeEnum
+from shared.processing_tasks import downstream_tasks_missing_geotiff, format_missing_geotiff_error
+
+
+def test_downstream_tasks_missing_geotiff_returns_unsafe_tasks_in_request_order():
+	missing = downstream_tasks_missing_geotiff(
+		[
+			TaskTypeEnum.thumbnail,
+			TaskTypeEnum.metadata,
+			TaskTypeEnum.deadwood_treecover_combined_v2,
+		]
+	)
+
+	assert missing == (TaskTypeEnum.thumbnail, TaskTypeEnum.deadwood_treecover_combined_v2)
+
+
+def test_downstream_tasks_missing_geotiff_allows_metadata_only():
+	assert downstream_tasks_missing_geotiff([TaskTypeEnum.metadata]) == ()
+
+
+def test_downstream_tasks_missing_geotiff_allows_downstream_when_geotiff_is_present():
+	assert downstream_tasks_missing_geotiff([TaskTypeEnum.geotiff, TaskTypeEnum.thumbnail]) == ()
+
+
+def test_format_missing_geotiff_error_names_unsafe_tasks():
+	message = format_missing_geotiff_error((TaskTypeEnum.thumbnail, TaskTypeEnum.treecover_v1))
+
+	assert 'require geotiff in the same processing request' in message
+	assert 'thumbnail' in message
+	assert 'treecover_v1' in message


### PR DESCRIPTION
## What changed

- Reject API processing requests that enqueue downstream ortho-dependent stages without `geotiff` in the same request.
- Add the same fail-fast guard in the processor for manually inserted unsafe queue rows.
- Centralize the task dependency policy in `shared.processing_tasks` and cover it with API/shared/processor tests.

## Why

Standardized orthos are transient processor files. Downstream-only reruns can fall back to archived originals, which caused user-visible AWI failures for thumbnail/treecover reruns.

## Validation

- `docker compose -f docker-compose.test.yaml exec -T api-test python -m pytest -v api/tests/routers/test_process.py shared/tests/test_processing_tasks.py` — 22 passed
- Processor unit validation on processing-server using the processor test image with `runc`: `python -m pytest -v processor/tests/test_process_task_validation.py` — 1 passed
- `git diff --check`
- Thermo-nuclear code-quality pass: accepted one maintainability cleanup in the processor unit test.

## Notes

Local processor compose could not start because this Docker runtime lacks NVIDIA support; the processing server compose path also failed before Python due an NVIDIA MPS mount issue. The isolated processor unit test was run in the existing processor test image without GPU hooks because this guard does not execute model/GPU code.

Autoreview panel was attempted with Codex and Claude at medium reasoning. The dry run confirmed `codex thinking=medium, claude thinking=medium`, but the escalated run was denied by the approval layer because it would send private branch code to external review services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes valid processing request shapes and rerun behavior; clients that enqueue thumbnail/COG/models without geotiff will get 400 instead of silent failures.
> 
> **Overview**
> **Downstream ortho-dependent processing** (COG, thumbnail, segmentation models) must now include **`geotiff` in the same enqueue request**, because standardized orthos are transient and downstream-only reruns could fall back to archived originals.
> 
> A shared policy in `shared/processing_tasks` defines which task types require geotiff. The **process API** returns **400** with a clear message when the request is invalid; the **processor** applies the same check for manually inserted queue rows, sets dataset error status, and fails the task without running stages.
> 
> Existing API/processor tests were updated to enqueue geotiff with raster/model reruns; new unit/integration tests cover rejection paths and shared helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10268c562a014347d5c13073f8015f8ec207809d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation to require GeoTIFF inclusion for dependent processing tasks in the same request.
  * Requests are now rejected early with clear error messages when required GeoTIFF dependencies are missing.

* **Improvements**
  * Enhanced processing safeguards to prevent execution of tasks with unmet GeoTIFF dependencies.
  * Improved error messaging to inform users which tasks require GeoTIFF to be included before rerunning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->