### PR TITLE
feat(database): add public tree observations

### DIFF
--- a/supabase/migrations/20260610120000_add_public_tree_observations.sql
+++ b/supabase/migrations/20260610120000_add_public_tree_observations.sql
@@ -1,0 +1,80 @@
+create table if not exists "public"."public_tree_observations" (
+  "id" uuid primary key default gen_random_uuid(),
+  "geom" geometry(Point, 4326) not null,
+  "condition" text not null,
+  "tree_type_group" text not null,
+  "tree_type_text" text,
+  "comment" text,
+  "client_id" text,
+  "created_at" timestamptz not null default now(),
+  constraint "public_tree_observations_condition_check"
+    check ("condition" in ('alive', 'declining', 'dead', 'not_sure')),
+  constraint "public_tree_observations_tree_type_group_check"
+    check ("tree_type_group" in ('conifer', 'broadleaf', 'palm_or_other', 'not_sure')),
+  constraint "public_tree_observations_tree_type_text_length_check"
+    check ("tree_type_text" is null or char_length("tree_type_text") <= 80),
+  constraint "public_tree_observations_comment_length_check"
+    check ("comment" is null or char_length("comment") <= 200),
+  constraint "public_tree_observations_client_id_length_check"
+    check ("client_id" is null or char_length("client_id") <= 64),
+  constraint "public_tree_observations_geom_point_check"
+    check (
+      ST_SRID("geom") = 4326
+      and GeometryType("geom") = 'POINT'
+      and ST_X("geom") between -180 and 180
+      and ST_Y("geom") between -90 and 90
+    )
+);
+
+create index if not exists "public_tree_observations_geom_idx"
+  on "public"."public_tree_observations"
+  using gist ("geom");
+
+create index if not exists "public_tree_observations_created_at_idx"
+  on "public"."public_tree_observations" ("created_at" desc);
+
+alter table "public"."public_tree_observations" enable row level security;
+
+revoke all on table "public"."public_tree_observations" from anon, authenticated;
+
+grant select (
+  "id",
+  "geom",
+  "condition",
+  "tree_type_group",
+  "tree_type_text",
+  "comment",
+  "created_at"
+) on table "public"."public_tree_observations" to anon, authenticated;
+grant insert ("geom", "condition", "tree_type_group", "tree_type_text", "comment", "client_id")
+  on table "public"."public_tree_observations"
+  to anon, authenticated;
+
+drop policy if exists "Anyone can read public tree observations"
+  on "public"."public_tree_observations";
+create policy "Anyone can read public tree observations"
+  on "public"."public_tree_observations"
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "Anonymous users can add constrained public tree observations"
+  on "public"."public_tree_observations";
+create policy "Anonymous users can add constrained public tree observations"
+  on "public"."public_tree_observations"
+  for insert
+  to anon, authenticated
+  with check (
+    "condition" in ('alive', 'declining', 'dead', 'not_sure')
+    and "tree_type_group" in ('conifer', 'broadleaf', 'palm_or_other', 'not_sure')
+    and ("tree_type_text" is null or char_length("tree_type_text") <= 80)
+    and ("comment" is null or char_length("comment") <= 200)
+    and ("client_id" is null or char_length("client_id") <= 64)
+    and ST_SRID("geom") = 4326
+    and GeometryType("geom") = 'POINT'
+    and ST_X("geom") between -180 and 180
+    and ST_Y("geom") between -90 and 90
+  );
+
+comment on table "public"."public_tree_observations" is
+  'Anonymous public field observations shown as unverified public contributions on the DeadTrees map. Disable insert policy to close submissions.';


### PR DESCRIPTION
## What changed
- Adds `public.public_tree_observations` for anonymous public dead-tree point contributions.
- Enables RLS with public read and constrained anon/authenticated insert policies.
- Stores point geometry, tree condition, coarse tree type, optional species text, optional comment, and a local client id.

## Why
This backend needs to be live before the mobile/frontend preview PR so field users can submit and immediately see public contribution points.

## Validation
- `supabase db reset` from this backend-only branch
- Verified migration ledger records `20260610120000_add_public_tree_observations`
- Verified anonymous Supabase client insert succeeds
- Verified public read-back succeeds with the frontend-selected columns

## Risk
- Anonymous insert is intentionally enabled for the short-term public field contribution workflow.
- Disable the insert policy to close submissions after the event if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Anonymous INSERT is intentionally open (spam/abuse surface) though constrained by CHECKs and RLS; no update/delete grants limits mutation risk.
> 
> **Overview**
> Adds a new **`public_tree_observations`** table and migration so anonymous field users can submit and read unverified dead-tree points on the DeadTrees map before the mobile/frontend work lands.
> 
> The table stores **WGS84 point geometry**, **condition** and **tree type** enums (with optional species text and comment), optional **`client_id`**, and **`created_at`**, with CHECK constraints on enums, string lengths, and valid lat/lon points. **GiST** (geometry) and **created_at** indexes support map queries and recency.
> 
> **RLS** is enabled with **public SELECT** for `anon`/`authenticated` and **column-scoped GRANTs** (read excludes `client_id`). **INSERT** is allowed for anon/authenticated with the same validation duplicated in the insert policy so submissions stay constrained without update/delete paths. Table comment documents that disabling the insert policy can shut off submissions after an event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd931a293a9dd9753c7f60a2c4c0ae6d22ebbdf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now submit public tree observations with location, tree type, condition, and comments.
  * Submissions include validation checks to ensure data quality.
  * Added database optimizations to efficiently query observations by location and date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->