### PR TITLE
fix(priwa): respect mobile safe area on field map

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,10 @@
       type="text/css"
       href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css"
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#1b5e35" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -188,7 +188,7 @@ export default function Navigation() {
         </Header>
       </div>
 
-      <div className="md:hidden fixed top-0 z-50 w-full px-2 pt-2 pointer-events-none">
+      <div className="dt-mobile-nav-shell md:hidden fixed top-0 z-50 w-full px-2 pointer-events-none">
         <Header
           className="pointer-events-auto"
           style={{

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -573,7 +573,7 @@ export default function PriwaFieldMap({
 
       {!isPlacingPoint && (
         <>
-          <div className="pointer-events-none absolute left-4 top-20 z-10 flex flex-col gap-2 md:top-24">
+          <div className="priwa-map-control-stack pointer-events-none absolute left-4 z-10 flex flex-col gap-2">
             <Tooltip title={locationButtonTitle}>
               <Button
                 className={
@@ -683,7 +683,7 @@ export default function PriwaFieldMap({
       )}
 
       {!isPlacingPoint && (
-        <div className="pointer-events-none absolute right-4 top-20 z-10 flex max-w-[calc(100%-5.75rem)] flex-col items-end gap-1.5 md:top-24">
+        <div className="priwa-map-status-stack pointer-events-none absolute right-4 z-10 flex max-w-[calc(100%-5.75rem)] flex-col items-end gap-1.5">
           {locationHintLabel && (
             <div className="rounded-md bg-white/90 px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm backdrop-blur">
               {locationHintLabel}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -323,3 +323,19 @@
   font-size: 20px;
   color: #2d6b3f !important;
 }
+
+.dt-mobile-nav-shell {
+  padding-top: calc(env(safe-area-inset-top, 0px) + 0.5rem);
+}
+
+.priwa-map-control-stack,
+.priwa-map-status-stack {
+  top: calc(env(safe-area-inset-top, 0px) + 5.75rem);
+}
+
+@media (min-width: 768px) {
+  .priwa-map-control-stack,
+  .priwa-map-status-stack {
+    top: 6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- enable iOS viewport safe-area insets with viewport-fit=cover
- pad the mobile navigation below the top safe area
- move PRIWA map controls and status chips below the safe-area-aware header

## Validation
- iPhone 15 Simulator screenshot confirmed the original top-control collision
- local simulator opened the updated build and showed the mobile header below the safe area
- npm run lint
- npm run build

## Notes
- Simulator was not signed into the local app, so the map-specific controls were verified by code path and layout offsets rather than an authenticated simulator map screenshot.
- Build still reports existing Vite chunk-size/dynamic-import warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and viewport-only layout changes for mobile; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes PRIWA field map and mobile navigation overlapping the iOS status bar and notch by wiring in **safe-area** layout.
> 
> The viewport meta tag now includes `viewport-fit=cover` so `env(safe-area-inset-*)` is available. The mobile nav shell uses top safe-area padding instead of a fixed `pt-2`, and PRIWA map control/status stacks get their vertical offset from shared CSS (`priwa-map-control-stack` / `priwa-map-status-stack`) that accounts for safe area on small screens and a fixed `6rem` on `md+`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ddffbfbd105bc1c7f67446f82856732f83c7845. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile viewport configuration with improved safe-area inset handling for devices with notches and home indicators.
  * Updated mobile navigation styling and layout.
  * Refined positioning and spacing of map overlay controls and status indicators on mobile devices with optimized responsive behavior for larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->