### PR TITLE
fix(processing): preserve high nodata masks in COGs

### DIFF
--- a/processor/src/cog/cog.py
+++ b/processor/src/cog/cog.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import subprocess
 import rasterio
+import rasterio.enums
 from shared.logger import logger
 from rio_cogeo.cogeo import cog_info, cog_validate
 # from rio_cogeo.profiles import cog_profiles
@@ -9,6 +10,7 @@ def _build_cog_translate_command(
 	tiff_file_path: str,
 	cog_target_path: str,
 	num_bands: int,
+	alpha_band_index: int | None = None,
 	force_epsg_3857: bool = False,
 ):
 	"""Build gdal_translate command with a safe strategy per band-count."""
@@ -19,8 +21,18 @@ def _build_cog_translate_command(
 	overview_compress = 'JPEG'
 	add_alpha = False
 	band_indexes = None
+	mask_band_index = None
 
-	if num_bands == 1:
+	if alpha_band_index is not None:
+		data_band_count = alpha_band_index - 1
+		if data_band_count == 1:
+			band_indexes = [1, 1, 1]
+		elif data_band_count == 2:
+			band_indexes = [1, 2, 1]
+		else:
+			band_indexes = [1, 2, 3]
+		mask_band_index = alpha_band_index
+	elif num_bands == 1:
 		# Grayscale input. Keep JPEG but pin explicit band.
 		band_indexes = [1]
 	elif num_bands == 2:
@@ -42,6 +54,11 @@ def _build_cog_translate_command(
 	if band_indexes:
 		for band_index in band_indexes:
 			cmd_translate.extend(['-b', str(band_index)])
+
+	if mask_band_index is not None:
+		# Public COGs use internal binary masks; graded alpha is intentionally
+		# collapsed here to prioritize reliable browser transparency.
+		cmd_translate.extend(['-mask', str(mask_band_index)])
 
 	cmd_translate.extend(
 		[
@@ -160,11 +177,15 @@ def calculate_cog(
 	# Get number of bands from input file
 	with rasterio.open(tiff_file_path) as src:
 		num_bands = src.count
+		alpha_band_index = None
+		if src.count >= 2 and src.colorinterp[src.count - 1] == rasterio.enums.ColorInterp.alpha:
+			alpha_band_index = src.count
 
 	cmd_translate = _build_cog_translate_command(
 		tiff_file_path=tiff_file_path,
 		cog_target_path=cog_target_path,
 		num_bands=num_bands,
+		alpha_band_index=alpha_band_index,
 	)
 
 	# Try to process with original CRS first
@@ -181,6 +202,7 @@ def calculate_cog(
 				tiff_file_path=tiff_file_path,
 				cog_target_path=cog_target_path,
 				num_bands=num_bands,
+				alpha_band_index=alpha_band_index,
 				force_epsg_3857=True,
 			)
 			_run_gdal_translate(cmd_translate_epsg, token=token, attempt='epsg-3857-retry')

--- a/processor/src/geotiff/standardise_geotiff.py
+++ b/processor/src/geotiff/standardise_geotiff.py
@@ -16,6 +16,19 @@ import rasterio.enums
 import numpy as np
 
 
+def _as_python_scalar(value):
+	if isinstance(value, np.generic):
+		return value.item()
+	return value
+
+
+def _has_alpha_band(src) -> bool:
+	try:
+		return src.count >= 2 and src.colorinterp[src.count - 1] == rasterio.enums.ColorInterp.alpha
+	except (IndexError, AttributeError):
+		return False
+
+
 def _check_if_already_standardized(
 	input_path: str, token: str = None, dataset_id: int = None, user_id: str = None
 ) -> dict:
@@ -45,11 +58,7 @@ def _check_if_already_standardized(
 
 			# Check if band 4 is an alpha channel
 			has_alpha = False
-			if num_bands == 4:
-				try:
-					has_alpha = src.colorinterp[3] == rasterio.enums.ColorInterp.alpha
-				except (IndexError, AttributeError):
-					has_alpha = False
+			has_alpha = _has_alpha_band(src)
 
 			# File is standardized if it's uint8, tiled, and compressed
 			is_standardized = is_uint8 and is_tiled and has_compression
@@ -163,7 +172,7 @@ def find_nodata_value(src, num_bands, token: str = None, dataset_id: int = None,
 			most_common_value = values[np.argmax(counts)]
 
 			if np.max(counts) > len(edges_clean) * 0.3:
-				return most_common_value
+				return _as_python_scalar(most_common_value)
 
 		except Exception as e:
 			logger.warning(
@@ -191,6 +200,116 @@ def find_nodata_value(src, num_bands, token: str = None, dataset_id: int = None,
 			),
 		)
 		return None
+
+
+def _source_nodata_mask(source_data: np.ndarray, nodata_value) -> np.ndarray:
+	"""Return pixels where all selected source bands are nodata."""
+	if nodata_value is None:
+		return np.zeros(source_data.shape[1:], dtype=bool)
+	if nodata_value == 'nan':
+		if not np.issubdtype(source_data.dtype, np.floating):
+			return np.zeros(source_data.shape[1:], dtype=bool)
+		return np.all(np.isnan(source_data), axis=0)
+	try:
+		numeric_nodata = float(nodata_value)
+	except (TypeError, ValueError):
+		return np.zeros(source_data.shape[1:], dtype=bool)
+	return np.all(source_data == numeric_nodata, axis=0)
+
+
+def _is_extreme_value_for_dtype(value: float, dtype: str) -> bool:
+	try:
+		np_dtype = np.dtype(dtype)
+	except TypeError:
+		return False
+	if np.issubdtype(np_dtype, np.integer):
+		info = np.iinfo(np_dtype)
+		return value in {float(info.min), float(info.max)}
+	return False
+
+
+def _is_plausible_detected_nodata(value: float, dtype: str) -> bool:
+	try:
+		np_dtype = np.dtype(dtype)
+	except TypeError:
+		return False
+	if np.issubdtype(np_dtype, np.floating):
+		return np.isfinite(value)
+	if not np.issubdtype(np_dtype, np.integer):
+		return False
+
+	info = np.iinfo(np_dtype)
+	integer_value = int(value)
+	if value != float(integer_value):
+		return False
+	if integer_value == 0:
+		return True
+	if abs(integer_value - int(info.min)) <= 1 or abs(integer_value - int(info.max)) <= 1:
+		return True
+	return integer_value < 0 and abs(integer_value) in {999, 9999, 32767, 32768}
+
+
+def _add_alpha_from_source_nodata(
+	input_path: str,
+	byte_output_path: str,
+	source_nodata_value,
+	bands_to_process: int,
+	source_alpha_band_index: int | None = None,
+	token: str = None,
+	dataset_id: int = None,
+	user_id: str = None,
+) -> str:
+	"""Create an RGBA byte file whose alpha is derived from source nodata.
+
+	Nodata values such as 65535 cannot be represented after `-ot Byte`.
+	GDAL scaling clips them to 255 unless transparency is derived from the
+	original source values before the final warp step.
+	"""
+	if source_nodata_value is None and source_alpha_band_index is None:
+		return byte_output_path
+
+	indexes = list(range(1, bands_to_process + 1))
+	alpha_output_path = f'{byte_output_path}.alpha.tif'
+	with rasterio.open(input_path) as src, rasterio.open(byte_output_path) as byte_src:
+		profile = byte_src.profile.copy()
+		profile.pop('photometric', None)
+		profile.update(count=4, dtype='uint8', nodata=None, compress='DEFLATE', predictor=2)
+
+		with rasterio.open(alpha_output_path, 'w', **profile) as dst:
+			dst.colorinterp = (
+				rasterio.enums.ColorInterp.red,
+				rasterio.enums.ColorInterp.green,
+				rasterio.enums.ColorInterp.blue,
+				rasterio.enums.ColorInterp.alpha,
+			)
+			for _, window in byte_src.block_windows(1):
+				byte_data = byte_src.read(indexes=indexes, window=window, masked=False)
+				source_data = src.read(indexes=indexes, window=window, masked=False)
+				nodata_mask = _source_nodata_mask(source_data, source_nodata_value)
+				if source_alpha_band_index is not None:
+					source_alpha = src.read(source_alpha_band_index, window=window, masked=False)
+					# The public COG path uses binary masks, so preserve fully transparent
+					# source pixels while treating any nonzero alpha as valid data.
+					nodata_mask |= source_alpha == 0
+				alpha = np.full(nodata_mask.shape, 255, dtype=np.uint8)
+				if np.any(nodata_mask):
+					byte_data[:, nodata_mask] = 0
+					alpha[nodata_mask] = 0
+				if bands_to_process == 1:
+					rgb_data = np.repeat(byte_data[:1], 3, axis=0)
+				elif bands_to_process == 2:
+					rgb_data = np.concatenate([byte_data[:2], byte_data[:1]], axis=0)
+				else:
+					rgb_data = byte_data[:3]
+				dst.write(rgb_data, indexes=[1, 2, 3], window=window)
+				dst.write(alpha, indexes=4, window=window)
+
+	logger.info(
+		f'Added alpha band from source nodata value: {source_nodata_value}',
+		LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
+	)
+	Path(byte_output_path).unlink()
+	return alpha_output_path
 
 
 def standardise_geotiff(
@@ -267,14 +386,18 @@ def standardise_geotiff(
 		if not processed_input:
 			return False
 
+		with rasterio.open(processed_input) as processed_src:
+			processed_num_bands = processed_src.count
+			processed_has_alpha = _has_alpha_band(processed_src)
+
 		# Step 3: Apply final transformations with gdalwarp (pass the actual nodata value AND alpha info AND compression)
 		success = _apply_final_transformations(
 			processed_input,
 			output_path,
 			src_properties['nodata'],
 			final_nodata_value,  # Pass the actual nodata value from intermediate file
-			src_properties['num_bands'],
-			src_properties['has_alpha'],  # Pass alpha band info to avoid conflicts
+			processed_num_bands,
+			processed_has_alpha,  # Pass alpha band info to avoid conflicts
 			src_properties['compression'],  # Pass original compression to preserve lossy formats
 			token,
 			dataset_id,
@@ -435,6 +558,10 @@ def _handle_bit_depth_conversion(
 	with rasterio.open(input_path) as src:
 		detected_nodata = find_nodata_value(src, src.count, token=token, dataset_id=dataset_id, user_id=user_id)
 		explicit_nodata = src.nodata
+		source_has_alpha = _has_alpha_band(src)
+		source_alpha_band_index = src.count if source_has_alpha else None
+		if source_has_alpha and explicit_nodata is None:
+			detected_nodata = None
 
 		# Calculate scaling parameters by reading from center of image
 		logger.info(
@@ -450,10 +577,13 @@ def _handle_bit_depth_conversion(
 
 		sample_window = rasterio.windows.Window(center_x, center_y, center_width, center_height)
 		sample_data = src.read(window=sample_window)
+		sample_alpha_mask = None
+		if source_has_alpha:
+			sample_alpha_mask = sample_data[source_alpha_band_index - 1] > 0
 
 		# Calculate min/max per band for RGB only (first 3 bands)
-		num_bands = src.count
-		bands_to_analyze = min(num_bands, 3)  # Only analyze RGB bands
+		data_band_count = src.count - 1 if source_has_alpha else src.count
+		bands_to_analyze = min(data_band_count, 3)  # Only analyze RGB/display bands
 		band_ranges = []
 
 		for band_idx in range(bands_to_analyze):
@@ -461,6 +591,8 @@ def _handle_bit_depth_conversion(
 
 			# Remove NaN values and any detected nodata for proper min/max calculation
 			valid_mask = ~np.isnan(band_data)
+			if sample_alpha_mask is not None:
+				valid_mask = valid_mask & sample_alpha_mask
 
 			# Exclude explicit nodata values from scaling calculation
 			if explicit_nodata is not None and not np.isnan(explicit_nodata):
@@ -517,21 +649,29 @@ def _handle_bit_depth_conversion(
 	# Build translate command - PRESERVE original nodata values
 	# Only process RGB bands (1-3) - extra bands (multispectral, undefined) are not needed
 	# and can cause issues (e.g., constant-value bands cause GDAL scaling divide-by-zero)
-	bands_to_process = min(num_bands, 3)  # Only RGB bands
-	if num_bands > 3:
+	bands_to_process = min(data_band_count, 3)  # Only RGB/display bands
+	if compress_arg == 'JPEG' and bands_to_process < 3:
 		logger.info(
-			f'File has {num_bands} bands, will only process first 3 (RGB) for standardization',
+			'Converting JPEG compression to DEFLATE for low-band byte conversion',
+			LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
+		)
+		compress_arg = 'DEFLATE'
+	if data_band_count > 3:
+		logger.info(
+			f'File has {data_band_count} data bands, will only process first 3 for standardization',
 			LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
 		)
 
 	translate_cmd = ['gdal_translate', '-ot', 'Byte']
 
-	# Select only RGB bands if file has more than 3
-	if num_bands > 3:
-		translate_cmd.extend(['-b', '1', '-b', '2', '-b', '3'])
+	# Select only data/display bands when the source has extra or alpha bands.
+	if source_has_alpha or data_band_count > 3:
+		for band_index in range(1, bands_to_process + 1):
+			translate_cmd.extend(['-b', str(band_index)])
 
 	# Determine what nodata value to preserve in the output
 	final_nodata_value = None
+	source_nodata_value = None
 
 	if explicit_nodata is not None and np.isnan(explicit_nodata):
 		# NaN nodata - convert to 0 (since Byte format can't store NaN)
@@ -541,6 +681,7 @@ def _handle_bit_depth_conversion(
 		)
 		translate_cmd.extend(['-a_nodata', '0'])
 		final_nodata_value = 0
+		source_nodata_value = 'nan'
 	elif detected_nodata == 'nan':
 		# Detected NaN nodata - convert to 0
 		logger.info(
@@ -549,25 +690,34 @@ def _handle_bit_depth_conversion(
 		)
 		translate_cmd.extend(['-a_nodata', '0'])
 		final_nodata_value = 0
+		source_nodata_value = 'nan'
 	elif explicit_nodata is not None:
-		# Preserve explicit numeric nodata value
-		nodata_int = int(explicit_nodata)
+		# Convert numeric source nodata to byte-safe nodata.
+		nodata_float = float(explicit_nodata)
 		logger.info(
-			f'Preserving explicit nodata value: {nodata_int}',
+			f'Converting explicit nodata value {nodata_float:g} to byte nodata value 0',
 			LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
 		)
-		translate_cmd.extend(['-a_nodata', str(nodata_int)])
-		final_nodata_value = nodata_int
+		translate_cmd.extend(['-a_nodata', '0'])
+		final_nodata_value = 0
+		source_nodata_value = nodata_float
 	elif detected_nodata is not None and detected_nodata != 'nan':
-		# Preserve detected numeric nodata value
+		# Convert detected numeric source nodata to byte-safe nodata.
 		try:
-			nodata_int = int(float(detected_nodata))
-			logger.info(
-				f'Preserving detected nodata value: {nodata_int}',
-				LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
-			)
-			translate_cmd.extend(['-a_nodata', str(nodata_int)])
-			final_nodata_value = nodata_int
+			nodata_float = float(detected_nodata)
+			if not _is_plausible_detected_nodata(nodata_float, src_dtype):
+				logger.warning(
+					f'Ignoring implausible detected nodata value: {nodata_float:g}',
+					LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
+				)
+			else:
+				logger.info(
+					f'Converting detected nodata value {nodata_float:g} to byte nodata value 0',
+					LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
+				)
+				translate_cmd.extend(['-a_nodata', '0'])
+				final_nodata_value = 0
+				source_nodata_value = nodata_float
 		except (ValueError, TypeError):
 			logger.warning(
 				f'Could not convert detected nodata to integer: {detected_nodata}',
@@ -621,6 +771,35 @@ def _handle_bit_depth_conversion(
 			f'gdal_translate output:\n{result.stdout}',
 			LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
 		)
+		try:
+			processed_output = _add_alpha_from_source_nodata(
+				input_path,
+				temp_output,
+				source_nodata_value,
+				bands_to_process,
+				source_alpha_band_index=source_alpha_band_index,
+				token=token,
+				dataset_id=dataset_id,
+				user_id=user_id,
+			)
+		except Exception as e:
+			for partial_path in [temp_output, f'{temp_output}.alpha.tif']:
+				partial = Path(partial_path)
+				if partial.exists():
+					partial.unlink()
+			logger.error(
+				f'Error creating alpha band from source nodata: {e}',
+				LogContext(
+					category=LogCategory.ORTHO,
+					dataset_id=dataset_id,
+					user_id=user_id,
+					token=token,
+					extra={'error': str(e)},
+				),
+			)
+			return None, None
+		if processed_output != temp_output:
+			return processed_output, None
 		return temp_output, final_nodata_value
 
 	except subprocess.CalledProcessError as e:
@@ -664,11 +843,13 @@ def _apply_final_transformations(
 	# Determine compression to use - preserve original if specified
 	# CRITICAL: JPEG YCbCr is incompatible with alpha band modifications
 	# If we need to create alpha from nodata, use DEFLATE instead
-	if compression == 'JPEG' and final_nodata_value is not None and not has_alpha:
+	if compression == 'JPEG' and (has_alpha or final_nodata_value is not None or num_bands < 3):
 		logger.info(
-			'Converting JPEG compression to DEFLATE for alpha band creation (JPEG YCbCr incompatible with warp)',
+			'Converting JPEG compression to DEFLATE for final warp (JPEG YCbCr incompatible with alpha/low-band output)',
 			LogContext(category=LogCategory.ORTHO, dataset_id=dataset_id, user_id=user_id, token=token),
 		)
+		# JPEG-in-GTiff is unsafe for alpha and low-band outputs; accept larger
+		# standardized files here to keep browser masks and grayscale data valid.
 		compress_arg = 'DEFLATE'
 	else:
 		compress_arg = compression if compression else 'DEFLATE'

--- a/processor/tests/test_cog_command_strategy.py
+++ b/processor/tests/test_cog_command_strategy.py
@@ -1,12 +1,24 @@
 import subprocess
 from types import SimpleNamespace
 
+import numpy as np
+import pytest
+import rasterio
+import rasterio.enums
+from rasterio.enums import Resampling
+from rasterio.warp import reproject
+
 from processor.src.cog import cog as cog_module
+from processor.src.geotiff.standardise_geotiff import standardise_geotiff
+
+
+pytestmark = pytest.mark.unit
 
 
 class _RasterStub:
-	def __init__(self, count: int):
+	def __init__(self, count: int, colorinterp=None):
 		self.count = count
+		self.colorinterp = colorinterp or [rasterio.enums.ColorInterp.undefined] * count
 
 	def __enter__(self):
 		return self
@@ -23,6 +35,13 @@ def _extract_band_indexes(command: list[str]) -> list[int]:
 	return band_indexes
 
 
+def _extract_mask_index(command: list[str]) -> int | None:
+	for index, value in enumerate(command[:-1]):
+		if value == '-mask':
+			return int(command[index + 1])
+	return None
+
+
 def _has_creation_option(command: list[str], option: str) -> bool:
 	for index, value in enumerate(command[:-1]):
 		if value == '-co' and command[index + 1] == option:
@@ -30,13 +49,26 @@ def _has_creation_option(command: list[str], option: str) -> bool:
 	return False
 
 
-def _patch_common(monkeypatch, band_count: int):
-	monkeypatch.setattr(cog_module.rasterio, 'open', lambda *_args, **_kwargs: _RasterStub(band_count))
+def _patch_common(monkeypatch, band_count: int, colorinterp=None):
+	monkeypatch.setattr(
+		cog_module.rasterio,
+		'open',
+		lambda *_args, **_kwargs: _RasterStub(band_count, colorinterp=colorinterp),
+	)
 	monkeypatch.setattr(cog_module, 'cog_info', lambda cog_path: {'cog_path': cog_path})
 
 
-def test_calculate_cog_uses_first_three_bands_for_four_band_inputs(monkeypatch):
-	_patch_common(monkeypatch, band_count=4)
+def test_calculate_cog_uses_fourth_band_as_mask_for_rgba_inputs(monkeypatch):
+	_patch_common(
+		monkeypatch,
+		band_count=4,
+		colorinterp=[
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+			rasterio.enums.ColorInterp.alpha,
+		],
+	)
 	commands: list[list[str]] = []
 
 	def _run_success(command, check, capture_output, text):
@@ -50,8 +82,56 @@ def test_calculate_cog_uses_first_three_bands_for_four_band_inputs(monkeypatch):
 	assert result == {'cog_path': 'output.tif'}
 	assert len(commands) == 1
 	assert _extract_band_indexes(commands[0]) == [1, 2, 3]
+	assert _extract_mask_index(commands[0]) == 4
 	assert not _has_creation_option(commands[0], 'ALPHA=YES')
 	assert _has_creation_option(commands[0], 'COMPRESS=JPEG')
+
+
+def test_calculate_cog_uses_first_three_bands_for_four_band_non_alpha_inputs(monkeypatch):
+	_patch_common(monkeypatch, band_count=4)
+	commands: list[list[str]] = []
+
+	def _run_success(command, check, capture_output, text):
+		commands.append(command)
+		return SimpleNamespace(stdout='ok', stderr='')
+
+	monkeypatch.setattr(cog_module.subprocess, 'run', _run_success)
+
+	cog_module.calculate_cog('input.tif', 'output.tif')
+
+	assert len(commands) == 1
+	assert _extract_band_indexes(commands[0]) == [1, 2, 3]
+	assert _extract_mask_index(commands[0]) is None
+	assert not _has_creation_option(commands[0], 'ALPHA=YES')
+	assert _has_creation_option(commands[0], 'COMPRESS=JPEG')
+
+
+def test_calculate_cog_uses_trailing_alpha_as_mask_for_three_band_inputs(monkeypatch):
+	_patch_common(
+		monkeypatch,
+		band_count=3,
+		colorinterp=[
+			rasterio.enums.ColorInterp.gray,
+			rasterio.enums.ColorInterp.undefined,
+			rasterio.enums.ColorInterp.alpha,
+		],
+	)
+	commands: list[list[str]] = []
+
+	def _run_success(command, check, capture_output, text):
+		commands.append(command)
+		return SimpleNamespace(stdout='ok', stderr='')
+
+	monkeypatch.setattr(cog_module.subprocess, 'run', _run_success)
+
+	cog_module.calculate_cog('input.tif', 'output.tif')
+
+	assert len(commands) == 1
+	assert _extract_band_indexes(commands[0]) == [1, 2, 1]
+	assert _extract_mask_index(commands[0]) == 3
+	assert _has_creation_option(commands[0], 'COMPRESS=JPEG')
+	assert _has_creation_option(commands[0], 'OVERVIEW_COMPRESS=JPEG')
+	assert not _has_creation_option(commands[0], 'ALPHA=YES')
 
 
 def test_calculate_cog_uses_deflate_for_two_band_inputs(monkeypatch):
@@ -71,6 +151,140 @@ def test_calculate_cog_uses_deflate_for_two_band_inputs(monkeypatch):
 	assert _has_creation_option(commands[0], 'COMPRESS=DEFLATE')
 	assert _has_creation_option(commands[0], 'OVERVIEW_COMPRESS=DEFLATE')
 	assert not _has_creation_option(commands[0], 'ALPHA=YES')
+
+
+def test_calculate_cog_preserves_rgba_alpha_as_internal_mask(tmp_path):
+	input_path = tmp_path / 'rgba_input.tif'
+	output_path = tmp_path / 'rgba_cog.tif'
+	width = 64
+	height = 64
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((4, height, width), dtype=np.uint8)
+	data[0] = 40 + x
+	data[1] = 60 + y
+	data[2] = 80 + ((x + y) // 2)
+	alpha_mask = np.zeros((height, width), dtype=bool)
+	alpha_mask[:16, :] = True
+	alpha_mask[32:46, 28:44] = True
+	data[3] = np.where(alpha_mask, 0, 255).astype(np.uint8)
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint8',
+		'width': width,
+		'height': height,
+		'count': 4,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442000.0, 7390000.0, 0.5, 0.5),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+			rasterio.enums.ColorInterp.alpha,
+		)
+
+	cog_module.calculate_cog(str(input_path), str(output_path))
+
+	with rasterio.open(input_path) as source, rasterio.open(output_path) as cog:
+		alpha_transparent = (source.read(4) == 0).astype(np.uint8)
+		footprint = np.ones((source.height, source.width), dtype=np.uint8)
+		alpha_on_cog = np.zeros((cog.height, cog.width), dtype=np.uint8)
+		footprint_on_cog = np.zeros((cog.height, cog.width), dtype=np.uint8)
+		reproject(
+			alpha_transparent,
+			alpha_on_cog,
+			src_transform=source.transform,
+			src_crs=source.crs,
+			dst_transform=cog.transform,
+			dst_crs=cog.crs,
+			resampling=Resampling.nearest,
+		)
+		reproject(
+			footprint,
+			footprint_on_cog,
+			src_transform=source.transform,
+			src_crs=source.crs,
+			dst_transform=cog.transform,
+			dst_crs=cog.crs,
+			resampling=Resampling.nearest,
+		)
+		expected_transparent = (alpha_on_cog == 1) | (footprint_on_cog == 0)
+		actual_transparent = cog.dataset_mask() == 0
+
+		assert cog.count == 3
+		assert list(cog.colorinterp) == [
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+		]
+		assert np.array_equal(actual_transparent, expected_transparent)
+
+
+def test_two_band_high_nodata_standardise_then_cog_preserves_internal_mask(tmp_path):
+	input_path = tmp_path / 'two_band_uint16_input.tif'
+	standardized_path = tmp_path / 'two_band_standardized.tif'
+	cog_path = tmp_path / 'two_band_cog.tif'
+	width = 64
+	height = 64
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((2, height, width), dtype=np.uint16)
+	data[0] = 1000 + x * 10
+	data[1] = 2000 + y * 8
+	nodata_mask = np.zeros((height, width), dtype=bool)
+	nodata_mask[:12, :] = True
+	nodata_mask[30:44, 28:46] = True
+	data[:, nodata_mask] = 65535
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 2,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442000.0, 7390000.0, 0.5, 0.5),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (rasterio.enums.ColorInterp.gray, rasterio.enums.ColorInterp.undefined)
+
+	assert standardise_geotiff(str(input_path), str(standardized_path), token='test-token', dataset_id=10388)
+	cog_module.calculate_cog(str(standardized_path), str(cog_path))
+
+	with rasterio.open(standardized_path) as source, rasterio.open(cog_path) as cog:
+		assert source.count == 4
+		assert source.colorinterp[3] == rasterio.enums.ColorInterp.alpha
+		assert cog.count == 3
+
+		alpha_transparent = (source.read(4) == 0).astype(np.uint8)
+		footprint = np.ones((source.height, source.width), dtype=np.uint8)
+		alpha_on_cog = np.zeros((cog.height, cog.width), dtype=np.uint8)
+		footprint_on_cog = np.zeros((cog.height, cog.width), dtype=np.uint8)
+		reproject(
+			alpha_transparent,
+			alpha_on_cog,
+			src_transform=source.transform,
+			src_crs=source.crs,
+			dst_transform=cog.transform,
+			dst_crs=cog.crs,
+			resampling=Resampling.nearest,
+		)
+		reproject(
+			footprint,
+			footprint_on_cog,
+			src_transform=source.transform,
+			src_crs=source.crs,
+			dst_transform=cog.transform,
+			dst_crs=cog.crs,
+			resampling=Resampling.nearest,
+		)
+		expected_transparent = (alpha_on_cog == 1) | (footprint_on_cog == 0)
+		actual_transparent = cog.dataset_mask() == 0
+
+		assert np.array_equal(actual_transparent, expected_transparent)
 
 
 def test_calculate_cog_logs_full_error_and_retries_with_epsg_3857(monkeypatch):

--- a/processor/tests/test_standardise_scaling.py
+++ b/processor/tests/test_standardise_scaling.py
@@ -14,10 +14,19 @@ The new percentile scaling should spread it across a much wider range.
 import pytest
 import rasterio
 import numpy as np
+from types import SimpleNamespace
 from pathlib import Path
 
-from processor.src.geotiff.standardise_geotiff import _handle_bit_depth_conversion
+from processor.src.geotiff import standardise_geotiff as standardise_module
+from processor.src.geotiff.standardise_geotiff import (
+	_apply_final_transformations,
+	_handle_bit_depth_conversion,
+	_is_plausible_detected_nodata,
+	standardise_geotiff,
+)
 
+
+pytestmark = pytest.mark.unit
 
 TEST_DATA_DIR = Path(__file__).parent.parent.parent / 'assets' / 'test_data'
 WORLDVIEW_FIXTURE = TEST_DATA_DIR / 'worldview_uint16_crop.tif'
@@ -162,3 +171,341 @@ def test_uint8_input_skips_scaling(tmp_path):
 
 	# For uint8, the function returns the original input path unchanged
 	assert result_path == input_path, 'uint8 input should not be converted'
+
+
+def test_uint16_high_nodata_survives_byte_conversion_as_alpha(tmp_path):
+	"""
+	Regression for AWI dataset 10388.
+
+	The source has 65535 background pixels but no explicit nodata metadata.
+	When converting to Byte, 65535 must be repainted to byte nodata before
+	the final alpha step. Otherwise the public COG renders large white blocks.
+	"""
+	input_path = tmp_path / 'uint16_65535_background.tif'
+	output_path = tmp_path / 'standardized.tif'
+	width = 96
+	height = 96
+
+	data = np.zeros((4, height, width), dtype=np.uint16)
+	y, x = np.mgrid[0:height, 0:width]
+	data[0] = 800 + x * 8
+	data[1] = 1200 + y * 8
+	data[2] = 1000 + (x + y) * 4
+	data[3] = 2500
+
+	# Background/no-data collar and an interior hole like a clipped orthomosaic.
+	nodata_mask = np.zeros((height, width), dtype=bool)
+	nodata_mask[:12, :] = True
+	nodata_mask[-12:, :] = True
+	nodata_mask[:, :10] = True
+	nodata_mask[:, -10:] = True
+	nodata_mask[40:55, 42:58] = True
+	data[:, nodata_mask] = 65535
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 4,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 0.03, 0.03),
+		'interleave': 'pixel',
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+			rasterio.enums.ColorInterp.gray,
+		)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.dtypes[0] == 'uint8'
+		assert dst.count == 4
+		alpha = dst.read(4)
+		rgb = dst.read([1, 2, 3])
+
+		assert np.all(alpha[nodata_mask] == 0)
+		assert np.all(alpha[~nodata_mask] == 255)
+		assert np.all(rgb[:, nodata_mask] == 0)
+		assert np.max(rgb[:, ~nodata_mask]) > 100
+
+
+def test_single_band_high_nodata_gets_alpha_without_rgb_assumption(tmp_path):
+	input_path = tmp_path / 'single_band_65535_background.tif'
+	output_path = tmp_path / 'single_band_standardized.tif'
+	width = 64
+	height = 64
+	y, x = np.mgrid[0:height, 0:width]
+	data = (1000 + x * 10 + y * 5).astype(np.uint16)
+	nodata_mask = np.zeros((height, width), dtype=bool)
+	nodata_mask[:10, :] = True
+	nodata_mask[28:40, 30:46] = True
+	data[nodata_mask] = 65535
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 1,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 1.0, 1.0),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data, 1)
+		dst.colorinterp = (rasterio.enums.ColorInterp.gray,)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.dtypes[0] == 'uint8'
+		assert dst.count == 4
+		assert dst.colorinterp[3] == rasterio.enums.ColorInterp.alpha
+		alpha = dst.read(4)
+		gray = dst.read(1)
+
+		assert np.all(alpha[nodata_mask] == 0)
+		assert np.all(alpha[~nodata_mask] == 255)
+		assert np.all(gray[nodata_mask] == 0)
+		assert np.max(gray[~nodata_mask]) > 100
+
+
+def test_float_detected_sentinel_nodata_gets_alpha(tmp_path):
+	input_path = tmp_path / 'float_sentinel_background.tif'
+	output_path = tmp_path / 'float_standardized.tif'
+	width = 72
+	height = 72
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((3, height, width), dtype=np.float32)
+	data[0] = 20.0 + x * 0.8
+	data[1] = 30.0 + y * 0.6
+	data[2] = 25.0 + (x + y) * 0.4
+
+	nodata_mask = np.zeros((height, width), dtype=bool)
+	nodata_mask[:12, :] = True
+	nodata_mask[-10:, :] = True
+	nodata_mask[:, :8] = True
+	nodata_mask[30:44, 34:50] = True
+	data[:, nodata_mask] = -9999.0
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'float32',
+		'width': width,
+		'height': height,
+		'count': 3,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 1.0, 1.0),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+		)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.dtypes[0] == 'uint8'
+		assert dst.count == 4
+		alpha = dst.read(4)
+		rgb = dst.read([1, 2, 3])
+
+		assert np.all(alpha[nodata_mask] == 0)
+		assert np.all(alpha[~nodata_mask] == 255)
+		assert np.all(rgb[:, nodata_mask] == 0)
+		assert np.max(rgb[:, ~nodata_mask]) > 100
+
+
+@pytest.mark.parametrize(
+	'value,dtype,expected',
+	[
+		(0, 'uint16', True),
+		(65535, 'uint16', True),
+		(65534, 'uint16', True),
+		(-32768, 'int16', True),
+		(-32767, 'int16', True),
+		(-9999, 'int16', True),
+		(1234, 'uint16', False),
+		(42, 'int16', False),
+		(-12.5, 'int16', False),
+	],
+)
+def test_detected_integer_nodata_plausibility(value, dtype, expected):
+	assert _is_plausible_detected_nodata(value, dtype) is expected
+
+
+def test_uint16_zero_detected_nodata_gets_alpha(tmp_path):
+	input_path = tmp_path / 'uint16_zero_background.tif'
+	output_path = tmp_path / 'zero_background_standardized.tif'
+	width = 64
+	height = 64
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((3, height, width), dtype=np.uint16)
+	data[0] = 700 + x * 6
+	data[1] = 900 + y * 6
+	data[2] = 800 + (x + y) * 3
+
+	nodata_mask = np.zeros((height, width), dtype=bool)
+	nodata_mask[:10, :] = True
+	nodata_mask[:, :8] = True
+	nodata_mask[30:42, 28:44] = True
+	data[:, nodata_mask] = 0
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 3,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 1.0, 1.0),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+		)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.count == 4
+		alpha = dst.read(4)
+		assert np.all(alpha[nodata_mask] == 0)
+		assert np.all(alpha[~nodata_mask] == 255)
+
+
+def test_source_alpha_pixels_are_excluded_from_scaling(tmp_path):
+	input_path = tmp_path / 'uint16_rgba_transparent_outliers.tif'
+	output_path = tmp_path / 'rgba_standardized.tif'
+	width = 80
+	height = 80
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((4, height, width), dtype=np.uint16)
+	data[0] = 900 + x * 5
+	data[1] = 1000 + y * 5
+	data[2] = 1100 + (x + y) * 2
+	data[3] = 65535
+
+	transparent_mask = np.zeros((height, width), dtype=bool)
+	transparent_mask[20:60, 20:60] = True
+	data[:3, transparent_mask] = 65535
+	data[3, transparent_mask] = 0
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 4,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 1.0, 1.0),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+			rasterio.enums.ColorInterp.alpha,
+		)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.dtypes[0] == 'uint8'
+		assert dst.count == 4
+		alpha = dst.read(4)
+		rgb = dst.read([1, 2, 3])
+
+		assert np.all(alpha[transparent_mask] == 0)
+		assert np.all(alpha[~transparent_mask] == 255)
+		assert np.max(rgb[:, ~transparent_mask]) > 100
+
+
+def test_final_warp_uses_deflate_for_low_band_jpeg_without_alpha_or_nodata(monkeypatch):
+	commands: list[list[str]] = []
+
+	def _run_success(command, check, capture_output, text):
+		commands.append(command)
+		return SimpleNamespace(stdout='ok', stderr='')
+
+	monkeypatch.setattr(standardise_module.subprocess, 'run', _run_success)
+	monkeypatch.setattr(standardise_module, 'verify_geotiff', lambda *args, **kwargs: True)
+
+	assert _apply_final_transformations(
+		'input.tif',
+		'output.tif',
+		original_nodata=None,
+		final_nodata_value=None,
+		num_bands=2,
+		has_alpha=False,
+		compression='JPEG',
+		token='test-token',
+		dataset_id=10388,
+		user_id='test-user',
+	)
+
+	assert len(commands) == 1
+	command = commands[0]
+	assert 'COMPRESS=DEFLATE' in command
+	assert 'PREDICTOR=2' in command
+	assert 'COMPRESS=JPEG' not in command
+
+
+def test_uint16_source_alpha_survives_byte_conversion(tmp_path):
+	input_path = tmp_path / 'uint16_rgba_alpha_only.tif'
+	output_path = tmp_path / 'rgba_standardized.tif'
+	width = 72
+	height = 72
+	y, x = np.mgrid[0:height, 0:width]
+	data = np.zeros((4, height, width), dtype=np.uint16)
+	data[0] = 800 + x * 8
+	data[1] = 1100 + y * 8
+	data[2] = 900 + (x + y) * 4
+	data[3] = 65535
+	transparent_mask = np.zeros((height, width), dtype=bool)
+	transparent_mask[:14, :] = True
+	transparent_mask[34:48, 30:50] = True
+	data[3, transparent_mask] = 0
+	data[:3, 20, 20] = 0
+
+	profile = {
+		'driver': 'GTiff',
+		'dtype': 'uint16',
+		'width': width,
+		'height': height,
+		'count': 4,
+		'crs': 'EPSG:32608',
+		'transform': rasterio.transform.from_origin(442287.0, 7390649.0, 1.0, 1.0),
+	}
+	with rasterio.open(input_path, 'w', **profile) as dst:
+		dst.write(data)
+		dst.colorinterp = (
+			rasterio.enums.ColorInterp.red,
+			rasterio.enums.ColorInterp.green,
+			rasterio.enums.ColorInterp.blue,
+			rasterio.enums.ColorInterp.alpha,
+		)
+
+	assert standardise_geotiff(str(input_path), str(output_path), token='test-token', dataset_id=10388)
+
+	with rasterio.open(output_path) as dst:
+		assert dst.dtypes[0] == 'uint8'
+		assert dst.count == 4
+		assert dst.colorinterp[3] == rasterio.enums.ColorInterp.alpha
+		alpha = dst.read(4)
+
+		assert np.all(alpha[transparent_mask] == 0)
+		assert np.all(alpha[~transparent_mask] == 255)
+		assert alpha[20, 20] == 255


### PR DESCRIPTION
## What

- Preserve high/out-of-byte-range source nodata as alpha before byte conversion in GeoTIFF standardisation.
- Preserve source alpha through standardisation and publish COG transparency as an internal mask.
- Avoid unsafe JPEG output for alpha and low-band GeoTIFF/COG paths.
- Add regression coverage for uint16 `65535`, zero, float sentinel nodata, source alpha, low-band inputs, and COG internal masks.

## Why

AWI dataset 10388 has large `65535` background regions. After byte conversion these were clipped into visible data, so the public COG rendered with broken white/green background instead of transparency.

## Validation

- `scripts/lint-python.sh`
- `git diff --check`
- Processor container focused tests: `24 passed, 2 skipped`
- Real 10388 crop smoke previously verified matching source nodata to standardized alpha and final COG mask.
- Autoreview: Codex + Claude medium panel drove fixes; final Claude retry hit quota, Codex medium fallback was clean with no accepted/actionable findings.

## Risk

Processor GeoTIFF/COG behavior changes for nodata and alpha handling. JPEG alpha/low-band outputs are intentionally converted to DEFLATE for correctness, which can increase standardized file size for those input classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ortho GeoTIFF/COG nodata and alpha behavior for all datasets; JPEG inputs with alpha or fewer than three bands may produce larger DEFLATE outputs by design.
> 
> **Overview**
> Fixes broken map transparency when orthomosaics use **out-of-range nodata** (e.g. uint16 `65535`) or existing alpha, which previously clipped to visible white/green after byte conversion.
> 
> **GeoTIFF standardisation** now derives transparency from **original source values** before the final warp: numeric nodata is mapped to byte-safe `0`, then `_add_alpha_from_source_nodata` builds RGBA (including 1- and 2-band cases). Trailing alpha is detected generically; transparent pixels are excluded from scaling; implausible edge-detected nodata is ignored. **JPEG** is switched to **DEFLATE** on alpha and low-band warp paths where YCbCr JPEG is unsafe.
> 
> **COG generation** treats a **trailing alpha band** as an internal **`-mask`** on RGB output (no `ALPHA=YES` / RGBA+JPEG path), including grayscale+alpha band layouts.
> 
> Regression tests cover uint16/float sentinels, source alpha, two-band flows, and COG `dataset_mask` alignment end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a300457584f8085f04a3eac0bd87009a3effd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and preservation of image transparency in output files
  * Automatic conversion of nodata values to transparency layers for better compatibility

* **Bug Fixes**
  * Enhanced mask handling accuracy during image processing and optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->