### PR TITLE
fix(frontend): restore ReactPlayer rendering

### DIFF
--- a/frontend/src/components/Home/Hero.tsx
+++ b/frontend/src/components/Home/Hero.tsx
@@ -5,13 +5,13 @@ import {
   SearchOutlined,
   UploadOutlined,
 } from "@ant-design/icons";
-import ReactPlayer from "react-player";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuthProvider";
 import { useHomeStats } from "../../hooks/useHomeReadModels";
 import { useDesktopOnlyFeature } from "../../hooks/useDesktopOnlyFeature";
 import { useAnalytics } from "../../hooks/useAnalytics";
 import LogoBannerBand from "./LogoBanner";
+import ReactPlayer from "../ReactPlayerCompat";
 
 const logos = [
   { path: "assets/logos/esa.jpg" },

--- a/frontend/src/components/ReactPlayerCompat.ts
+++ b/frontend/src/components/ReactPlayerCompat.ts
@@ -1,0 +1,14 @@
+import type { ComponentType } from "react";
+import ReactPlayerModule from "react-player";
+
+type ReactPlayerComponent = ComponentType<Record<string, unknown>>;
+type ReactPlayerModuleShape = ReactPlayerComponent & {
+  default?: ReactPlayerComponent;
+};
+
+const playerModule = ReactPlayerModule as unknown as ReactPlayerModuleShape;
+
+// Vite 8 can preserve react-player's CommonJS wrapper as a double default.
+const ReactPlayer = (playerModule.default ?? playerModule) as ReactPlayerComponent;
+
+export default ReactPlayer;

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -14,7 +14,7 @@ import { usePublications } from "../hooks/usePublications";
 import { ReactNode, useMemo } from "react";
 import LogoBannerBand from "../components/Home/LogoBanner";
 import { useData } from "../hooks/useDataProvider";
-import ReactPlayer from "react-player";
+import ReactPlayer from "../components/ReactPlayerCompat";
 
 export default function About() {
   const coreTeam = [


### PR DESCRIPTION
## What changed
- Add a small `ReactPlayerCompat` wrapper that unwraps `react-player` when the production bundle receives the CommonJS module as a double-default object.
- Route the Home hero and About video embeds through that wrapper.

## Why
The live homepage loaded HTML quickly but React crashed before rendering visible content. Browser validation on `https://deadtrees.earth/` showed minified React error #130 from `react-dom`, which means React was asked to render an object instead of a valid component. This started after recent dependency bumps; the local dependency shape for `react-player` under the Vite 8 bundle exposes a `default.default` component shape.

## Validation
- Browser plugin on live `https://deadtrees.earth/`: reproduced blank homepage with React #130 and no initial PostgREST homepage requests.
- Browser plugin on local patched production preview `http://localhost:4178/`: hero heading visible, homepage controls visible, no local console errors.
- Browser plugin on local patched production preview `/about`: `The Initiative` heading visible, no local console errors.
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `git diff --check`

## Risk
Low. This centralizes the import compatibility handling for the two existing `react-player` call sites and does not change player props or homepage data loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored video player component references throughout the application to use a new centralized compatibility wrapper. This improves code organization, maintainability, and consistency by standardizing how the video player is imported and utilized across all application components and pages. This reduces overall dependency complexity and makes future updates easier to manage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->