### PR TITLE
feat(frontend): wire releases to signed downloads

### DIFF
--- a/frontend/e2e/data-factory-readonly.spec.ts
+++ b/frontend/e2e/data-factory-readonly.spec.ts
@@ -213,7 +213,9 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
     await expect(
       page
         .getByTestId("release-artifacts")
-        .getByRole("button", { name: /Download dataset|Download ZIP/ })
+        .getByRole("button", {
+          name: /Download dataset|Download ZIP|Sign in to download/,
+        })
         .first(),
     ).toBeVisible();
   });

--- a/frontend/src/components/Releases/PrepackagedDownloadButton.tsx
+++ b/frontend/src/components/Releases/PrepackagedDownloadButton.tsx
@@ -1,0 +1,75 @@
+import { DownloadOutlined } from "@ant-design/icons";
+import { Button, message, type ButtonProps } from "antd";
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAuth } from "../../hooks/useAuthProvider";
+import { useCreatePrepackagedDownloadGrant } from "../../hooks/usePrepackagedDatasets";
+
+interface PrepackagedDownloadButtonProps {
+  versionId: number | null | undefined;
+  returnTo: string;
+  children?: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  icon?: ReactNode;
+  size?: ButtonProps["size"];
+  type?: ButtonProps["type"];
+}
+
+export function PrepackagedDownloadButton({
+  versionId,
+  returnTo,
+  children = "Download ZIP",
+  className,
+  disabled = false,
+  icon = <DownloadOutlined />,
+  size = "large",
+  type = "primary",
+}: PrepackagedDownloadButtonProps) {
+  const navigate = useNavigate();
+  const [messageApi, contextHolder] = message.useMessage();
+  const { session } = useAuth();
+  const token = session?.access_token;
+  const grantMutation = useCreatePrepackagedDownloadGrant();
+
+  const handleDownload = async () => {
+    if (!versionId) {
+      void messageApi.warning("This package is not available yet.");
+      return;
+    }
+
+    if (!token) {
+      navigate(`/sign-in?returnTo=${encodeURIComponent(returnTo)}`);
+      return;
+    }
+
+    try {
+      const grant = await grantMutation.mutateAsync({ versionId, token });
+      window.location.assign(grant.download_url);
+    } catch (downloadError) {
+      const errorMessage =
+        downloadError instanceof Error
+          ? downloadError.message
+          : "Could not start the package download.";
+      void messageApi.error(errorMessage);
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Button
+        type={type}
+        size={size}
+        icon={icon}
+        loading={grantMutation.isPending}
+        onClick={handleDownload}
+        disabled={disabled || !versionId}
+        className={className}
+      >
+        {token ? children : "Sign in to download"}
+      </Button>
+    </>
+  );
+}

--- a/frontend/src/components/Releases/PrepackagedReleaseDownloads.tsx
+++ b/frontend/src/components/Releases/PrepackagedReleaseDownloads.tsx
@@ -1,0 +1,138 @@
+import { DatabaseOutlined } from "@ant-design/icons";
+import { Alert, Skeleton, Tag } from "antd";
+
+import { usePrepackagedDatasets } from "../../hooks/usePrepackagedDatasets";
+import {
+  formatPrepackagedBytes,
+  formatPrepackagedDate,
+  getLatestPrepackagedVersion,
+  prepackagedKindLabel,
+} from "../../utils/prepackagedDatasets";
+import { PrepackagedDownloadButton } from "./PrepackagedDownloadButton";
+
+interface PrepackagedReleaseDownloadsProps {
+  packageSlugs: string[];
+  returnTo: string;
+}
+
+export function PrepackagedReleaseDownloads({
+  packageSlugs,
+  returnTo,
+}: PrepackagedReleaseDownloadsProps) {
+  const { data, isLoading, error } = usePrepackagedDatasets();
+
+  if (isLoading) {
+    return <Skeleton active paragraph={{ rows: 5 }} />;
+  }
+
+  if (error) {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        message="Could not load dataset packages"
+        description={error instanceof Error ? error.message : undefined}
+      />
+    );
+  }
+
+  const catalog = data ?? [];
+  const packageBySlug = new Map(
+    catalog.map((candidate) => [candidate.slug, candidate]),
+  );
+  const packages = packageSlugs
+    .map((slug) => packageBySlug.get(slug))
+    .filter((candidate): candidate is NonNullable<typeof candidate> =>
+      Boolean(candidate),
+    );
+  const missingPackageSlugs = packageSlugs.filter(
+    (slug) => !packageBySlug.has(slug),
+  );
+  const missingPackageDescription = `Waiting for: ${missingPackageSlugs.join(", ")}`;
+
+  if (!packages.length) {
+    return (
+      <Alert
+        type={missingPackageSlugs.length > 0 ? "warning" : "info"}
+        showIcon
+        message="Dataset package is not available yet"
+        description={
+          missingPackageSlugs.length > 0
+            ? missingPackageDescription
+            : "The release preview is public; downloadable ZIP packages will appear here when they are published."
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      {missingPackageSlugs.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Some dataset packages are not available yet"
+          description={missingPackageDescription}
+        />
+      )}
+      {packages.map((datasetPackage) => {
+        const latestVersion = getLatestPrepackagedVersion(datasetPackage);
+        return (
+          <article
+            key={datasetPackage.slug}
+            className="rounded-lg border border-gray-200 bg-white p-5"
+          >
+            <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Tag className="m-0">
+                    {prepackagedKindLabel(datasetPackage.kind)}
+                  </Tag>
+                  {latestVersion && (
+                    <Tag className="m-0" color="green">
+                      v{latestVersion.version}
+                    </Tag>
+                  )}
+                </div>
+                <h3 className="m-0 mt-3 text-xl font-semibold leading-tight text-gray-950">
+                  {datasetPackage.title}
+                </h3>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
+                  {datasetPackage.summary}
+                </p>
+                {latestVersion && (
+                  <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-sm text-gray-500">
+                    <span>
+                      {formatPrepackagedBytes(latestVersion.size_bytes)}
+                    </span>
+                    <span>
+                      Published{" "}
+                      {formatPrepackagedDate(latestVersion.published_at)}
+                    </span>
+                  </div>
+                )}
+                {latestVersion?.known_issues && (
+                  <Alert
+                    className="mt-4"
+                    type="warning"
+                    showIcon
+                    message={latestVersion.known_issues}
+                  />
+                )}
+              </div>
+
+              <PrepackagedDownloadButton
+                versionId={latestVersion?.id}
+                returnTo={returnTo}
+                icon={<DatabaseOutlined />}
+                className="min-h-11 shrink-0"
+              >
+                Download ZIP
+              </PrepackagedDownloadButton>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/data/releases.ts
+++ b/frontend/src/data/releases.ts
@@ -75,6 +75,7 @@ export interface PublicReleaseBase {
   typeLabel: string;
   status: "available" | "coming-soon";
   summary: string;
+  prepackagedPackageSlugs?: string[];
   links: {
     artifact: string;
   };
@@ -555,6 +556,11 @@ export const dteAerialRelease: DteAerialRelease = {
   status: "available",
   summary:
     "A curated aerial benchmark for tree cover and mortality segmentation, built from high-resolution drone and aircraft orthophotos with expert masks.",
+  prepackagedPackageSlugs: [
+    "tree-cover-aerial-global",
+    "standing-deadwood-aerial-global-conservative",
+    "image-tiles-1024-global-aerial-sampled-20-random",
+  ],
   links: {
     artifact: "#dataset-download-placeholder",
   },

--- a/frontend/src/hooks/usePrepackagedDatasets.ts
+++ b/frontend/src/hooks/usePrepackagedDatasets.ts
@@ -12,9 +12,14 @@ export function usePrepackagedDatasets() {
   });
 }
 
-export function useCreatePrepackagedDownloadGrant(token?: string) {
+interface CreatePrepackagedDownloadGrantVariables {
+  versionId: number;
+  token: string;
+}
+
+export function useCreatePrepackagedDownloadGrant() {
   return useMutation({
-    mutationFn: (versionId: number) =>
-      createPrepackagedDownloadGrant(versionId, token as string),
+    mutationFn: ({ versionId, token }: CreatePrepackagedDownloadGrantVariables) =>
+      createPrepackagedDownloadGrant(versionId, token),
   });
 }

--- a/frontend/src/pages/DteAerialRelease.tsx
+++ b/frontend/src/pages/DteAerialRelease.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowLeftOutlined,
-  DatabaseOutlined,
   DownloadOutlined,
   GlobalOutlined,
 } from "@ant-design/icons";
@@ -10,6 +9,7 @@ import { useNavigate } from "react-router-dom";
 
 import { DteAerialReleaseGallery } from "../components/Releases/DteAerialReleaseGallery";
 import { DteAerialReleaseSiteMap } from "../components/Releases/DteAerialReleaseSiteMap";
+import { PrepackagedReleaseDownloads } from "../components/Releases/PrepackagedReleaseDownloads";
 import {
   getReleaseStats,
   getCoarseBiomeGroup,
@@ -24,6 +24,8 @@ interface DteAerialReleaseProps {
 export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
   const navigate = useNavigate();
   const benchmark = release.dteAerial;
+  const prepackagedPackageSlugs = release.prepackagedPackageSlugs ?? [];
+  const hasPrepackagedDownloads = prepackagedPackageSlugs.length > 0;
   const { adminInfoByDatasetId, isAdminInfoLoading } =
     useDteAerialDatasetAdminInfo(release);
   const heroTagline = release.title.startsWith(`${release.name}: `)
@@ -31,6 +33,11 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
     : release.title;
 
   const releaseStats = useMemo(() => getReleaseStats(release), [release]);
+  const scrollToDownloads = () => {
+    document
+      .getElementById("dataset-download-placeholder")
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   const biomeCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -74,13 +81,17 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
                 type="primary"
                 size="large"
                 icon={<DownloadOutlined />}
-                disabled
+                disabled={!hasPrepackagedDownloads}
+                onClick={scrollToDownloads}
                 className="min-h-11"
               >
-                Download dataset
+                View downloads
               </Button>
-              <Tag className="m-0" color="warning">
-                Coming soon
+              <Tag
+                className="m-0"
+                color={hasPrepackagedDownloads ? "green" : "warning"}
+              >
+                {hasPrepackagedDownloads ? "Available" : "Coming soon"}
               </Tag>
             </div>
           </div>
@@ -162,22 +173,15 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
               Dataset package
             </h2>
             <p className="mt-3 text-base leading-7 text-gray-600">
-              The gallery above is the live preview of the dataset. The download
-              button is disabled until the Hugging Face package is available.
+              The gallery above is the live preview of the dataset. ZIP
+              artifacts are issued as short-lived signed links after sign-in so
+              downloads can be audited.
             </p>
-            <div className="mt-6 flex flex-wrap items-center gap-3">
-              <Button
-                type="primary"
-                size="large"
-                icon={<DatabaseOutlined />}
-                disabled
-                className="min-h-11"
-              >
-                Download dataset
-              </Button>
-              <Tag className="m-0" color="warning">
-                Coming soon
-              </Tag>
+            <div className="mt-6">
+              <PrepackagedReleaseDownloads
+                packageSlugs={prepackagedPackageSlugs}
+                returnTo={`/releases/${release.slug}`}
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -5,18 +5,14 @@ import {
   ExportOutlined,
   FileOutlined,
   LinkOutlined,
-  LoginOutlined,
 } from "@ant-design/icons";
-import { Alert, Button, Empty, Skeleton, message } from "antd";
+import { Alert, Button, Empty, Skeleton } from "antd";
 import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { PrepackagedDownloadButton } from "../components/Releases/PrepackagedDownloadButton";
 import { ReleasePreviewStrip } from "../components/Releases/ReleasePreviewStrip";
-import {
-  useCreatePrepackagedDownloadGrant,
-  usePrepackagedDatasets,
-} from "../hooks/usePrepackagedDatasets";
-import { useAuth } from "../hooks/useAuthProvider";
+import { usePrepackagedDatasets } from "../hooks/usePrepackagedDatasets";
 import { getPrepackagedDatasetPreviewTiles } from "../utils/prepackagedDatasetPreviews";
 import {
   formatPrepackagedBytes,
@@ -48,7 +44,10 @@ function buildSourceCodeUrl(
   const safeRepositoryUrl = getSafeHttpUrl(repositoryUrl);
   if (!safeRepositoryUrl || !sourceFilePath || !sourceCommit) return null;
 
-  const encodedPath = sourceFilePath.split("/").map(encodeURIComponent).join("/");
+  const encodedPath = sourceFilePath
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
   return `${safeRepositoryUrl}/blob/${encodeURIComponent(sourceCommit)}/${encodedPath}`;
 }
 
@@ -59,14 +58,8 @@ function getShortCommit(sourceCommit: string | null) {
 export default function PrepackagedDatasetRelease() {
   const { slug } = useParams();
   const navigate = useNavigate();
-  const [messageApi, contextHolder] = message.useMessage();
-  const { session } = useAuth();
-  const token = session?.access_token;
   const { data, isLoading, error } = usePrepackagedDatasets();
-  const grantMutation = useCreatePrepackagedDownloadGrant(token);
   const returnTo = `/releases/${slug ?? ""}`;
-  const handleSignIn = () =>
-    navigate(`/sign-in?returnTo=${encodeURIComponent(returnTo)}`);
 
   const datasetPackage = useMemo(
     () => data?.find((candidate) => candidate.slug === slug),
@@ -130,37 +123,17 @@ export default function PrepackagedDatasetRelease() {
     : null;
   const hasReproducibilityMetadata = Boolean(
     datasetPackage?.technical_description ||
-      sourceCodeUrl ||
-      safeRepositoryUrl ||
-      latestVersion?.source_package_version ||
-      shortSourceCommit,
+    sourceCodeUrl ||
+    safeRepositoryUrl ||
+    latestVersion?.source_package_version ||
+    shortSourceCommit,
   );
-
-  const handleDownload = async (versionId: number) => {
-    if (!token) {
-      handleSignIn();
-      return;
-    }
-
-    try {
-      const grant = await grantMutation.mutateAsync(versionId);
-      window.location.assign(grant.download_url);
-    } catch (downloadError) {
-      const errorMessage =
-        downloadError instanceof Error
-          ? downloadError.message
-          : "Could not start the package download.";
-      void messageApi.error(errorMessage);
-    }
-  };
 
   return (
     <main
       className="min-h-screen bg-[#f8faf9] pt-20 md:pt-24"
       data-testid="release-detail-page"
     >
-      {contextHolder}
-
       <section className="border-b border-gray-200/80 bg-white">
         <div className="mx-auto max-w-7xl px-4 pt-8 md:px-8">
           <Button
@@ -331,9 +304,7 @@ export default function PrepackagedDatasetRelease() {
                             rel="noreferrer"
                             className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
                           >
-                            <span className="truncate">
-                              Open repository
-                            </span>
+                            <span className="truncate">Open repository</span>
                             <ExportOutlined className="shrink-0 text-xs" />
                           </a>
                         </dd>
@@ -351,9 +322,7 @@ export default function PrepackagedDatasetRelease() {
                             rel="noreferrer"
                             className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
                           >
-                            <span className="truncate">
-                              Open source file
-                            </span>
+                            <span className="truncate">Open source file</span>
                             <ExportOutlined className="shrink-0 text-xs" />
                           </a>
                         </dd>
@@ -402,30 +371,14 @@ export default function PrepackagedDatasetRelease() {
                   </p>
                 </div>
                 <div className="flex shrink-0 flex-wrap gap-3">
-                  <Button
-                    type="primary"
-                    size="large"
+                  <PrepackagedDownloadButton
+                    versionId={latestVersion.id}
+                    returnTo={returnTo}
                     icon={<DatabaseOutlined />}
-                    loading={
-                      grantMutation.isPending &&
-                      grantMutation.variables === latestVersion.id
-                    }
-                    onClick={() => handleDownload(latestVersion.id)}
-                    disabled={!token}
                     className="min-h-11"
                   >
                     Download ZIP
-                  </Button>
-                  {!token && (
-                    <Button
-                      size="large"
-                      icon={<LoginOutlined />}
-                      onClick={handleSignIn}
-                      className="min-h-11"
-                    >
-                      Sign in
-                    </Button>
-                  )}
+                  </PrepackagedDownloadButton>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the DTE aerial disabled download placeholder with prepackaged ZIP downloads backed by signed grants
- share the signed download button with existing prepackaged package release pages
- expose missing configured package slugs instead of silently hiding catalog drift

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend test -- --run
- npm --prefix frontend run build
- scripts/lint-ast-grep.sh
- external autoreview: codex + claude:opus, 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added prepackaged dataset downloads with organized grid display showing package details, versions, and file sizes
* Implemented authentication-aware download button that redirects unsigned-in users to sign-in page
* Added "View downloads" button for quick navigation to release artifacts section

**Tests**
* Updated download button visibility tests to support additional button text variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->