### PR TITLE
fix(frontend): hide unavailable dataset downloads

### DIFF
--- a/frontend/src/components/DatasetDetailsMap/DownloadSection.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DownloadSection.tsx
@@ -5,16 +5,16 @@ import type { IDataset } from "../../types/dataset";
 import { supabase } from "../../hooks/useSupabase";
 import { useAuth } from "../../hooks/useAuthProvider";
 import { resolveDownloadUrl } from "../../utils/downloadUrl";
-import { useEffect } from "react";
 import DesktopOnlyFeatureNotice from "../DesktopOnlyFeatureNotice";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
 import { useAnalytics } from "../../hooks/useAnalytics";
+import { canDownloadCompleteDataset } from "../../utils/datasetDownloads";
 
 interface DownloadSectionProps {
   dataset: IDataset;
   labelsOnly: boolean;
   setLabelsOnly: (value: boolean) => void;
-  hasLabels: boolean;
+  hasExportableLabels: boolean;
   isDownloading: boolean;
   currentDownloadId: string | null;
   startDownload: (id: string) => boolean;
@@ -33,7 +33,7 @@ export default function DownloadSection({
   dataset,
   labelsOnly,
   setLabelsOnly,
-  hasLabels,
+  hasExportableLabels,
   isDownloading,
   currentDownloadId,
   startDownload,
@@ -43,12 +43,13 @@ export default function DownloadSection({
   const { isMobile } = useDesktopOnlyFeature();
   const { track } = useAnalytics("dataset_detail");
   const isViewOnlyDataset = dataset.data_access === "viewonly";
-
-  useEffect(() => {
-    if (isViewOnlyDataset && !labelsOnly) {
-      setLabelsOnly(true);
-    }
-  }, [isViewOnlyDataset, labelsOnly, setLabelsOnly]);
+  const completeDatasetAvailable = canDownloadCompleteDataset(dataset);
+  const forcedLabelsOnly =
+    hasExportableLabels && (isViewOnlyDataset || !completeDatasetAvailable);
+  const effectiveLabelsOnly = labelsOnly || forcedLabelsOnly;
+  const shouldUseLabelsDownload =
+    hasExportableLabels && effectiveLabelsOnly;
+  const hasAvailableDownload = completeDatasetAvailable || shouldUseLabelsDownload;
 
   const getAuthHeaders = async (): Promise<Record<string, string>> => {
     const accessToken = session?.access_token;
@@ -93,9 +94,8 @@ export default function DownloadSection({
       return;
     }
 
-    if (isViewOnlyDataset && !labelsOnly) {
-      setLabelsOnly(true);
-      message.warning("This is a view-only dataset. You can only download predictions.");
+    if (!hasAvailableDownload) {
+      message.info("This dataset is not ready for download yet.");
       return;
     }
 
@@ -109,18 +109,18 @@ export default function DownloadSection({
     const downloadStarted = startDownload(dataset.id.toString());
     if (!downloadStarted) return;
 
-    const downloadType = labelsOnly || isViewOnlyDataset ? "labels" : "dataset";
+    const downloadType = shouldUseLabelsDownload ? "labels" : "dataset";
     track("dataset_download_started", {
       dataset_id: dataset.id,
       download_type: downloadType,
     });
 
-    const baseUrl = labelsOnly
+    const baseUrl = shouldUseLabelsDownload
       ? `${Settings.API_URL}/download/datasets/${dataset.id}/labels.gpkg`
       : `${Settings.API_URL}/download/datasets/${dataset.id}/dataset.zip`;
 
     const downloadMsg = message.loading({
-      content: `Preparing ${labelsOnly ? "predictions" : "complete dataset"} for download...`,
+      content: `Preparing ${shouldUseLabelsDownload ? "predictions" : "complete dataset"} for download...`,
       duration: 0,
     });
 
@@ -135,10 +135,10 @@ export default function DownloadSection({
         if (!jobId) {
           throw new Error("Missing job ID in download response");
         }
-        const statusEndpoint = labelsOnly
+        const statusEndpoint = shouldUseLabelsDownload
           ? `${Settings.API_URL}/download/datasets/${dataset.id}/labels/status`
           : `${Settings.API_URL}/download/datasets/${jobId}/status`;
-        const downloadEndpoint = labelsOnly
+        const downloadEndpoint = shouldUseLabelsDownload
           ? `${Settings.API_URL}/download/datasets/${dataset.id}/labels/download`
           : `${Settings.API_URL}/download/datasets/${jobId}/download`;
 
@@ -160,7 +160,7 @@ export default function DownloadSection({
                 });
                 window.location.href = downloadUrl;
                 message.success({
-                  content: `${labelsOnly ? "Predictions" : "Dataset"} download started!`,
+                  content: `${shouldUseLabelsDownload ? "Predictions" : "Dataset"} download started!`,
                   duration: 5,
                 });
               } else if (statusData.status === "failed") {
@@ -211,9 +211,11 @@ export default function DownloadSection({
       : "Another download is in progress. Only one download can be active at a time."
     : !session
       ? "Please log in to download datasets."
-    : isViewOnlyDataset && !labelsOnly
-      ? "This dataset is view-only. Labels/predictions are available."
-      : labelsOnly
+    : !hasAvailableDownload
+      ? "Downloads are available after dataset processing finishes."
+    : forcedLabelsOnly && !labelsOnly
+      ? "Only labels/predictions are available for this dataset."
+      : shouldUseLabelsDownload
         ? "Download vector data of tree mortality predictions (GPKG format)"
         : "Download both orthophoto and tree mortality predictions";
 
@@ -244,18 +246,22 @@ export default function DownloadSection({
               size="large"
               icon={<DownloadOutlined />}
               className="w-full shadow-sm"
-              disabled={!session || isDownloading}
+              disabled={!session || isDownloading || !hasAvailableDownload}
               loading={isDownloading && currentDownloadId === dataset.id.toString()}
               onClick={handleDownload}
             >
-              {labelsOnly || isViewOnlyDataset ? "Download Predictions (GPKG)" : "Download Complete Dataset"}
+              {!hasAvailableDownload
+                ? "Download unavailable"
+                : shouldUseLabelsDownload
+                  ? "Download Predictions (GPKG)"
+                  : "Download Complete Dataset"}
             </Button>
           </Tooltip>
-          {hasLabels && (
+          {hasExportableLabels && (
             <Tooltip title="Only download the vector data containing tree mortality predictions, without the orthophoto">
               <Checkbox
-                checked={labelsOnly || isViewOnlyDataset}
-                disabled={isViewOnlyDataset}
+                checked={effectiveLabelsOnly}
+                disabled={isViewOnlyDataset || !completeDatasetAvailable}
                 onChange={(e) => setLabelsOnly(e.target.checked)}
                 className="mt-2 flex justify-center text-gray-600"
               >

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -12,7 +12,7 @@ import { useState, useCallback, Suspense, lazy, useEffect } from "react";
 import { usePublicDatasetById } from "../hooks/useDatasets";
 import { useDatasetLabels } from "../hooks/useDatasetLabels";
 import { useModelVariantLabels } from "../hooks/useModelVariantLabels";
-import { ILabelData } from "../types/labels";
+import { ILabelData, ILabelSource } from "../types/labels";
 import { useDownload } from "../hooks/useDownloadProvider";
 import { useOverlappingDatasets } from "../hooks/useOverlappingDatasets";
 import { useDatasetDetailsMap } from "../hooks/useDatasetDetailsMapProvider";
@@ -167,10 +167,8 @@ export default function DatasetDetails() {
   );
 
   useEffect(() => {
-    if (dataset?.data_access === "viewonly" && !labelsOnly) {
-      setLabelsOnly(true);
-    }
-  }, [dataset?.data_access, labelsOnly, setLabelsOnly]);
+    setLabelsOnly(false);
+  }, [dataset?.id]);
 
   useEffect(() => {
     setSelectedDeadwoodLabelId(null);
@@ -230,6 +228,11 @@ export default function DatasetDetails() {
   } = editing;
   const hasDisplayableForestCover =
     hasForestCover && hasForestCoverPredictionOutput(dataset);
+  const hasExportableLabels = [preferredDeadwoodLabel, preferredForestLabel].some(
+    (label) =>
+      label?.label_source === ILabelSource.MODEL_PREDICTION ||
+      label?.label_source === ILabelSource.VISUAL_INTERPRETATION,
+  );
   const SIDEBAR_LEFT_PX = 16;
   const SIDEBAR_WIDTH_PX = 384;
   const SIDEBAR_BUTTON_TOP_PX = 112;
@@ -261,7 +264,7 @@ export default function DatasetDetails() {
         dataset={dataset}
         labelsOnly={labelsOnly}
         setLabelsOnly={setLabelsOnly}
-        hasLabels={!!preferredDeadwoodLabel || !!preferredForestLabel}
+        hasExportableLabels={hasExportableLabels}
         isDownloading={isDownloading}
         currentDownloadId={currentDownloadId}
         startDownload={startDownload}

--- a/frontend/src/utils/datasetDownloads.test.ts
+++ b/frontend/src/utils/datasetDownloads.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { IDataAccess } from "../types/dataset";
+import { canDownloadCompleteDataset } from "./datasetDownloads";
+import type { DatasetProgress } from "./processingSteps";
+
+const completeDataset: DatasetProgress & { data_access: IDataAccess } = {
+  file_name: "complete.tif",
+  data_access: IDataAccess.public,
+  current_status: "idle",
+  has_error: false,
+  is_upload_done: true,
+  is_ortho_done: true,
+  is_metadata_done: true,
+  is_cog_done: true,
+  is_deadwood_done: true,
+  is_forest_cover_done: true,
+  is_combined_model_done: false,
+};
+
+describe("canDownloadCompleteDataset", () => {
+  it("allows complete public datasets", () => {
+    expect(canDownloadCompleteDataset(completeDataset)).toBe(true);
+  });
+
+  it("blocks errored datasets", () => {
+    expect(canDownloadCompleteDataset({ ...completeDataset, has_error: true })).toBe(false);
+  });
+
+  it("blocks datasets with active processing status", () => {
+    expect(canDownloadCompleteDataset({ ...completeDataset, current_status: "cog_processing" })).toBe(false);
+  });
+
+  it("allows completed datasets while an audit is in progress", () => {
+    expect(canDownloadCompleteDataset({ ...completeDataset, current_status: "audit_in_progress" })).toBe(true);
+  });
+
+  it("blocks incomplete datasets", () => {
+    expect(canDownloadCompleteDataset({ ...completeDataset, is_cog_done: false })).toBe(false);
+  });
+
+  it("blocks view-only datasets from full archive downloads", () => {
+    expect(canDownloadCompleteDataset({ ...completeDataset, data_access: IDataAccess.viewonly })).toBe(false);
+  });
+});

--- a/frontend/src/utils/datasetDownloads.ts
+++ b/frontend/src/utils/datasetDownloads.ts
@@ -1,0 +1,27 @@
+import { IDataAccess, type IDataset } from "../types/dataset";
+import {
+  isPredictionProcessingComplete,
+  type DatasetProgress,
+} from "./processingSteps";
+
+type DatasetDownloadStatus = DatasetProgress & Pick<IDataset, "data_access">;
+const FULL_DOWNLOAD_ALLOWED_STATUSES = new Set([undefined, "", "idle", "audit_in_progress"]);
+
+function isOdmWorkflow(dataset: DatasetProgress): boolean {
+  return dataset.file_name?.toLowerCase().endsWith(".zip") || false;
+}
+
+export function canDownloadCompleteDataset(dataset: DatasetDownloadStatus): boolean {
+  const odmComplete = !isOdmWorkflow(dataset) || dataset.is_odm_done;
+  return !!(
+    dataset.data_access !== IDataAccess.viewonly &&
+    !dataset.has_error &&
+    FULL_DOWNLOAD_ALLOWED_STATUSES.has(dataset.current_status) &&
+    dataset.is_upload_done &&
+    odmComplete &&
+    dataset.is_ortho_done &&
+    dataset.is_metadata_done &&
+    dataset.is_cog_done &&
+    isPredictionProcessingComplete(dataset)
+  );
+}


### PR DESCRIPTION
Fixes #412.

## What changed

- Add a small `canDownloadCompleteDataset` helper that reuses the existing processing-complete predicate and blocks full archive downloads for errored, actively processing, incomplete, or view-only datasets.
- Update the dataset detail download section so incomplete/error datasets do not present `Download Complete Dataset`.
- Keep prediction downloads available when labels exist; otherwise show a disabled `Download unavailable` state.
- Add focused unit coverage for complete, errored, actively processing, incomplete, and view-only datasets.

## Why

The Chrome QA pilot found that `/dataset/91004`, an incomplete/error-like local fixture, exposed a complete dataset download action. That made an errored dataset look ready for archive download.

## Validation

- `npm --prefix frontend test -- datasetDownloads.test.ts`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- `npm --prefix frontend run test:e2e:local` while the Chrome QA worker ran: `6 passed`, `6 skipped`
- Chrome QA worker via `scripts/qa/run-agent-qa.sh --profile qa-realistic --parallel 1 --agent-browser-surface chrome --agent-model 'gpt-5.5 low' --playbook negative-empty-error-states --playbook public-archive-detail-download --focus 'Issue 412: verify /dataset/91004 no longer exposes Download Complete Dataset for an errored/incomplete dataset, while /dataset/91001 still has the expected completed-dataset download affordance.' --no-seed --run-dir .local/qa-runs/issue-412-chrome-qa`

Chrome QA result:

- `negative-empty-error-states`: pass. `/dataset/91004` showed `Download unavailable`; `Download Complete Dataset` was not visible.
- `public-archive-detail-download`: fail, existing broader product/QA finding. `/dataset` showed zero archive results, and `/dataset/91001` showed the completed-dataset affordance but the worker remained anonymous so the action was disabled. This is separate from the issue #412 fix.

## Stack note

This PR is stacked on #411 because it uses the new `qa-realistic` and Chrome QA lane introduced there. After #411 merges, retarget this PR to `main`.