### PR TITLE
perf(frontend): cache COG range reads

### DIFF
--- a/frontend/src/components/Corrections/CorrectionEditorView.tsx
+++ b/frontend/src/components/Corrections/CorrectionEditorView.tsx
@@ -27,6 +27,7 @@ import { createDeadwoodVectorLayer, createForestCoverVectorLayer } from "../Data
 import { useDatasetLabelTypes } from "../../hooks/useDatasetLabelTypes";
 import { useDatasetDetailsMap } from "../../hooks/useDatasetDetailsMapProvider";
 import { createOpenFreeMapLibertyLayerGroup, createStandardMapControls } from "../../utils/basemaps";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import { hasForestCoverPredictionOutput } from "../../utils/predictionAvailability";
 
 interface Props {
@@ -101,6 +102,7 @@ export default function CorrectionEditorView({ dataset, initialLayerType, onClos
           },
         ],
         convertToRGB: true,
+        sourceOptions: COG_SOURCE_OPTIONS,
       }),
       maxZoom: 23,
       cacheSize: 4096,

--- a/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
+++ b/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
@@ -7,6 +7,7 @@ import type { Layer } from "ol/layer";
 
 import { Settings } from "../../../config";
 import { createStandardMapControls } from "../../../utils/basemaps";
+import { COG_SOURCE_OPTIONS } from "../../../utils/cogSourceOptions";
 import { createMapInteractions } from "../../../utils/mapInteractions";
 
 export interface Viewport {
@@ -155,6 +156,7 @@ export function useMapCore({
 					bands: [1, 2, 3],
 				}],
 				convertToRGB: true,
+				sourceOptions: COG_SOURCE_OPTIONS,
 			}),
 			maxZoom: 23,
 			cacheSize: 4096,

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -44,6 +44,7 @@ import {
   getForestCOGUrl,
   type MapModelVersion,
 } from "../../utils/getDeadwoodCOGUrl";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import {
   createOpenFreeMapLibertyLayerGroup,
   createStandardMapControls,
@@ -116,6 +117,7 @@ const createDeadwoodSource = (year: string, version: MapModelVersion) => {
     ],
     normalize: true,
     interpolate: false,
+    sourceOptions: COG_SOURCE_OPTIONS,
   });
 };
 
@@ -127,6 +129,7 @@ const createForestSource = (year: string, version: MapModelVersion) => {
     ],
     normalize: true,
     interpolate: false,
+    sourceOptions: COG_SOURCE_OPTIONS,
   });
 };
 

--- a/frontend/src/components/DeadwoodMap/createDeadwoodGeotiffLayer.ts
+++ b/frontend/src/components/DeadwoodMap/createDeadwoodGeotiffLayer.ts
@@ -1,5 +1,6 @@
 import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { GeoTIFF } from "ol/source";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import getDeadwoodCOGUrl from "../../utils/getDeadwoodCOGUrl";
 
 const createDeadwoodGeotiffLayer = (year: string) => {
@@ -14,6 +15,7 @@ const createDeadwoodGeotiffLayer = (year: string) => {
     ],
     normalize: true,
     interpolate: false, // Show actual pixel grid
+    sourceOptions: COG_SOURCE_OPTIONS,
   });
 
   // Single-band COG: values 0-255 (normalized to 0-1)

--- a/frontend/src/components/DeadwoodMap/createForestGeotiffLayer.ts
+++ b/frontend/src/components/DeadwoodMap/createForestGeotiffLayer.ts
@@ -1,5 +1,6 @@
 import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { GeoTIFF } from "ol/source";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import { getForestCOGUrl } from "../../utils/getDeadwoodCOGUrl";
 
 const createForestGeotiffLayer = (year: string) => {
@@ -14,6 +15,7 @@ const createForestGeotiffLayer = (year: string) => {
     ],
     normalize: true,
     interpolate: false, // Show actual pixel grid
+    sourceOptions: COG_SOURCE_OPTIONS,
   });
 
   // Single-band COG: values 0-255 (normalized to 0-1)

--- a/frontend/src/components/Home/MiniSatelliteMap.tsx
+++ b/frontend/src/components/Home/MiniSatelliteMap.tsx
@@ -8,6 +8,7 @@ import { GeoTIFF } from "ol/source";
 import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { fromLonLat } from "ol/proj";
 
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import { getDeadwoodCOGUrl, getForestCOGUrl } from "../../utils/getDeadwoodCOGUrl";
 import { getWaybackTileUrl } from "../../utils/waybackVersions";
 
@@ -26,6 +27,7 @@ const createRasterSource = (url: string) =>
     sources: [{ url, bands: [1], min: 0, max: 255 }],
     normalize: true,
     interpolate: false,
+    sourceOptions: COG_SOURCE_OPTIONS,
   });
 
 const MiniSatelliteMap = () => {

--- a/frontend/src/components/MLTiles/MLTileMap.tsx
+++ b/frontend/src/components/MLTiles/MLTileMap.tsx
@@ -28,6 +28,7 @@ import {
 } from "../DatasetDetailsMap/createVectorLayer";
 import { Settings } from "../../config";
 import { createOpenFreeMapLibertyLayerGroup } from "../../utils/basemaps";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import { palette } from "../../theme/palette";
 import { polygonToBBox } from "../../utils/utm";
 
@@ -205,6 +206,7 @@ export default function MLTileMap({
             },
           ],
           convertToRGB: true,
+          sourceOptions: COG_SOURCE_OPTIONS,
         }),
         maxZoom: 23,
         cacheSize: 1024,

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.ts
@@ -2,6 +2,7 @@ import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { GeoTIFF } from "ol/source";
 
 import { Settings } from "../../config";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 
 export const createPriwaCogLayer = (cogPath: string) =>
   new TileLayerWebGL({
@@ -14,6 +15,7 @@ export const createPriwaCogLayer = (cogPath: string) =>
         },
       ],
       convertToRGB: true,
+      sourceOptions: COG_SOURCE_OPTIONS,
     }),
     opacity: 0.82,
     maxZoom: 23,

--- a/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
+++ b/frontend/src/components/ReferencePatches/ReferencePatchMap.tsx
@@ -31,6 +31,7 @@ import {
   createAOIMaskLayer,
 } from "../DatasetDetailsMap/createVectorLayer";
 import { Settings } from "../../config";
+import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 import {
   transformPolygonUtmToWebMercator,
   transformPolygonWebMercatorToUtm,
@@ -225,6 +226,7 @@ export default function ReferencePatchMap({
             },
           ],
           convertToRGB: true,
+          sourceOptions: COG_SOURCE_OPTIONS,
         }),
         maxZoom: 25, // Allow very high zoom for detailed ortho imagery
         cacheSize: 1024,

--- a/frontend/src/pages/DatasetLabelEditor.tsx
+++ b/frontend/src/pages/DatasetLabelEditor.tsx
@@ -24,6 +24,7 @@ import type { StyleFunction as OLStyleFunction } from "ol/style/Style";
 import type { IDataset } from "../types/dataset";
 import type MapBrowserEvent from "ol/MapBrowserEvent";
 import { createOpenFreeMapLibertyLayerGroup } from "../utils/basemaps";
+import { COG_SOURCE_OPTIONS } from "../utils/cogSourceOptions";
 import { palette } from "../theme/palette";
 
 type StyleFn = (f: Feature<Geometry>) => Style | null | undefined;
@@ -84,6 +85,7 @@ export default function DatasetLabelEditor() {
             },
           ],
           convertToRGB: true,
+          sourceOptions: COG_SOURCE_OPTIONS,
         }),
         maxZoom: 23,
         cacheSize: 4096,

--- a/frontend/src/utils/cogSourceOptions.ts
+++ b/frontend/src/utils/cogSourceOptions.ts
@@ -1,0 +1,4 @@
+export const COG_SOURCE_OPTIONS = {
+  blockSize: 65536,
+  cacheSize: 200,
+};


### PR DESCRIPTION
## Summary
- add shared OpenLayers GeoTIFF source options for COG reads
- use 64KB range blocks with a bounded cache across all frontend COG layers
- reduce geotiff.js lazy TileOffsets/TileByteCounts metadata fan-out without changing the passive COG architecture

## Why
Browser measurements on /dataset/10510 showed the slowdown was not caused by missing COG tile offset or byte-count metadata. The COGs expose valid index data, but geotiff.js/OpenLayers was fetching many tiny range reads lazily for those index arrays. Caching range blocks lets the browser keep using raw COGs while collapsing those tiny index requests.

## Validation
- Browser plugin, production /dataset/10510 reload baseline: 83 COG responses, 60 tiny <=100B reads
- Browser plugin, patched local /dataset/10510 reload: 6 COG responses, 0 tiny reads, 64KB blocks
- Browser plugin, patched local zoom/pan interaction: 10 further COG responses, 0 tiny reads, 64KB blocks
- npm run build