### PR TITLE
perf(frontend): speed up homepage dataset loading

### DIFF
--- a/frontend/e2e/data-factory-readonly.spec.ts
+++ b/frontend/e2e/data-factory-readonly.spec.ts
@@ -32,6 +32,76 @@ const expectReleasesReady = async (page: Page) => {
 };
 
 test.describe("DeadTrees Data Factory read-only smoke", () => {
+  test("homepage uses lightweight read models for stats and deferred teasers", async ({
+    page,
+  }) => {
+    const restRequests: string[] = [];
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (url.includes("/rest/v1/")) {
+        restRequests.push(decodeURIComponent(url));
+      }
+    });
+
+    const statsResponsePromise = page
+      .waitForResponse((response) =>
+        response.url().includes("/rest/v1/public_home_stats"),
+      )
+      .catch(() => null);
+
+    await page.goto("/");
+
+    const statsResponse = await statsResponsePromise;
+    test.skip(
+      statsResponse?.status() === 404,
+      "homepage read-model migration has not been deployed to this backend yet",
+    );
+
+    expect(statsResponse, "home stats read-model request was not issued").not.toBeNull();
+    expect(statsResponse?.ok(), "home stats read-model request failed").toBe(true);
+
+    await expect(page.getByTestId("home-page")).toBeVisible();
+    await expect(page.getByTestId("home-stat-datasets-value")).not.toHaveText(
+      "...",
+      { timeout: 20_000 },
+    );
+    await expect(page.getByTestId("home-stat-countries-value")).not.toHaveText(
+      "...",
+      { timeout: 20_000 },
+    );
+    await expect(
+      page.getByTestId("home-stat-contributors-value"),
+    ).not.toHaveText("...", { timeout: 20_000 });
+
+    expect(
+      restRequests.some((url) => url.includes("/rest/v1/public_home_stats")),
+    ).toBe(true);
+    expect(
+      restRequests.some(
+        (url) =>
+          url.includes("/rest/v1/v2_full_dataset_view_public") &&
+          url.includes("select=*"),
+      ),
+    ).toBe(false);
+    expect(
+      restRequests.some((url) =>
+        url.includes("/rest/v1/public_home_dataset_teasers"),
+      ),
+    ).toBe(false);
+
+    await page.getByTestId("home-data-gallery-anchor").scrollIntoViewIfNeeded();
+    await expect
+      .poll(
+        () =>
+          restRequests.some((url) =>
+            url.includes("/rest/v1/public_home_dataset_teasers"),
+          ),
+        { timeout: 20_000 },
+      )
+      .toBe(true);
+  });
+
   test("public info and auth routes render their base read-only states", async ({
     page,
   }) => {

--- a/frontend/src/components/Home/DataGallery.tsx
+++ b/frontend/src/components/Home/DataGallery.tsx
@@ -3,35 +3,15 @@ import { useMemo, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { LeftOutlined, RightOutlined } from "@ant-design/icons";
 import type { CarouselRef } from "antd/es/carousel";
-import { useData } from "../../hooks/useDataProvider";
 import { Settings } from "../../config";
 import countryList from "../../utils/countryList";
 import { useDatasetDetailsMap } from "../../hooks/useDatasetDetailsMapProvider";
-import parseBBox from "../../utils/parseBBox";
-import { isDatasetViewable } from "../../utils/datasetVisibility";
-import type { IDataset } from "../../types/dataset";
-
-// Convert a geographic bounding box to area in hectares
-const calculateAreaFromBBox = (bboxArray: number[]): number => {
-  if (!bboxArray || bboxArray.length !== 4) return 0;
-
-  const [minLon, minLat, maxLon, maxLat] = bboxArray;
-
-  // Approximate conversion (this is a simplification that works reasonably well for small areas)
-  // 1 degree of latitude is approximately 111.32 km
-  // 1 degree of longitude varies with latitude: 111.32 * cos(latitude in radians)
-  const latDistance = (maxLat - minLat) * 111.32; // in km
-
-  // Average latitude for longitude calculation
-  const avgLat = (minLat + maxLat) / 2;
-  const lonDistance = (maxLon - minLon) * 111.32 * Math.cos(avgLat * (Math.PI / 180)); // in km
-
-  // Area in square kilometers
-  const areaKm2 = latDistance * lonDistance;
-
-  // Convert to hectares (1 km² = 100 hectares)
-  return areaKm2 * 100;
-};
+import {
+  useHomeDatasetTeasers,
+  useHomeStats,
+  type IHomeDatasetTeaser,
+  type IHomeStats,
+} from "../../hooks/useHomeReadModels";
 
 const Stat = ({ title, value, unit }: { title: string; value: string; unit: string }) => {
   return (
@@ -45,132 +25,69 @@ const Stat = ({ title, value, unit }: { title: string; value: string; unit: stri
   );
 };
 
-const getDatasetLocationLabel = (item: IDataset): string => {
+const getDatasetLocationLabel = (item: IHomeDatasetTeaser): string => {
   const place = item.admin_level_3 || item.admin_level_2;
 
   if (place) {
-    const country = item.admin_level_1 ? `, ${countryList[item.admin_level_1 as keyof typeof countryList]}` : "";
-    return `${place.slice(0, 10)}${place.length > 15 ? "..." : ""}${country}`;
+    const countryName = item.admin_level_1
+      ? countryList[item.admin_level_1 as keyof typeof countryList] ?? item.admin_level_1
+      : "";
+    const country = countryName ? `, ${countryName}` : "";
+    const truncatedPlace = place.length > 10 ? `${place.slice(0, 10)}...` : place;
+    return `${truncatedPlace}${country}`;
   }
 
-  return item.admin_level_1 ? countryList[item.admin_level_1 as keyof typeof countryList] : "";
+  return item.admin_level_1
+    ? countryList[item.admin_level_1 as keyof typeof countryList] ?? item.admin_level_1
+    : "";
 };
 
-const Stats = ({ datasets }: { datasets: IDataset[] }) => {
-  const stats = useMemo(() => {
-    if (!datasets.length) return { orthophotos: 0, area: 0, countries: 0, fileSize: 0 };
+const getDatasetDateLabel = (item: IHomeDatasetTeaser): string => {
+  if (!item.aquisition_year) return "Unknown date";
 
-    // Calculate orthophoto count
-    const orthophotos = datasets.length;
+  return new Date(
+    item.aquisition_year,
+    item.aquisition_month ? item.aquisition_month - 1 : 0,
+    item.aquisition_day ? item.aquisition_day : 1,
+  ).toLocaleDateString("en-GB", {
+    year: "numeric",
+    ...(item.aquisition_month && { month: "numeric" }),
+    ...(item.aquisition_day && { day: "numeric" }),
+  });
+};
 
-    // Calculate total area from bounding boxes
-    let totalArea = 0;
-    datasets.forEach((item) => {
-      if (item.bbox) {
-        const parsedBBox = parseBBox(item.bbox);
-        if (parsedBBox) {
-          totalArea += calculateAreaFromBBox(parsedBBox);
-        }
-      }
-    });
+type StatsProps = { stats: IHomeStats | null | undefined };
 
-    // Unique countries
-    const countries = new Set<string>();
-    datasets.forEach((item) => {
-      if (item.admin_level_1) {
-        countries.add(item.admin_level_1);
-      }
-    });
-
-    // Total file size in TB
-    const totalFileSizeBytes = datasets.reduce((sum, item) => {
-      // Convert from MB to TB (1 TB = 1,048,576 MB)
-      return sum + (item.ortho_file_size || 0);
-    }, 0);
-
-    // Convert MB to TB
-    const totalFileSizeTB = totalFileSizeBytes / 1_048_576;
-
-    return {
-      orthophotos,
-      area: totalArea,
-      countries: countries.size,
-      fileSize: totalFileSizeTB,
-    };
-  }, [datasets]);
-
+const Stats = ({ stats }: StatsProps) => {
   return (
     <div className="mt-4 flex flex-col justify-center rounded-2xl bg-white/50 py-6 md:mt-8">
       <div className="grid grid-cols-2 gap-y-8 md:flex md:justify-around md:gap-y-0">
-        <Stat title="Orthophotos" value={stats.orthophotos.toLocaleString()} unit="" />
-        <Stat title="Area Covered" value={Math.round(stats.area).toLocaleString()} unit="ha" />
-        <Stat title="Countries" value={stats.countries.toString()} unit="" />
-        <Stat title="Data Size" value={stats.fileSize.toFixed(2)} unit="TB" />
+        <Stat title="Orthophotos" value={(stats?.dataset_count ?? 0).toLocaleString()} unit="" />
+        <Stat title="Area Covered" value={Math.round(stats?.area_covered_ha ?? 0).toLocaleString()} unit="ha" />
+        <Stat title="Countries" value={(stats?.country_count ?? 0).toString()} unit="" />
+        <Stat title="Data Size" value={(stats?.data_size_tb ?? 0).toFixed(2)} unit="TB" />
       </div>
     </div>
   );
 };
 
 const DataGallery = ({ hideHeader = false }: { hideHeader?: boolean }) => {
-  const { data } = useData();
+  const { data: galleryData = [], isLoading } = useHomeDatasetTeasers();
+  const { data: stats } = useHomeStats();
   const carouselRef = useRef<CarouselRef | null>(null);
   const navigate = useNavigate();
   const { setNavigationSource } = useDatasetDetailsMap();
 
-  const viewableData = useMemo(() => {
-    if (!data) return [];
-    return data.filter((item) => isDatasetViewable(item));
-  }, [data]);
+  const visibleGalleryData = useMemo(() => {
+    if (!galleryData.length) return [];
 
-  const sortedUniqueData = useMemo(() => {
-    if (!viewableData.length) return [];
-
-    const sorted = [...viewableData].sort((a, b) => b.id - a.id);
-
-    // Debug: Check initial data
-    // console.log("Initial data count:", sorted.length);
-
-    // First filter for required fields using centralized visibility check
-    const filtered = sorted.filter((item) => {
-      // Carousel-specific requirements (authors and thumbnail for display)
+    return galleryData.filter((item) => {
       if (!item.authors || !Array.isArray(item.authors) || !item.thumbnail_path) {
         return false;
       }
       return true;
     });
-
-    // Debug: Check after required fields filter
-    // console.log("After required fields filter:", filtered.length);
-    // console.log(
-    //   "Sample authors:",
-    //   filtered.slice(0, 5).map((item) => item.authors),
-    // );
-
-    // Create a map to store one entry per author
-    const authorMap = new Map<string, IDataset>();
-
-    // Take only the first entry for each author in the authors array
-    filtered.forEach((item) => {
-      item.authors?.forEach((author: string) => {
-        const authorKey = author.trim().toLowerCase();
-        if (!authorMap.has(authorKey)) {
-          authorMap.set(authorKey, item);
-        }
-      });
-    });
-
-    // Convert map values back to array and remove duplicates
-    const oneImagePerAuthor = Array.from(new Set<IDataset>(authorMap.values()));
-
-    // Debug: Final result
-    // console.log("Final unique entries:", oneImagePerAuthor.length);
-    // console.log(
-    //   "Final unique authors:",
-    //   oneImagePerAuthor.map((item) => item.authors),
-    // );
-
-    return oneImagePerAuthor;
-  }, [viewableData]);
+  }, [galleryData]);
 
   const onClickHandler = useCallback((id: number) => {
     setNavigationSource("dataset");
@@ -234,63 +151,63 @@ const DataGallery = ({ hideHeader = false }: { hideHeader?: boolean }) => {
               shape="circle"
             />
 
-            <Carousel ref={carouselRef} {...settings}>
-              {sortedUniqueData.map((item) => (
-                <div key={item.id} className="px-2 py-4">
-                  <div
-                    className="cursor-pointer rounded-lg bg-white shadow-md transition-shadow duration-200 hover:shadow-lg"
-                    onClick={() => onClickHandler(item.id)}
-                  >
-                    <div className="relative m-2 mt-2 overflow-hidden rounded-lg">
-                      <img
-                        src={
-                          item.thumbnail_path ? Settings.THUMBNAIL_URL + item.thumbnail_path : "/assets/tree-icon.png"
-                        }
-                        className="h-36 w-48 scale-150 rounded-t-lg object-cover"
-                        loading="lazy"
-                        alt={`Dataset ${item.id}`}
-                      />
-                    </div>
-                    <div className="p-4">
-                      <div className="mb-2 flex items-baseline justify-between">
-                        <Tooltip
-                          title={
-                            item.admin_level_1
-                              ? `${item.admin_level_3 || item.admin_level_2 || ""}${item.admin_level_1 ? `, ${item.admin_level_1}` : ""}`
-                              : ""
+            {isLoading ? (
+              <div
+                className="h-64 animate-pulse rounded-lg bg-white/70"
+                data-testid="home-data-gallery-loading"
+              />
+            ) : (
+              <Carousel ref={carouselRef} {...settings} data-testid="home-data-gallery">
+                {visibleGalleryData.map((item) => (
+                  <div key={item.id} className="px-2 py-4">
+                    <button
+                      className="block w-full cursor-pointer rounded-lg border-0 bg-white p-0 text-left shadow-md transition-shadow duration-200 hover:shadow-lg"
+                      onClick={() => onClickHandler(item.id)}
+                      type="button"
+                    >
+                      <div className="relative m-2 mt-2 overflow-hidden rounded-lg">
+                        <img
+                          src={
+                            item.thumbnail_path ? Settings.THUMBNAIL_URL + item.thumbnail_path : "/assets/tree-icon.png"
                           }
-                        >
-                          <span className="max-w-[70%] truncate font-semibold">
-                            {getDatasetLocationLabel(item)}
-                          </span>
-                        </Tooltip>
-                        <span className="text-xs text-gray-500">
-                          {new Date(
-                            parseInt(item.aquisition_year),
-                            item.aquisition_month ? parseInt(item.aquisition_month) - 1 : 0,
-                            item.aquisition_day ? parseInt(item.aquisition_day) : 1,
-                          ).toLocaleDateString("en-GB", {
-                            year: "numeric",
-                            ...(item.aquisition_month && { month: "numeric" }),
-                            ...(item.aquisition_day && { day: "numeric" }),
-                          })}
-                        </span>
+                          className="h-36 w-48 scale-150 rounded-t-lg object-cover"
+                          loading="lazy"
+                          alt={`Dataset ${item.id}`}
+                        />
                       </div>
-                      <div className="flex items-center justify-between">
-                        <Tooltip title={item.authors}>
-                          <span className="max-w-[70%] truncate text-sm text-gray-600">
-                            {item.authors && item.authors.slice(0, 18) + (item.authors.length > 18 ? "..." : "")}
+                      <div className="p-4">
+                        <div className="mb-2 flex items-baseline justify-between">
+                          <Tooltip
+                            title={
+                              item.admin_level_1
+                                ? `${item.admin_level_3 || item.admin_level_2 || ""}${item.admin_level_1 ? `, ${item.admin_level_1}` : ""}`
+                                : ""
+                            }
+                          >
+                            <span className="max-w-[70%] truncate font-semibold">
+                              {getDatasetLocationLabel(item)}
+                            </span>
+                          </Tooltip>
+                          <span className="text-xs text-gray-500">
+                            {getDatasetDateLabel(item)}
                           </span>
-                        </Tooltip>
-                        <Tag>{item.platform}</Tag>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <Tooltip title={item.authors?.join(", ")}>
+                            <span className="max-w-[70%] truncate text-sm text-gray-600">
+                              {item.authors?.join(", ")}
+                            </span>
+                          </Tooltip>
+                          <Tag>{item.platform}</Tag>
+                        </div>
                       </div>
-                    </div>
+                    </button>
                   </div>
-                </div>
-              ))}
-            </Carousel>
+                ))}
+              </Carousel>
+            )}
           </div>
-          <Stats datasets={viewableData} />
+          <Stats stats={stats} />
         </div>
         {!hideHeader && (
           <div className="flex justify-center pt-8">

--- a/frontend/src/components/Home/Hero.tsx
+++ b/frontend/src/components/Home/Hero.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Button } from "antd";
 import {
   DatabaseOutlined,
@@ -8,9 +8,8 @@ import {
 import ReactPlayer from "react-player";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuthProvider";
-import { useData } from "../../hooks/useDataProvider";
+import { useHomeStats } from "../../hooks/useHomeReadModels";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
-import { isDatasetViewable } from "../../utils/datasetVisibility";
 import { useAnalytics } from "../../hooks/useAnalytics";
 import LogoBannerBand from "./LogoBanner";
 
@@ -89,8 +88,14 @@ const AnimatedStat = ({
   }, [value]);
 
   return (
-    <div className="flex items-baseline gap-1.5">
-      <span className="min-w-[3ch] text-xl font-bold tabular-nums text-[#FFB31C]">
+    <div
+      className="flex items-baseline gap-1.5"
+      data-testid={`home-stat-${label.toLowerCase()}`}
+    >
+      <span
+        className="min-w-[3ch] text-xl font-bold tabular-nums text-[#FFB31C]"
+        data-testid={`home-stat-${label.toLowerCase()}-value`}
+      >
         {displayValue === null ? "..." : displayValue.toLocaleString()}
       </span>
       <span className="text-sm font-medium text-gray-500">{label}</span>
@@ -101,22 +106,9 @@ const AnimatedStat = ({
 const Hero = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { data, authors } = useData();
+  const { data: stats } = useHomeStats();
   const { isMobile, runDesktopOnlyAction } = useDesktopOnlyFeature();
   const { track } = useAnalytics("home");
-
-  const stats = useMemo(() => {
-    if (!data) return null;
-    const valid = data.filter((item) => isDatasetViewable(item));
-    const countries = new Set(
-      valid.map((d) => d.admin_level_1).filter(Boolean),
-    );
-    return {
-      datasets: valid.length,
-      countries: countries.size,
-      contributors: authors?.length ?? 0,
-    };
-  }, [data, authors]);
 
   const handleContribute = useCallback(() => {
     track("landing_cta_clicked", {
@@ -226,13 +218,16 @@ const Hero = () => {
             )}
 
             <div className="mt-8 flex flex-wrap items-center justify-center gap-6 md:justify-start">
-              <AnimatedStat value={stats?.datasets ?? null} label="Datasets" />
               <AnimatedStat
-                value={stats?.countries ?? null}
+                value={stats?.dataset_count ?? null}
+                label="Datasets"
+              />
+              <AnimatedStat
+                value={stats?.country_count ?? null}
                 label="Countries"
               />
               <AnimatedStat
-                value={stats?.contributors ?? null}
+                value={stats?.contributor_count ?? null}
                 label="Contributors"
               />
             </div>

--- a/frontend/src/components/Home/HowItWorks.tsx
+++ b/frontend/src/components/Home/HowItWorks.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "antd";
 import { CloudUploadOutlined, GlobalOutlined, DatabaseOutlined } from "@ant-design/icons";
@@ -10,7 +10,19 @@ const UPLOAD_VIDEO_URL = "https://data2.deadtrees.earth/assets/v1/videos/upload.
 
 const MiniSatelliteMap = lazy(() => import("./MiniSatelliteMap"));
 
-const DeferredMiniSatelliteMap = () => {
+const DeferredUntilVisible = ({
+  children,
+  className,
+  placeholder,
+  rootMargin,
+  testId,
+}: {
+  children: ReactNode;
+  className?: string;
+  placeholder: ReactNode;
+  rootMargin: string;
+  testId?: string;
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -24,25 +36,46 @@ const DeferredMiniSatelliteMap = () => {
           observer.disconnect();
         }
       },
-      { rootMargin: "250px 0px" },
+      { rootMargin },
     );
 
     observer.observe(containerRef.current);
     return () => observer.disconnect();
-  }, [isVisible]);
+  }, [isVisible, rootMargin]);
 
   return (
-    <div ref={containerRef} className="h-full w-full">
-      {isVisible ? (
-        <Suspense fallback={<div className="h-full w-full animate-pulse bg-gray-100" />}>
-          <MiniSatelliteMap />
-        </Suspense>
-      ) : (
-        <div className="h-full w-full animate-pulse bg-gray-100" />
-      )}
+    <div ref={containerRef} className={className} data-testid={testId}>
+      {isVisible ? children : placeholder}
     </div>
   );
 };
+
+const DeferredMiniSatelliteMap = () => (
+  <DeferredUntilVisible
+    className="h-full w-full"
+    placeholder={<div className="h-full w-full animate-pulse bg-gray-100" />}
+    rootMargin="250px 0px"
+  >
+    <Suspense fallback={<div className="h-full w-full animate-pulse bg-gray-100" />}>
+      <MiniSatelliteMap />
+    </Suspense>
+  </DeferredUntilVisible>
+);
+
+const DeferredDataGallery = () => (
+  <DeferredUntilVisible
+    placeholder={
+      <div
+        className="h-80 w-full animate-pulse rounded-lg bg-white/70"
+        data-testid="home-data-gallery-placeholder"
+      />
+    }
+    rootMargin="300px 0px"
+    testId="home-data-gallery-anchor"
+  >
+    <DataGallery hideHeader={true} />
+  </DeferredUntilVisible>
+);
 
 const HowItWorks = () => {
   const navigate = useNavigate();
@@ -123,7 +156,7 @@ const HowItWorks = () => {
             </p>
           </div>
           <div className="-mx-4 md:mx-0 relative z-10">
-             <DataGallery hideHeader={true} />
+             <DeferredDataGallery />
           </div>
           <div className="flex justify-center">
             <Link to="/dataset">

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -49,6 +49,8 @@ export const Settings = {
 
   DATA_TABLE_FULL: "v2_full_dataset_view", // For admin/audit use (includes excluded datasets)
   DATA_TABLE_PUBLIC: "v2_full_dataset_view_public", // For public use (excludes excluded datasets)
+  HOME_STATS_VIEW: "public_home_stats",
+  HOME_DATASET_TEASERS_VIEW: "public_home_dataset_teasers",
   THUMBNAILS_TABLE: "v2_thumbnails",
   COLLABORATORS_TABLE: "collaborators",
   LABELS_TABLE: "v2_labels",

--- a/frontend/src/hooks/useDataProvider.tsx
+++ b/frontend/src/hooks/useDataProvider.tsx
@@ -38,9 +38,10 @@ const DataProvider = ({ children }: DataProviderProps) => {
   const location = useLocation();
   const shouldFetchDataContext = useMemo(() => {
     const pathname = location.pathname;
-    // Home/About and data-management pages rely on this context.
+    // About and data-management pages rely on this broad context.
+    // Home uses dedicated lightweight read models.
     // Skip broad prefetch for heavy detail/map routes like /dataset/:id.
-    if (pathname === "/" || pathname === "/about") return true;
+    if (pathname === "/about") return true;
     if (pathname.startsWith("/profile")) return true;
     if (pathname === "/dataset") return true;
     return false;

--- a/frontend/src/hooks/useHomeReadModels.ts
+++ b/frontend/src/hooks/useHomeReadModels.ts
@@ -1,0 +1,120 @@
+import { useQuery } from "@tanstack/react-query";
+import { Settings } from "../config";
+import { fixTextEncoding } from "../utils/textUtils";
+import { useAuth } from "./useAuthProvider";
+import { supabase } from "./useSupabase";
+
+export interface IHomeStats {
+  dataset_count: number;
+  country_count: number;
+  contributor_count: number;
+  area_covered_ha: number;
+  data_size_tb: number;
+  contributor_names: string[];
+}
+
+export interface IHomeDatasetTeaser {
+  id: number;
+  authors: string[] | null;
+  aquisition_year: number | null;
+  aquisition_month: number | null;
+  aquisition_day: number | null;
+  platform: string | null;
+  thumbnail_path: string | null;
+  admin_level_1: string | null;
+  admin_level_2: string | null;
+  admin_level_3: string | null;
+}
+
+const HOME_DATASET_TEASER_FIELDS = [
+  "id",
+  "authors",
+  "aquisition_year",
+  "aquisition_month",
+  "aquisition_day",
+  "platform",
+  "thumbnail_path",
+  "admin_level_1",
+  "admin_level_2",
+  "admin_level_3",
+].join(",");
+
+const HOME_STATS_FIELDS = [
+  "dataset_count",
+  "country_count",
+  "contributor_count",
+  "area_covered_ha",
+  "data_size_tb",
+  "contributor_names",
+].join(",");
+
+const normalizeContributorNames = (names: string[]) => {
+  const seen = new Set<string>();
+
+  return names
+    .map((author) => fixTextEncoding(author).replace(/\s+/g, " ").trim())
+    .filter((author) => {
+      if (!author || seen.has(author)) {
+        return false;
+      }
+
+      seen.add(author);
+      return true;
+    })
+    .sort((a, b) => a.localeCompare(b));
+};
+
+const normalizeHomeStats = (stats: IHomeStats | null): IHomeStats | null => {
+  if (!stats) return stats;
+
+  const contributor_names = normalizeContributorNames(stats.contributor_names || []);
+
+  return {
+    ...stats,
+    contributor_count: contributor_names.length,
+    contributor_names,
+  };
+};
+
+export function useHomeStats() {
+  const { status } = useAuth();
+
+  return useQuery({
+    queryKey: ["home-stats"],
+    enabled: status !== "checking",
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(Settings.HOME_STATS_VIEW)
+        .select(HOME_STATS_FIELDS)
+        .maybeSingle();
+
+      if (error) throw error;
+
+      return normalizeHomeStats(data as unknown as IHomeStats | null);
+    },
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}
+
+export function useHomeDatasetTeasers(limit = 64) {
+  const { status } = useAuth();
+
+  return useQuery({
+    queryKey: ["home-dataset-teasers", limit],
+    enabled: status !== "checking",
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(Settings.HOME_DATASET_TEASERS_VIEW)
+        .select(HOME_DATASET_TEASER_FIELDS)
+        .order("id", { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      return data as unknown as IHomeDatasetTeaser[];
+    },
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,8 +7,8 @@ import ReleasesSection from "../components/Home/Releases";
 import PlatformFeatures from "../components/Home/PlatformFeatures";
 import GetInContact from "../components/Home/GetInContact";
 
-import { useData } from "../hooks/useDataProvider";
 import { useAnalytics } from "../hooks/useAnalytics";
+import { useHomeStats } from "../hooks/useHomeReadModels";
 
 const FAQ_ITEM_STYLE = {
   border: "1px solid #e2e8f0",
@@ -20,14 +20,11 @@ const FAQ_ITEM_STYLE = {
 };
 
 const FAQ = () => {
-  const { authors } = useData();
+  const { data: stats } = useHomeStats();
   const { track } = useAnalytics("faq");
   const contributorNames = useMemo(
-    () =>
-      (authors || [])
-        .map((author) => author.label)
-        .sort((a, b) => a.localeCompare(b)),
-    [authors],
+    () => stats?.contributor_names || [],
+    [stats?.contributor_names],
   );
 
   const FAQItems = useMemo(

--- a/supabase/migrations/20260617112812_add_homepage_read_models.sql
+++ b/supabase/migrations/20260617112812_add_homepage_read_models.sql
@@ -1,0 +1,128 @@
+create or replace view "public"."public_home_dataset_base" as
+select
+  id,
+  authors,
+  aquisition_year::smallint as aquisition_year,
+  aquisition_month::smallint as aquisition_month,
+  aquisition_day::smallint as aquisition_day,
+  platform,
+  thumbnail_path,
+  admin_level_1,
+  admin_level_2,
+  admin_level_3,
+  ortho_file_size,
+  bbox
+from v2_full_dataset_view_public
+where is_cog_done = true
+  and is_thumbnail_done = true
+  and is_metadata_done = true
+  and admin_level_1 is not null
+  and (
+    has_error = false
+    or (is_deadwood_done = true and is_forest_cover_done = false)
+  );
+
+alter view public.public_home_dataset_base set (security_invoker = true);
+
+grant select on table "public"."public_home_dataset_base" to "anon";
+grant select on table "public"."public_home_dataset_base" to "authenticated";
+grant select on table "public"."public_home_dataset_base" to "service_role";
+
+create or replace view "public"."public_home_dataset_teasers" as
+with ranked_author_teasers as (
+  select
+    base.id,
+    base.authors,
+    base.aquisition_year,
+    base.aquisition_month,
+    base.aquisition_day,
+    base.platform,
+    base.thumbnail_path,
+    base.admin_level_1,
+    base.admin_level_2,
+    base.admin_level_3,
+    row_number() over (
+      partition by lower(nullif(trim(author), ''))
+      order by base.id desc
+    ) as author_rank
+  from public_home_dataset_base base
+  cross join lateral unnest(base.authors) as author
+  where nullif(trim(author), '') is not null
+    and base.thumbnail_path is not null
+)
+select distinct on (id)
+  id,
+  authors,
+  aquisition_year,
+  aquisition_month,
+  aquisition_day,
+  platform,
+  thumbnail_path,
+  admin_level_1,
+  admin_level_2,
+  admin_level_3
+from ranked_author_teasers
+where author_rank = 1
+order by id;
+
+alter view public.public_home_dataset_teasers set (security_invoker = true);
+
+grant select on table "public"."public_home_dataset_teasers" to "anon";
+grant select on table "public"."public_home_dataset_teasers" to "authenticated";
+grant select on table "public"."public_home_dataset_teasers" to "service_role";
+
+create or replace view "public"."public_home_stats" as
+with bbox_parts as (
+  select
+    id,
+    regexp_match(
+      bbox::text,
+      '^BOX\(([-+0-9.eE]+) ([-+0-9.eE]+),([-+0-9.eE]+) ([-+0-9.eE]+)\)$'
+    ) as coords
+  from public_home_dataset_base
+),
+contributors as (
+  select distinct nullif(trim(author), '') as name
+  from v2_full_dataset_view_public
+  cross join lateral unnest(authors) as author
+)
+select
+  (select count(*) from public_home_dataset_base)::bigint as dataset_count,
+  (select count(distinct admin_level_1) from public_home_dataset_base)::bigint as country_count,
+  (select count(*) from contributors where name is not null)::bigint as contributor_count,
+  coalesce(
+    (
+      select sum(
+        case
+          when bp.coords is null then 0
+          else abs(
+            (((bp.coords)[4]::double precision - (bp.coords)[2]::double precision) * 111.32)
+            * (((bp.coords)[3]::double precision - (bp.coords)[1]::double precision)
+              * 111.32
+              * cos(radians(((bp.coords)[2]::double precision + (bp.coords)[4]::double precision) / 2)))
+            * 100
+          )
+        end
+      )
+      from bbox_parts bp
+    ),
+    0
+  )::double precision as area_covered_ha,
+  (
+    select (coalesce(sum(ortho_file_size), 0) / 1048576.0)::double precision
+    from public_home_dataset_base
+  ) as data_size_tb,
+  coalesce(
+    (
+      select array_agg(name order by name)
+      from contributors
+      where name is not null
+    ),
+    array[]::text[]
+  ) as contributor_names;
+
+alter view public.public_home_stats set (security_invoker = true);
+
+grant select on table "public"."public_home_stats" to "anon";
+grant select on table "public"."public_home_stats" to "authenticated";
+grant select on table "public"."public_home_stats" to "service_role";


### PR DESCRIPTION
## What changed

- Added homepage-specific Supabase read models for public dataset stats and dataset teaser rows.
- Switched the home hero, FAQ, and gallery from the full public dataset payload to the lightweight read-model hooks.
- Stopped the global data provider from prefetching the full public dataset view on `/`.
- Deferred the below-fold homepage dataset gallery until it nears the viewport.
- Added a read-only Playwright smoke for the homepage read-model request pattern.

## Why

The homepage was pulling the full public dataset view during initial load just to render stats and teaser content. That made the first home visit pay for a large dataset payload before the user needed the archive.

## Validation

- `npm --prefix frontend ci`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- `git diff --check`
- `supabase migration up --local`
- Local anon SQL probe against `public_home_dataset_base`, `public_home_stats`, and `public_home_dataset_teasers`
- `npm --prefix frontend run test:e2e -- data-factory-readonly.spec.ts -g "homepage uses lightweight read models"` skipped as expected because the configured backend has not deployed the new read-model view yet

## Risk

The new home views derive from `v2_full_dataset_view_public`, so they preserve the existing public visibility contract while reducing the homepage response shape.

Structured autoreview could not run in this environment because the escalation reviewer blocked exporting the frozen review bundle to external review services, including Claude Code Opus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred loading for heavy UI sections on the homepage—they now load only when scrolling into view, improving initial page performance.

* **Bug Fixes**
  * Optimized homepage stats and data gallery to use lightweight, read-only data sources for faster queries and rendering.
  * Added loading skeleton UI while homepage data loads.

* **Tests**
  * Added homepage smoke test validating lightweight read models and request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->