### PR TITLE
fix(frontend): distinguish map flag colors

### DIFF
--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -732,7 +732,7 @@ const DeadtreesMap = () => {
         });
       } else {
         return new Style({
-          fill: new Fill({ color: "rgba(22, 119, 255, 0.15)" }),
+          fill: new Fill({ color: mapColors.flag.areaFill }),
           stroke: new Stroke({ color: mapColors.flag.stroke, width: 2 }),
         });
       }
@@ -1649,7 +1649,12 @@ const DeadtreesMap = () => {
               <p className="mb-1 font-medium text-blue-700">Share feedback</p>
               <p className="text-sm leading-6">
                 After signing in, use{" "}
-                <span className="font-semibold text-blue-600">Flag Area</span>{" "}
+                <span
+                  className="font-semibold"
+                  style={{ color: mapColors.flag.stroke }}
+                >
+                  Flag Area
+                </span>{" "}
                 to report issues in your forest or study area.
               </p>
             </div>

--- a/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
+++ b/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
@@ -333,7 +333,10 @@ const LayerControlPanel = ({
                 </Button>
                 {setShowFlagsLayer && (
                   <div className="mt-2 flex items-center justify-between">
-                    <span className="text-xs text-blue-600">
+                    <span
+                      className="text-xs"
+                      style={{ color: mapColors.flag.stroke }}
+                    >
                       Show Flags{" "}
                       {flagsCount !== undefined &&
                         flagsCount > 0 &&

--- a/frontend/src/theme/mapColors.ts
+++ b/frontend/src/theme/mapColors.ts
@@ -16,8 +16,8 @@ export const mapColors = {
     fill: hexToRgba(palette.secondary[500], 0.2),
   },
   flag: {
-    stroke: palette.primary[500],
-    fill: palette.primary[500],
+    stroke: palette.secondary[500],
+    fill: palette.secondary[500],
+    areaFill: hexToRgba(palette.secondary[500], 0.15),
   },
 } as const;
-


### PR DESCRIPTION
## Summary
- Move map flag styling from brand green to the existing secondary blue palette
- Keep public tree observations condition-colored so live/dead observations remain semantically distinct
- Reuse the same flag color in the map style, layer control, and feedback hint text

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend test -- --run
- npm --prefix frontend run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated flag visualization colors throughout the map interface for improved visual consistency
  * Enhanced flag area display with refined transparency and color treatment
  * Adjusted flag-related UI labels to align with updated color scheme

<!-- end of auto-generated comment: release notes by coderabbit.ai -->