### PR TITLE
refactor(database): remove stale status audit column

### DIFF
--- a/api/tests/db/test_data_publication.py
+++ b/api/tests/db/test_data_publication.py
@@ -1,5 +1,5 @@
 import pytest
-from shared.db import use_client
+from shared.db import use_client, use_service_client
 from shared.settings import settings
 from shared.models import LicenseEnum, PlatformEnum, DatasetAccessEnum
 
@@ -9,6 +9,7 @@ def test_datasets_for_publication(auth_token, test_user):
 	"""Create multiple test datasets for publication testing"""
 	dataset_ids = []
 	publication_ids = []
+	audit_rows = []
 
 	try:
 		with use_client(auth_token) as client:
@@ -68,7 +69,6 @@ def test_datasets_for_publication(auth_token, test_user):
 						'is_deadwood_done': True,
 						'is_forest_cover_done': True,
 						'is_metadata_done': True,
-						'is_audited': True,
 						'has_error': False,
 						'error_message': None,
 					}
@@ -86,7 +86,6 @@ def test_datasets_for_publication(auth_token, test_user):
 							'is_deadwood_done': False,
 							'is_forest_cover_done': False,
 							'is_metadata_done': True,
-							'is_audited': False,
 							'has_error': True,
 							'error_message': 'Error during COG processing',
 						}
@@ -102,12 +101,31 @@ def test_datasets_for_publication(auth_token, test_user):
 							'is_deadwood_done': False,
 							'is_forest_cover_done': False,
 							'is_metadata_done': True,
-							'is_audited': False,
 							'has_error': False,
 							'error_message': None,
 						}
 
 				client.table(settings.statuses_table).insert(status_data).execute()
+				if i % 2 == 0:
+					audit_rows.append(
+						{
+							'dataset_id': dataset_id,
+							'is_georeferenced': True,
+							'has_valid_acquisition_date': True,
+							'has_valid_phenology': True,
+							'deadwood_quality': 'sentinel_ok',
+							'forest_cover_quality': 'great',
+							'aoi_done': True,
+							'has_cog_issue': False,
+							'has_thumbnail_issue': False,
+							'audited_by': test_user,
+							'has_major_issue': False,
+							'final_assessment': 'ready',
+						}
+					)
+
+			with use_service_client() as service_client:
+				service_client.table('dataset_audit').insert(audit_rows).execute()
 
 			yield dataset_ids
 
@@ -134,11 +152,13 @@ def test_datasets_for_publication(auth_token, test_user):
 					client.table('data_publication').delete().eq('id', pub_id).execute()
 
 				# 3. Delete datasets
-				for dataset_id in dataset_ids:
-					# Delete all related tables explicitly in proper order
-					client.table(settings.metadata_table).delete().eq('dataset_id', dataset_id).execute()
-					client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
-					client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+				with use_service_client() as service_client:
+					for dataset_id in dataset_ids:
+						# Delete all related tables explicitly in proper order
+						service_client.table('dataset_audit').delete().eq('dataset_id', dataset_id).execute()
+						client.table(settings.metadata_table).delete().eq('dataset_id', dataset_id).execute()
+						client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+						client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
 
 				# 4. Clean up logs
 				client.table(settings.logs_table).delete().neq('id', 1).execute()

--- a/processor/tests/conftest.py
+++ b/processor/tests/conftest.py
@@ -138,7 +138,6 @@ def test_dataset_for_processing(auth_token, test_file, test_processor_user):
 				'is_deadwood_done': False,
 				'is_forest_cover_done': False,
 				'is_metadata_done': False,
-				'is_audited': False,
 				'has_error': False,
 			}
 			client.table(settings.statuses_table).insert(status_data).execute()

--- a/processor/tests/test_pipeline_integration.py
+++ b/processor/tests/test_pipeline_integration.py
@@ -90,7 +90,6 @@ def pipeline_test_dataset(auth_token, pipeline_test_zip, test_processor_user):
 				'is_deadwood_done': False,
 				'is_forest_cover_done': False,
 				'is_metadata_done': False,
-				'is_audited': False,
 				'has_error': False,
 			}
 			client.table(settings.statuses_table).insert(status_data).execute()

--- a/processor/tests/test_process_cog.py
+++ b/processor/tests/test_process_cog.py
@@ -106,7 +106,6 @@ def comprehensive_test_dataset(auth_token, small_test_file, test_processor_user)
 				'is_deadwood_done': False,
 				'is_forest_cover_done': False,
 				'is_metadata_done': False,
-				'is_audited': False,
 				'has_error': False,
 			}
 			client.table(settings.statuses_table).insert(status_data).execute()
@@ -234,7 +233,6 @@ def create_test_dataset(auth_token, test_file, test_processor_user):
 			'is_deadwood_done': False,
 			'is_forest_cover_done': False,
 			'is_metadata_done': False,
-			'is_audited': False,
 			'has_error': False,
 		}
 		client.table(settings.statuses_table).insert(status_data).execute()

--- a/processor/tests/test_process_metadata.py
+++ b/processor/tests/test_process_metadata.py
@@ -56,7 +56,6 @@ def metadata_dataset_for_processing(auth_token, test_processor_user):
 				'is_deadwood_done': False,
 				'is_forest_cover_done': False,
 				'is_metadata_done': False,
-				'is_audited': False,
 				'has_error': False,
 			}
 			client.table(settings.statuses_table).insert(status_data).execute()

--- a/processor/tests/test_process_odm.py
+++ b/processor/tests/test_process_odm.py
@@ -257,7 +257,6 @@ def odm_test_dataset(auth_token, test_zip_file, test_processor_user):
 				'is_deadwood_done': False,
 				'is_forest_cover_done': False,
 				'is_metadata_done': False,
-				'is_audited': False,
 				'has_error': False,
 			}
 			client.table(settings.statuses_table).insert(status_data).execute()

--- a/shared/models.py
+++ b/shared/models.py
@@ -196,7 +196,6 @@ class Status(BaseModel):
 	is_combined_model_done: bool = False
 	is_metadata_done: bool = False
 	is_odm_done: bool = False
-	is_audited: bool = False
 	has_error: bool = False
 	error_message: Optional[str] = None
 	created_at: Optional[datetime] = None

--- a/shared/status.py
+++ b/shared/status.py
@@ -21,7 +21,6 @@ def update_status(
 	is_combined_model_done: Optional[bool] = None,
 	is_metadata_done: Optional[bool] = None,
 	is_odm_done: Optional[bool] = None,
-	is_audited: Optional[bool] = None,
 	has_error: Optional[bool] = None,
 	error_message: Optional[str] = None,
 ) -> None:
@@ -41,7 +40,6 @@ def update_status(
 	    is_combined_model_done (bool, optional): Combined model completion status
 	    is_metadata_done (bool, optional): Metadata processing completion status
 	    is_odm_done (bool, optional): ODM processing completion status
-	    is_audited (bool, optional): Audit completion status
 	    has_error (bool, optional): Error status flag
 	    error_message (str, optional): Error message if any
 	"""
@@ -67,8 +65,6 @@ def update_status(
 			update_data['is_metadata_done'] = is_metadata_done
 		if is_odm_done is not None:
 			update_data['is_odm_done'] = is_odm_done
-		if is_audited is not None:
-			update_data['is_audited'] = is_audited
 		if has_error is not None:
 			update_data['has_error'] = has_error
 		if error_message is not None:

--- a/supabase/migrations/20260618120000_drop_status_is_audited.sql
+++ b/supabase/migrations/20260618120000_drop_status_is_audited.sql
@@ -1,0 +1,2 @@
+alter table public.v2_statuses
+  drop column if exists is_audited;

--- a/supabase/seeds/qa/qa-base.sql
+++ b/supabase/seeds/qa/qa-base.sql
@@ -250,16 +250,15 @@ insert into public.v2_statuses (
 	is_forest_cover_done,
 	is_metadata_done,
 	is_combined_model_done,
-	is_audited,
 	has_error,
 	error_message,
 	is_in_audit
 )
 values
-	(91001, 'idle', true, true, true, true, true, true, true, true, false, false, null, false),
-	(91002, 'idle', true, true, true, true, true, true, true, true, true, false, null, false),
-	(91003, 'idle', true, true, true, true, false, false, true, false, false, false, null, false),
-	(91004, 'cog_processing', true, true, false, false, false, false, true, false, false, true, 'QA fixture processing error', false);
+	(91001, 'idle', true, true, true, true, true, true, true, true, false, null, false),
+	(91002, 'idle', true, true, true, true, true, true, true, true, false, null, false),
+	(91003, 'idle', true, true, true, true, false, false, true, false, false, null, false),
+	(91004, 'cog_processing', true, true, false, false, false, false, true, false, true, 'QA fixture processing error', false);
 
 insert into public.v2_orthos (
 	dataset_id,


### PR DESCRIPTION
## Summary
- drop the stale `public.v2_statuses.is_audited` physical column in a new migration
- remove stale shared model/update-status support for writing that column
- update DB/API/processor fixtures so audited state comes from `dataset_audit` while frontend/view `is_audited` stays intact

## Why
Audit state is now derived from `dataset_audit`; keeping a writable status-column surface creates a stale contract without changing real audit behavior.

## Validation
- `scripts/dev/isolated-supabase.sh start` applied migrations through `20260618120000_drop_status_is_audited.sql`
- local schema checks confirmed `v2_statuses.is_audited` is gone and all three dataset/processing views still expose `is_audited`
- `scripts/qa/seed.sh qa-base`
- `deadtrees dev test api shared/tests/test_status.py`
- `deadtrees dev test api shared/tests/test_odm_models.py`
- `deadtrees dev test api api/tests/db/test_data_publication.py`
- `scripts/test-api-smoke.sh`
- `scripts/lint-python.sh`
- `scripts/lint-ast-grep.sh`
- `supabase db lint --workdir .local/supabase/6c1c` exited 0 with pre-existing PostGIS/extension lint warnings
- autoreview panel clean: Codex + Claude Opus, 0 findings

## Risk
Historical migrations still reference the old physical column and were intentionally left untouched. Current view behavior remains derived from `dataset_audit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured dataset status tracking architecture by removing audit status tracking and introducing new completion flags for combined model generation, metadata processing, and ODM processing stages.

* **Chores**
  * Updated database schema through migrations and adjusted seed data and test fixtures to reflect the revised status model and field structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->