### PR TITLE
Cleanup/prepackaged release page

### DIFF
--- a/frontend/src/data/releases.ts
+++ b/frontend/src/data/releases.ts
@@ -553,7 +553,7 @@ export const dteAerialRelease: DteAerialRelease = {
     "DTE-aerial-bench: A multi-resolution manually labelled aerial benchmark for tree cover and mortality segmentation",
   type: "benchmark-dataset",
   typeLabel: "Benchmark dataset",
-  status: "coming-soon",
+  status: "available",
   summary:
     "A curated aerial benchmark for tree cover and mortality segmentation, built from high-resolution drone and aircraft orthophotos with expert masks.",
   prepackagedPackageSlugs: [

--- a/frontend/src/data/releases.ts
+++ b/frontend/src/data/releases.ts
@@ -553,7 +553,7 @@ export const dteAerialRelease: DteAerialRelease = {
     "DTE-aerial-bench: A multi-resolution manually labelled aerial benchmark for tree cover and mortality segmentation",
   type: "benchmark-dataset",
   typeLabel: "Benchmark dataset",
-  status: "available",
+  status: "coming-soon",
   summary:
     "A curated aerial benchmark for tree cover and mortality segmentation, built from high-resolution drone and aircraft orthophotos with expert masks.",
   prepackagedPackageSlugs: [

--- a/frontend/src/pages/DteAerialRelease.tsx
+++ b/frontend/src/pages/DteAerialRelease.tsx
@@ -9,7 +9,6 @@ import { useNavigate } from "react-router-dom";
 
 import { DteAerialReleaseGallery } from "../components/Releases/DteAerialReleaseGallery";
 import { DteAerialReleaseSiteMap } from "../components/Releases/DteAerialReleaseSiteMap";
-import { PrepackagedReleaseDownloads } from "../components/Releases/PrepackagedReleaseDownloads";
 import {
   getReleaseStats,
   getCoarseBiomeGroup,
@@ -24,8 +23,6 @@ interface DteAerialReleaseProps {
 export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
   const navigate = useNavigate();
   const benchmark = release.dteAerial;
-  const prepackagedPackageSlugs = release.prepackagedPackageSlugs ?? [];
-  const hasPrepackagedDownloads = prepackagedPackageSlugs.length > 0;
   const { adminInfoByDatasetId, isAdminInfoLoading } =
     useDteAerialDatasetAdminInfo(release);
   const heroTagline = release.title.startsWith(`${release.name}: `)
@@ -33,11 +30,6 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
     : release.title;
 
   const releaseStats = useMemo(() => getReleaseStats(release), [release]);
-  const scrollToDownloads = () => {
-    document
-      .getElementById("dataset-download-placeholder")
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
 
   const biomeCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -81,17 +73,13 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
                 type="primary"
                 size="large"
                 icon={<DownloadOutlined />}
-                disabled={!hasPrepackagedDownloads}
-                onClick={scrollToDownloads}
+                disabled
                 className="min-h-11"
               >
                 View downloads
               </Button>
-              <Tag
-                className="m-0"
-                color={hasPrepackagedDownloads ? "green" : "warning"}
-              >
-                {hasPrepackagedDownloads ? "Available" : "Coming soon"}
+              <Tag className="m-0" color="warning">
+                Coming soon
               </Tag>
             </div>
           </div>
@@ -158,37 +146,6 @@ export default function DteAerialRelease({ release }: DteAerialReleaseProps) {
         adminInfoByDatasetId={adminInfoByDatasetId}
         isAdminInfoLoading={isAdminInfoLoading}
       />
-
-      <section
-        id="dataset-download-placeholder"
-        data-testid="release-artifacts"
-        className="border-t border-gray-200 bg-white"
-      >
-        <div className="mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-20">
-          <div className="max-w-3xl">
-            <p className="m-0 text-sm font-semibold uppercase tracking-wider text-[#1B5E35]">
-              Release artifacts
-            </p>
-            <h2 className="m-0 mt-3 text-3xl font-semibold leading-tight text-gray-950 md:text-4xl">
-              Dataset package
-            </h2>
-            <p className="mt-3 text-base leading-7 text-gray-600">
-              The gallery above is the live preview of the dataset. ZIP
-              artifacts are issued as short-lived signed links after sign-in so
-              downloads can be audited. Use the main button for a browser
-              download, or open the menu next to it to copy wget/curl commands
-              for server-side downloads. Copied commands include expiring signed
-              links; regenerate a command if one has expired.
-            </p>
-            <div className="mt-6">
-              <PrepackagedReleaseDownloads
-                packageSlugs={prepackagedPackageSlugs}
-                returnTo={`/releases/${release.slug}`}
-              />
-            </div>
-          </div>
-        </div>
-      </section>
     </main>
   );
 }

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -36,21 +36,6 @@ function getSafeHttpUrl(url: string | null) {
   }
 }
 
-function buildSourceCodeUrl(
-  repositoryUrl: string | null,
-  sourceFilePath: string | null,
-  sourceCommit: string | null,
-) {
-  const safeRepositoryUrl = getSafeHttpUrl(repositoryUrl);
-  if (!safeRepositoryUrl || !sourceFilePath || !sourceCommit) return null;
-
-  const encodedPath = sourceFilePath
-    .split("/")
-    .map(encodeURIComponent)
-    .join("/");
-  return `${safeRepositoryUrl}/blob/${encodeURIComponent(sourceCommit)}/${encodedPath}`;
-}
-
 function getShortCommit(sourceCommit: string | null) {
   return sourceCommit ? sourceCommit.slice(0, 7) : null;
 }
@@ -86,13 +71,6 @@ export default function PrepackagedDatasetRelease() {
               : prepackagedNumberFormatter.format(latestVersion.dataset_count),
         },
         {
-          label: "Artifacts",
-          value:
-            latestVersion.artifact_count === null
-              ? "Unknown"
-              : prepackagedNumberFormatter.format(latestVersion.artifact_count),
-        },
-        {
           label: "Built",
           value: formatPrepackagedDate(latestVersion.built_at),
         },
@@ -110,20 +88,11 @@ export default function PrepackagedDatasetRelease() {
   const safeRepositoryUrl = datasetPackage
     ? getSafeHttpUrl(datasetPackage.source_repository_url)
     : null;
-  const sourceCodeUrl =
-    datasetPackage && latestVersion
-      ? buildSourceCodeUrl(
-          datasetPackage.source_repository_url,
-          datasetPackage.source_file_path,
-          latestVersion.source_commit,
-        )
-      : null;
   const shortSourceCommit = latestVersion
     ? getShortCommit(latestVersion.source_commit)
     : null;
   const hasReproducibilityMetadata = Boolean(
     datasetPackage?.technical_description ||
-    sourceCodeUrl ||
     safeRepositoryUrl ||
     latestVersion?.source_package_version ||
     shortSourceCommit,
@@ -231,12 +200,6 @@ export default function PrepackagedDatasetRelease() {
                   </div>
                   <dl className="mt-4 grid gap-3 text-sm text-gray-600 sm:grid-cols-2">
                     <div>
-                      <dt className="font-semibold text-gray-800">Published</dt>
-                      <dd className="m-0 mt-0.5">
-                        {formatPrepackagedDate(latestVersion.published_at)}
-                      </dd>
-                    </div>
-                    <div>
                       <dt className="font-semibold text-gray-800">Version</dt>
                       <dd className="m-0 mt-0.5">v{latestVersion.version}</dd>
                     </div>
@@ -255,14 +218,6 @@ export default function PrepackagedDatasetRelease() {
                       </div>
                     )}
                   </dl>
-                  {latestVersion.known_issues && (
-                    <Alert
-                      className="mt-4"
-                      type="warning"
-                      showIcon
-                      message={latestVersion.known_issues}
-                    />
-                  )}
                 </div>
               </div>
             </div>
@@ -305,24 +260,6 @@ export default function PrepackagedDatasetRelease() {
                             className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
                           >
                             <span className="truncate">Open repository</span>
-                            <ExportOutlined className="shrink-0 text-xs" />
-                          </a>
-                        </dd>
-                      </div>
-                    )}
-                    {sourceCodeUrl && (
-                      <div>
-                        <dt className="font-semibold text-gray-800">
-                          Source file
-                        </dt>
-                        <dd className="m-0 mt-2">
-                          <a
-                            href={sourceCodeUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#1B5E35]/20 bg-[#f8faf9] px-3 py-2 font-semibold text-[#1B5E35] transition hover:border-[#1B5E35]/40 hover:bg-[#eef6f0]"
-                          >
-                            <span className="truncate">Open source file</span>
                             <ExportOutlined className="shrink-0 text-xs" />
                           </a>
                         </dd>

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -144,8 +144,7 @@ export default function PrepackagedDatasetRelease() {
                 {datasetPackage.description || datasetPackage.summary}
               </p>
               <p className="mt-6 max-w-2xl text-sm leading-6 text-gray-500">
-                Metadata is public. ZIP downloads require sign-in and use
-                short-lived links.
+                Metadata is public.
               </p>
             </div>
 

--- a/frontend/src/pages/PrepackagedDatasetRelease.tsx
+++ b/frontend/src/pages/PrepackagedDatasetRelease.tsx
@@ -36,10 +36,6 @@ function getSafeHttpUrl(url: string | null) {
   }
 }
 
-function getShortCommit(sourceCommit: string | null) {
-  return sourceCommit ? sourceCommit.slice(0, 7) : null;
-}
-
 export default function PrepackagedDatasetRelease() {
   const { slug } = useParams();
   const navigate = useNavigate();
@@ -88,14 +84,10 @@ export default function PrepackagedDatasetRelease() {
   const safeRepositoryUrl = datasetPackage
     ? getSafeHttpUrl(datasetPackage.source_repository_url)
     : null;
-  const shortSourceCommit = latestVersion
-    ? getShortCommit(latestVersion.source_commit)
-    : null;
   const hasReproducibilityMetadata = Boolean(
     datasetPackage?.technical_description ||
     safeRepositoryUrl ||
-    latestVersion?.source_package_version ||
-    shortSourceCommit,
+    latestVersion?.source_package_version,
   );
 
   return (
@@ -262,14 +254,6 @@ export default function PrepackagedDatasetRelease() {
                             <span className="truncate">Open repository</span>
                             <ExportOutlined className="shrink-0 text-xs" />
                           </a>
-                        </dd>
-                      </div>
-                    )}
-                    {shortSourceCommit && (
-                      <div>
-                        <dt className="font-semibold text-gray-800">Commit</dt>
-                        <dd className="m-0 mt-1 font-mono text-gray-700">
-                          {shortSourceCommit}
                         </dd>
                       </div>
                     )}

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -135,8 +135,7 @@ export default function Releases() {
           <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-600">
             Stable datasets and benchmarks with metadata and previews for
             scientific reuse—including versioned ZIP packages sourced from
-            public CC BY data (downloads require sign-in and use short-lived
-            links).
+            public CC BY data.
           </p>
         </div>
       </section>

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -107,13 +107,6 @@ function buildPrepackagedStats(pkg: IPrepackagedDatasetPackage): ReleaseStat[] {
           ? "Unknown"
           : prepackagedNumberFormatter.format(v.dataset_count),
     },
-    {
-      label: "Artifacts",
-      value:
-        v.artifact_count === null
-          ? "Unknown"
-          : prepackagedNumberFormatter.format(v.artifact_count),
-    },
     { label: "Built", value: formatPrepackagedDate(v.built_at) },
   ];
 }

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -49,7 +49,7 @@ function ReleaseCard({
       <div className="grid gap-8 p-6 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] md:p-10">
         <div>
           <div className="flex flex-wrap items-center gap-2">
-            <Tag color={isAvailable ? "green" : "default"} className="m-0">
+            <Tag color={isAvailable ? "green" : "warning"} className="m-0">
               {isAvailable ? "Available" : "Coming soon"}
             </Tag>
             <Tag className="m-0">{typeLabel}</Tag>

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -195,27 +195,6 @@ export default function Releases() {
             );
           })}
         </div>
-
-        <div className="mt-10 rounded-2xl border border-dashed border-gray-300 bg-white/60 px-6 py-8 text-center md:px-10">
-          <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#1B5E35]">
-            More coming
-          </span>
-          <h3 className="m-0 mt-4 text-lg font-semibold text-gray-900 md:text-xl">
-            Additional releases are in preparation
-          </h3>
-          <p className="mx-auto mt-2 max-w-2xl text-sm leading-6 text-gray-600">
-            New resources, including datasets, models, and benchmark
-            collections, will appear here as they are finalised. If you have a
-            release to contribute,{" "}
-            <a
-              href="mailto:info@deadtrees.earth?subject=Release contribution"
-              className="font-semibold text-[#1B5E35] underline"
-            >
-              get in touch
-            </a>
-            .
-          </p>
-        </div>
       </section>
     </main>
   );

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -68,7 +68,6 @@ function ReleaseCard({
               icon={<DatabaseOutlined />}
               onClick={onOpen}
               className="min-h-11"
-              disabled={!isAvailable}
             >
               Open release
             </Button>

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -135,7 +135,8 @@ export default function Releases() {
           <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-600">
             Stable datasets and benchmarks with metadata and previews for
             scientific reuse—including versioned ZIP packages sourced from
-            public CC BY data.
+            public CC BY data (downloads require sign-in and use short-lived
+            links).
           </p>
         </div>
       </section>

--- a/frontend/src/pages/Releases.tsx
+++ b/frontend/src/pages/Releases.tsx
@@ -195,6 +195,27 @@ export default function Releases() {
             );
           })}
         </div>
+
+        <div className="mt-10 rounded-2xl border border-dashed border-gray-300 bg-white/60 px-6 py-8 text-center md:px-10">
+          <span className="inline-flex items-center rounded-full bg-[#E8F3EB] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#1B5E35]">
+            More coming
+          </span>
+          <h3 className="m-0 mt-4 text-lg font-semibold text-gray-900 md:text-xl">
+            Additional releases are in preparation
+          </h3>
+          <p className="mx-auto mt-2 max-w-2xl text-sm leading-6 text-gray-600">
+            New resources, including datasets, models, and benchmark
+            collections, will appear here as they are finalised. If you have a
+            release to contribute,{" "}
+            <a
+              href="mailto:info@deadtrees.earth?subject=Release contribution"
+              className="font-semibold text-[#1B5E35] underline"
+            >
+              get in touch
+            </a>
+            .
+          </p>
+        </div>
       </section>
     </main>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* DTE Aerial benchmark dataset status changed to "Coming soon" with downloads temporarily unavailable
* Release detail pages streamlined: removed artifact statistics, publication dates, known issues alerts, and source code references
* Updated visual styling and button states for unavailable releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->