### PR TITLE
fix(frontend): stabilize deadtrees pwa map controls

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#1b5e35" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="PRIWA Field" />
+    <meta name="apple-mobile-web-app-title" content="deadtrees.earth" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta
       name="description"

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,8 +1,8 @@
 {
-  "name": "PRIWA Field - deadtrees.earth",
-  "short_name": "PRIWA Field",
-  "description": "PRIWA field capture app for Kaeferbaum records.",
-  "start_url": "/priwa-field",
+  "name": "deadtrees.earth",
+  "short_name": "deadtrees",
+  "description": "Mobile map for exploring and contributing dead-tree observations.",
+  "start_url": "/deadtrees",
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
@@ -25,8 +25,20 @@
   "categories": ["productivity", "utilities"],
   "shortcuts": [
     {
+      "name": "DeadTrees map",
+      "short_name": "Map",
+      "url": "/deadtrees",
+      "icons": [
+        {
+          "src": "/assets/app-icon.png",
+          "sizes": "512x512",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
       "name": "PRIWA Field",
-      "short_name": "Field",
+      "short_name": "PRIWA",
       "url": "/priwa-field",
       "icons": [
         {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,5 +1,5 @@
 const CACHE_VERSION = "deadtrees-app-shell-v2";
-const APP_SHELL_CACHE = `deadtrees-${CACHE_VERSION}`;
+const APP_SHELL_CACHE = CACHE_VERSION;
 const BASEMAP_CACHE_PREFIX = "deadtrees-priwa-basemap-v1";
 const VIEWED_BASEMAP_CACHE = `${BASEMAP_CACHE_PREFIX}-viewed`;
 const LGL_BASEMAP_URL_PREFIX =

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "priwa-app-shell-v1";
+const CACHE_VERSION = "deadtrees-app-shell-v2";
 const APP_SHELL_CACHE = `deadtrees-${CACHE_VERSION}`;
 const BASEMAP_CACHE_PREFIX = "deadtrees-priwa-basemap-v1";
 const VIEWED_BASEMAP_CACHE = `${BASEMAP_CACHE_PREFIX}-viewed`;
@@ -8,6 +8,7 @@ const TOPOGRAPHIC_TILE_URL_PREFIX =
   "https://sgx.geodatenzentrum.de/wmts_basemapde/tile/1.0.0/de_basemapde_web_raster_farbe/default/GLOBAL_WEBMERCATOR";
 const APP_SHELL_URLS = [
   "/",
+  "/deadtrees",
   "/priwa-field",
   "/manifest.webmanifest",
   "/assets/favicon.png",
@@ -64,7 +65,7 @@ const handleNavigation = async (request) => {
       (await caches.match(request)) ||
       (await caches.match("/priwa-field")) ||
       (await caches.match("/")) ||
-      new Response("PRIWA Field is offline and the app shell is unavailable.", {
+      new Response("deadtrees.earth is offline and the app shell is unavailable.", {
         headers: { "Content-Type": "text/plain; charset=utf-8" },
         status: 503,
         statusText: "Offline",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,15 +62,14 @@ function LayoutWrapper() {
         style={{
           margin: "0 auto",
           height: shouldUseFullHeight ? "100dvh" : "auto",
-          minHeight: shouldUseFullHeight ? "100vh" : undefined,
           backgroundColor: "var(--dt-surface-base)",
         }}
       >
         <Navigation />
         <Content
           style={{
-            height: shouldUseFullHeight ? "100dvh" : "auto",
-            minHeight: shouldUseFullHeight ? "100vh" : undefined,
+            flex: shouldUseFullHeight ? 1 : undefined,
+            minHeight: shouldUseFullHeight ? 0 : undefined,
             backgroundColor: "var(--dt-surface-base)",
           }}
         >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,14 +61,16 @@ function LayoutWrapper() {
       <Layout
         style={{
           margin: "0 auto",
-          height: shouldUseFullHeight ? "100vh" : "auto",
+          height: shouldUseFullHeight ? "100dvh" : "auto",
+          minHeight: shouldUseFullHeight ? "100vh" : undefined,
           backgroundColor: "var(--dt-surface-base)",
         }}
       >
         <Navigation />
         <Content
           style={{
-            height: shouldUseFullHeight ? "100vh" : "auto",
+            height: shouldUseFullHeight ? "100dvh" : "auto",
+            minHeight: shouldUseFullHeight ? "100vh" : undefined,
             backgroundColor: "var(--dt-surface-base)",
           }}
         >

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PointerEvent as ReactPointerEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Button,
@@ -1148,22 +1147,6 @@ const DeadtreesMap = () => {
     }
   }, [userLocation.locationError]);
 
-  const maybeStartMobileOrientationTracking = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (!isMobile || !userLocation.needsOrientationPermission) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target?.closest(
-          "button, input, textarea, select, .ant-drawer, .deadtrees-mobile-control-panel",
-        )
-      ) {
-        return;
-      }
-      locateUser(true);
-    },
-    [isMobile, locateUser, userLocation.needsOrientationPermission],
-  );
-
   const requestPublicObservationPlacement = useCallback(() => {
     if (!mapRef.current || !isMobile) return;
 
@@ -1283,10 +1266,7 @@ const DeadtreesMap = () => {
     isDrawingFlag || polygonAnalysis.isDrawing || isPlacingPublicObservation;
 
   return (
-    <div
-      className="h-full w-full"
-      onPointerDownCapture={maybeStartMobileOrientationTracking}
-    >
+    <div className="h-full w-full">
       <div
         style={{
           width: "100%",
@@ -1443,7 +1423,10 @@ const DeadtreesMap = () => {
         />
 
         {activeMobileDrawMode && (
-          <div className="pointer-events-none absolute bottom-[calc(0.75rem+env(safe-area-inset-bottom))] left-1/2 z-[60] w-fit max-w-[calc(100vw-1.5rem)] -translate-x-1/2 md:hidden">
+          <div
+            className="pointer-events-none absolute left-1/2 z-[60] w-fit max-w-[calc(100vw-1.5rem)] -translate-x-1/2 md:hidden"
+            style={{ bottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+          >
             <div className="pointer-events-auto flex items-center gap-2 rounded-2xl border border-gray-200/80 bg-white/95 p-2 shadow-xl backdrop-blur-sm">
               <div className="hidden min-w-0 flex-1 px-1 sm:block">
                 <div className="text-xs font-semibold text-gray-700">

--- a/frontend/src/components/DeadwoodMap/mobile/MobileAddTreeButton.tsx
+++ b/frontend/src/components/DeadwoodMap/mobile/MobileAddTreeButton.tsx
@@ -13,7 +13,10 @@ const MobileAddTreeButton = ({
   if (hidden) return null;
 
   return (
-    <div className="pointer-events-none absolute bottom-[calc(1rem+env(safe-area-inset-bottom))] right-3 z-[54] md:hidden">
+    <div
+      className="pointer-events-none absolute right-3 z-[54] md:hidden"
+      style={{ bottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+    >
       <Button
         type="primary"
         shape="round"

--- a/frontend/src/components/DeadwoodMap/mobile/MobileTimePill.tsx
+++ b/frontend/src/components/DeadwoodMap/mobile/MobileTimePill.tsx
@@ -21,7 +21,10 @@ const MobileTimePill = ({
   if (hidden) return null;
 
   return (
-    <div className="pointer-events-none absolute bottom-[calc(1rem+env(safe-area-inset-bottom))] left-3 z-[54] md:hidden">
+    <div
+      className="pointer-events-none absolute left-3 z-[54] md:hidden"
+      style={{ bottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+    >
       <button
         type="button"
         aria-label={`Prediction year ${year}. Change time settings`}

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -229,6 +229,7 @@ export default function Navigation() {
         open={mobileMenuOpen}
         width="82vw"
         onClose={() => setMobileMenuOpen(false)}
+        rootClassName="dt-mobile-navigation-drawer-root"
         styles={{
           body: { padding: 0, display: "flex", flexDirection: "column" },
         }}
@@ -257,7 +258,7 @@ export default function Navigation() {
             />
           </ConfigProvider>
         </div>
-        <div className="p-4 border-t border-gray-100">
+        <div className="dt-mobile-navigation-drawer-footer p-4 border-t border-gray-100">
           <Button
             className="w-full font-medium"
             type={session ? "default" : "primary"}

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -410,7 +410,7 @@ export default function PriwaPointDrawer({
           overflowX: "hidden",
           overflowY: "auto",
           overscrollBehavior: "contain",
-          padding: "14px 18px 18px",
+          padding: "14px 18px calc(env(safe-area-inset-bottom, 0px) + 18px)",
           touchAction: "pan-y",
           WebkitOverflowScrolling: "touch",
         },

--- a/frontend/src/hooks/useUserLocationLayer.ts
+++ b/frontend/src/hooks/useUserLocationLayer.ts
@@ -124,6 +124,7 @@ export const useUserLocationLayer = (mapRef: MutableRefObject<Map | null>) => {
       const view = mapRef.current?.getView();
       if (!view) return;
 
+      view.cancelAnimations();
       view.animate({
         center: coordinates,
         zoom: Math.max(view.getZoom() || 0, 18),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,6 +102,26 @@
   .dt-map-attribution-control {
     display: none !important;
   }
+
+  .dt-mobile-navigation-drawer-root .ant-drawer-content,
+  .dt-mobile-navigation-drawer-root .ant-drawer-content-wrapper,
+  .priwa-point-drawer-root .ant-drawer-content,
+  .priwa-point-drawer-root .ant-drawer-content-wrapper {
+    max-height: 100dvh;
+  }
+
+  .dt-mobile-navigation-drawer-root .ant-drawer-header,
+  .priwa-point-drawer-root .ant-drawer-header {
+    padding-top: calc(env(safe-area-inset-top, 0px) + 16px);
+  }
+
+  .dt-mobile-navigation-drawer-root .ant-drawer-body {
+    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+  }
+
+  .dt-mobile-navigation-drawer-footer {
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 16px) !important;
+  }
 }
 
 .priwa-point-drawer-root .ant-drawer-body {


### PR DESCRIPTION
## Summary
- lower the DeadTrees mobile bottom controls in PWA/mobile view by avoiding extra safe-area spacing
- stop map-wide pointer-down events from retrying orientation/location permission, which could interrupt pan/zoom and trigger unwanted recentering on iOS
- use dynamic viewport height for full-height routes and cancel queued map animations before location recentering
- make PWA metadata DeadTrees-first while preserving a PRIWA shortcut and cache /deadtrees in the app shell

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend test -- --run
- npm --prefix frontend run build
- Browser plugin: opened http://127.0.0.1:5174/deadtrees at 393x852, confirmed bottom controls at 12px bottom gap and map drag remained interactive
- iOS simulator: opened patched /deadtrees on booted iOS 18 Remodex iPhone 15, granted Safari location, captured layout screenshots; Safari mode still shows its own bottom toolbar, but controls are lower and PWA manifest now serves deadtrees.earth with /deadtrees start_url

## Notes
- Existing Vite large chunk warnings remain unchanged.
- Existing Ant Design console warnings remain unrelated to this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, PWA metadata, and service-worker cache versioning only; no auth, API, or data-model changes.
> 
> **Overview**
> **Stabilizes the DeadTrees mobile/PWA map** by fixing layout, interaction, and install metadata without changing core map data logic.
> 
> **Mobile map UX:** Removes the map container’s capture-phase `pointerdown` handler that retried orientation/location permission on every touch (which could interrupt pan/zoom and cause unwanted recentering on iOS). Recenters via `view.cancelAnimations()` before animating to the user. Bottom floating controls (time pill, Add tree, draw-mode bar) use `bottom: max(0.75rem, env(safe-area-inset-bottom))` instead of stacking extra safe-area padding on top of a fixed offset.
> 
> **Full-height routes:** `LayoutWrapper` uses **`100dvh`** with **`minHeight: 100vh`** fallback so the map fills the dynamic viewport on mobile browsers/PWA.
> 
> **PWA shell:** Manifest and `index.html` are **deadtrees.earth**-first (`start_url` `/deadtrees`, new DeadTrees shortcut); PRIWA Field remains as a shortcut. Service worker bumps cache to **v2**, precaches `/deadtrees`, and updates the offline fallback copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c586022d27857956aae28fc0fd450438fc48adb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rebranded app identity from "PRIWA Field" to "deadtrees.earth" in metadata, manifest, and service worker cache naming; updated manifest name, short_name, description, start URL and shortcuts.

* **Bug Fixes**
  * Improved mobile safe-area handling and positioning across drawers, map controls, and buttons for notched devices.
  * Adjusted layout height handling for full-height routes.
  * Prevented conflicting map view animations; updated offline fallback messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->