### PR TITLE
feat(frontend): add prepackaged download commands

### DIFF
--- a/frontend/src/components/Releases/PrepackagedDownloadButton.tsx
+++ b/frontend/src/components/Releases/PrepackagedDownloadButton.tsx
@@ -1,6 +1,19 @@
-import { DownloadOutlined } from "@ant-design/icons";
-import { Button, message, type ButtonProps } from "antd";
-import type { ReactNode } from "react";
+import {
+  CopyOutlined,
+  DownOutlined,
+  DownloadOutlined,
+} from "@ant-design/icons";
+import {
+  Button,
+  Dropdown,
+  Input,
+  message,
+  Modal,
+  Space,
+  type ButtonProps,
+  type MenuProps,
+} from "antd";
+import { useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../hooks/useAuthProvider";
@@ -9,6 +22,7 @@ import { useCreatePrepackagedDownloadGrant } from "../../hooks/usePrepackagedDat
 interface PrepackagedDownloadButtonProps {
   versionId: number | null | undefined;
   returnTo: string;
+  fileName?: string | null;
   children?: ReactNode;
   className?: string;
   disabled?: boolean;
@@ -17,9 +31,12 @@ interface PrepackagedDownloadButtonProps {
   type?: ButtonProps["type"];
 }
 
+type DownloadCopyMode = "wget" | "curl" | "url";
+
 export function PrepackagedDownloadButton({
   versionId,
   returnTo,
+  fileName,
   children = "Download ZIP",
   className,
   disabled = false,
@@ -29,23 +46,34 @@ export function PrepackagedDownloadButton({
 }: PrepackagedDownloadButtonProps) {
   const navigate = useNavigate();
   const [messageApi, contextHolder] = message.useMessage();
+  const [manualCopyText, setManualCopyText] = useState<string | null>(null);
+  const [manualCopyTitle, setManualCopyTitle] = useState("Copy download command");
+  const [manualCopyDescription, setManualCopyDescription] = useState(
+    "Copy this command into your terminal.",
+  );
   const { session } = useAuth();
   const token = session?.access_token;
   const grantMutation = useCreatePrepackagedDownloadGrant();
 
-  const handleDownload = async () => {
+  const createGrant = async () => {
     if (!versionId) {
       void messageApi.warning("This package is not available yet.");
-      return;
+      return null;
     }
 
     if (!token) {
       navigate(`/sign-in?returnTo=${encodeURIComponent(returnTo)}`);
-      return;
+      return null;
     }
 
+    return grantMutation.mutateAsync({ versionId, token });
+  };
+
+  const handleDownload = async () => {
     try {
-      const grant = await grantMutation.mutateAsync({ versionId, token });
+      const grant = await createGrant();
+      if (!grant) return;
+
       window.location.assign(grant.download_url);
     } catch (downloadError) {
       const errorMessage =
@@ -56,20 +84,131 @@ export function PrepackagedDownloadButton({
     }
   };
 
+  const shellQuote = (value: string) => `'${value.replace(/'/g, "'\"'\"'")}'`;
+
+  const getExpiryMessage = (expiresAt: string | null | undefined) => {
+    if (!expiresAt) return "Signed link expires automatically.";
+
+    const expiresAtDate = new Date(expiresAt);
+    if (Number.isNaN(expiresAtDate.getTime())) {
+      return "Signed link expires automatically.";
+    }
+
+    return `Signed link expires ${new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(expiresAtDate)}.`;
+  };
+
+  const buildDownloadText = (
+    copyMode: DownloadCopyMode,
+    downloadFileName: string,
+    downloadUrl: string,
+  ) =>
+    copyMode === "wget"
+      ? `wget -c -O ${shellQuote(downloadFileName)} ${shellQuote(downloadUrl)}`
+      : copyMode === "curl"
+        ? `curl --fail -L -C - -o ${shellQuote(downloadFileName)} ${shellQuote(downloadUrl)}`
+        : downloadUrl;
+
+  const copyDownloadText = async (copyMode: DownloadCopyMode, successPrefix: string) => {
+    try {
+      const grant = await createGrant();
+      if (!grant) return;
+
+      const downloadFileName = fileName || `prepackaged-dataset-${versionId}.zip`;
+      const text = buildDownloadText(copyMode, downloadFileName, grant.download_url);
+      const expiryMessage = getExpiryMessage(grant.expires_at);
+
+      try {
+        await navigator.clipboard.writeText(text);
+        void messageApi.success(`${successPrefix} ${expiryMessage}`);
+      } catch {
+        setManualCopyTitle(
+          copyMode === "url"
+            ? "Copy signed URL"
+            : `Copy ${copyMode === "wget" ? "wget" : "curl"} command`,
+        );
+        setManualCopyDescription(expiryMessage);
+        setManualCopyText(text);
+        void messageApi.warning(
+          "Clipboard access was blocked. Copy from the dialog instead.",
+        );
+      }
+    } catch (downloadError) {
+      const errorMessage =
+        downloadError instanceof Error
+          ? downloadError.message
+          : "Could not copy the download command.";
+      void messageApi.error(errorMessage);
+    }
+  };
+
+  const downloadCommandItems: MenuProps["items"] = [
+    {
+      key: "wget",
+      icon: <CopyOutlined />,
+      label: "Copy wget command",
+      onClick: () => void copyDownloadText("wget", "wget command copied."),
+    },
+    {
+      key: "curl",
+      icon: <CopyOutlined />,
+      label: "Copy curl command",
+      onClick: () => void copyDownloadText("curl", "curl command copied."),
+    },
+    {
+      key: "url",
+      icon: <CopyOutlined />,
+      label: "Copy signed URL",
+      onClick: () => void copyDownloadText("url", "Signed URL copied."),
+    },
+  ];
+
   return (
     <>
       {contextHolder}
-      <Button
-        type={type}
-        size={size}
-        icon={icon}
-        loading={grantMutation.isPending}
-        onClick={handleDownload}
-        disabled={disabled || !versionId}
-        className={className}
+      <Space.Compact className={className}>
+        <Button
+          type={type}
+          size={size}
+          icon={icon}
+          loading={grantMutation.isPending}
+          onClick={handleDownload}
+          disabled={disabled || !versionId}
+        >
+          {token ? children : "Sign in to download"}
+        </Button>
+        <Dropdown
+          menu={{ items: downloadCommandItems }}
+          trigger={["click"]}
+          placement="bottomRight"
+          disabled={disabled || !versionId || grantMutation.isPending}
+        >
+          <Button
+            type={type}
+            size={size}
+            icon={<DownOutlined />}
+            aria-label="More download options"
+            disabled={disabled || !versionId}
+            loading={grantMutation.isPending}
+          />
+        </Dropdown>
+      </Space.Compact>
+      <Modal
+        title={manualCopyTitle}
+        open={Boolean(manualCopyText)}
+        footer={null}
+        onCancel={() => setManualCopyText(null)}
       >
-        {token ? children : "Sign in to download"}
-      </Button>
+        <p>{manualCopyDescription}</p>
+        <Input.TextArea
+          value={manualCopyText ?? ""}
+          readOnly
+          autoSize={{ minRows: 3, maxRows: 8 }}
+          onFocus={(event) => event.currentTarget.select()}
+        />
+      </Modal>
     </>
   );
 }

--- a/frontend/src/components/Releases/PrepackagedReleaseDownloads.tsx
+++ b/frontend/src/components/Releases/PrepackagedReleaseDownloads.tsx
@@ -123,6 +123,7 @@ export function PrepackagedReleaseDownloads({
 
               <PrepackagedDownloadButton
                 versionId={latestVersion?.id}
+                fileName={latestVersion?.file_name}
                 returnTo={returnTo}
                 icon={<DatabaseOutlined />}
                 className="min-h-11 shrink-0"

--- a/frontend/src/pages/DteAerialRelease.tsx
+++ b/frontend/src/pages/DteAerialRelease.tsx
@@ -175,7 +175,10 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
             <p className="mt-3 text-base leading-7 text-gray-600">
               The gallery above is the live preview of the dataset. ZIP
               artifacts are issued as short-lived signed links after sign-in so
-              downloads can be audited.
+              downloads can be audited. Use the main button for a browser
+              download, or open the menu next to it to copy wget/curl commands
+              for server-side downloads. Copied commands include expiring signed
+              links; regenerate a command if one has expired.
             </p>
             <div className="mt-6">
               <PrepackagedReleaseDownloads

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -367,12 +367,17 @@ export default function PrepackagedDatasetRelease() {
                   </h2>
                   <p className="mt-3 max-w-2xl text-base leading-7 text-gray-600">
                     Downloads use short-lived links so access can be limited and
-                    audited without exposing the storage server directly.
+                    audited without exposing the storage server directly. Use
+                    the main button for a browser download, or open the menu
+                    next to it to copy wget/curl commands for server-side
+                    downloads. Copied commands include expiring signed links;
+                    regenerate a command if one has expired.
                   </p>
                 </div>
                 <div className="flex shrink-0 flex-wrap gap-3">
                   <PrepackagedDownloadButton
                     versionId={latestVersion.id}
+                    fileName={latestVersion.file_name}
                     returnTo={returnTo}
                     icon={<DatabaseOutlined />}
                     className="min-h-11"


### PR DESCRIPTION
## Summary
- add a split download control for prepackaged release packages
- keep the direct browser download action and add copy actions for wget, curl, and the signed URL
- pass each package ZIP filename into the shared download button so copied commands save with the expected file name

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend test -- --run
- npm --prefix frontend run build
- scripts/lint-ast-grep.sh
- local browser smoke against /releases/dte-aerial-bench confirmed the three package cards and download options render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "More download options" dropdown to download buttons, enabling users to copy wget commands, curl commands, or signed download URLs to clipboard.

* **Improvements**
  * Enhanced download flow with improved error messaging and sign-in handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->