### PR TITLE
perf(frontend): optimize dataset archive loading

### DIFF
--- a/frontend/e2e/data-factory-readonly.spec.ts
+++ b/frontend/e2e/data-factory-readonly.spec.ts
@@ -166,7 +166,41 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
   test("archive journey searches public data and applies a biome filter", async ({
     page,
   }) => {
+    const restRequests: string[] = [];
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (url.includes("/rest/v1/")) {
+        restRequests.push(decodeURIComponent(url));
+      }
+    });
+
+    const archiveResponsePromise = page
+      .waitForResponse((response) =>
+        response.url().includes("/rest/v1/public_dataset_archive_items"),
+      )
+      .catch(() => null);
+
     await openArchiveFromHome(page);
+
+    const archiveResponse = await archiveResponsePromise;
+    test.skip(
+      archiveResponse?.status() === 404,
+      "archive read-model migration has not been deployed to this backend yet",
+    );
+
+    expect(
+      restRequests.some((url) =>
+        url.includes("/rest/v1/public_dataset_archive_items"),
+      ),
+    ).toBe(true);
+    expect(
+      restRequests.some(
+        (url) =>
+          url.includes("/rest/v1/v2_full_dataset_view_public") &&
+          url.includes("select=*"),
+      ),
+    ).toBe(false);
 
     const searchInput = page.getByTestId("dataset-search-input");
     await searchInput.fill("no-matching-public-dataset-smoke-query");
@@ -293,6 +327,18 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
   test("satellite map journey loads public layers and read-only controls", async ({
     page,
   }) => {
+    const earlyWaybackMetadataRequests: string[] = [];
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (
+        url.toLowerCase().includes("wayback") &&
+        url.toLowerCase().includes("metadata")
+      ) {
+        earlyWaybackMetadataRequests.push(url);
+      }
+    });
+
     await page.goto("/");
 
     await page.getByRole("button", { name: "Explore Map" }).click();
@@ -309,6 +355,7 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
 
     const controls = page.getByTestId("deadtrees-layer-controls");
     await expect(controls).toBeVisible();
+    expect(earlyWaybackMetadataRequests).toHaveLength(0);
     await expect(
       controls.getByRole("checkbox", { name: "Tree cover [%]" }),
     ).toBeChecked();

--- a/frontend/e2e/data-factory-readonly.spec.ts
+++ b/frontend/e2e/data-factory-readonly.spec.ts
@@ -9,6 +9,27 @@ const expectArchiveReady = async (page: Page) => {
   return firstDataset;
 };
 
+const waitForArchiveReadModelResponse = async (page: Page) =>
+  page
+    .waitForResponse(
+      (response) =>
+        response.url().includes("/rest/v1/public_dataset_archive_items"),
+      { timeout: 20_000 },
+    )
+    .catch(() => null);
+
+const skipIfArchiveReadModelMissing = (
+  archiveResponse: Awaited<ReturnType<typeof waitForArchiveReadModelResponse>>,
+) => {
+  test.skip(
+    archiveResponse?.status() === 404,
+    "archive read-model migration has not been deployed to this backend yet",
+  );
+
+  expect(archiveResponse, "archive read-model request was not issued").not.toBeNull();
+  expect(archiveResponse?.ok(), "archive read-model request failed").toBe(true);
+};
+
 const openArchiveFromHome = async (page: Page) => {
   await page.goto("/");
 
@@ -17,8 +38,10 @@ const openArchiveFromHome = async (page: Page) => {
     page.getByRole("img", { name: "deadtrees.earth" }).first(),
   ).toBeVisible();
 
+  const archiveResponsePromise = waitForArchiveReadModelResponse(page);
   await page.getByRole("menuitem", { name: "Drone Archive" }).click();
   await expect(page).toHaveURL(/\/dataset$/);
+  skipIfArchiveReadModelMissing(await archiveResponsePromise);
 
   return expectArchiveReady(page);
 };
@@ -175,19 +198,7 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
       }
     });
 
-    const archiveResponsePromise = page
-      .waitForResponse((response) =>
-        response.url().includes("/rest/v1/public_dataset_archive_items"),
-      )
-      .catch(() => null);
-
     await openArchiveFromHome(page);
-
-    const archiveResponse = await archiveResponsePromise;
-    test.skip(
-      archiveResponse?.status() === 404,
-      "archive read-model migration has not been deployed to this backend yet",
-    );
 
     expect(
       restRequests.some((url) =>

--- a/frontend/src/components/DataList.tsx
+++ b/frontend/src/components/DataList.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import ListItem from "./ListItem";
 import { Button } from "antd";
-import { IDataset } from "../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../types/dataset";
+
+type ListDataset = IDataset | IDatasetArchiveItem;
 
 interface DataListProps {
-  data: IDataset[];
+  data: ListDataset[];
   hoveredItem: number | null;
   setHoveredItem: (id: number | null) => void;
   visibleFeatures: string[];

--- a/frontend/src/components/DatasetMap/DatasetMap.tsx
+++ b/frontend/src/components/DatasetMap/DatasetMap.tsx
@@ -10,7 +10,7 @@ import type { SelectEvent } from "ol/interaction/Select";
 import "ol/ol.css";
 import { fromExtent } from "ol/geom/Polygon.js";
 import { useNavigate } from "react-router-dom";
-import { IDataset } from "../../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../../types/dataset";
 import parseBBox from "../../utils/parseBBox";
 import {
   applyOpenFreeMapLibertyStyle,
@@ -72,12 +72,14 @@ const createHoverExtentStyle = (spec: DatasetVisualSpec): Style =>
     stroke: new Stroke({ color: "#ffffff", width: 2.5 }),
   });
 
-const parseYear = (dataset: IDataset): number | null => {
+type DatasetMapItem = IDataset | IDatasetArchiveItem;
+
+const parseYear = (dataset: DatasetMapItem): number | null => {
   const year = Number.parseInt(dataset.aquisition_year, 10);
   return Number.isNaN(year) ? null : year;
 };
 
-const getDatasetVisualSpec = (dataset: IDataset, mode: DatasetMapColorMode): DatasetVisualSpec => {
+const getDatasetVisualSpec = (dataset: DatasetMapItem, mode: DatasetMapColorMode): DatasetVisualSpec => {
   if (mode === "labels") {
     if (dataset.has_labels) {
       return {
@@ -177,7 +179,7 @@ const getDatasetVisualSpec = (dataset: IDataset, mode: DatasetMapColorMode): Dat
   };
 };
 
-const formatAcquisitionDate = (dataset: IDataset): string => {
+const formatAcquisitionDate = (dataset: DatasetMapItem): string => {
   const year = Number.parseInt(dataset.aquisition_year, 10);
   if (Number.isNaN(year)) return "Unknown date";
 
@@ -191,7 +193,7 @@ const formatAcquisitionDate = (dataset: IDataset): string => {
   });
 };
 
-const buildTooltipTitle = (dataset: IDataset): string => {
+const buildTooltipTitle = (dataset: DatasetMapItem): string => {
   const place = dataset.admin_level_3 || dataset.admin_level_2 || "";
   const country = dataset.admin_level_1 || "";
 
@@ -218,7 +220,7 @@ const DatasetMapOL = ({
   colorMode = "quality",
   onMapInteracted,
 }: {
-  data: IDataset[];
+  data: DatasetMapItem[];
   hoveredItem: number | null;
   setHoveredItem: (id: number | null) => void;
   setVisibleFeatures: (ids: string[]) => void;

--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -258,6 +258,8 @@ const DeadtreesMap = () => {
     DEFAULT_WAYBACK_RELEASE,
   );
   const [autoMatchImagery, setAutoMatchImagery] = useState(true); // Auto-match imagery to prediction year
+  const [shouldLoadLocalWaybackItems, setShouldLoadLocalWaybackItems] =
+    useState(false);
 
   // Track map center in lon/lat for location-specific wayback queries
   const [mapCenterLonLat, setMapCenterLonLat] = useState<{
@@ -279,7 +281,7 @@ const DeadtreesMap = () => {
       mapCenterLonLat?.lon,
       mapCenterLonLat?.lat,
       currentZoom,
-      DeadwoodMapStyle === "wayback", // Only fetch when wayback basemap is active
+      DeadwoodMapStyle === "wayback" && shouldLoadLocalWaybackItems,
     );
 
   useMobileImageryAutoSelect({
@@ -620,6 +622,21 @@ const DeadtreesMap = () => {
   }, []);
 
   // effects -----------------------------------------------------------
+
+  useEffect(() => {
+    if (DeadwoodMapStyle !== "wayback" || shouldLoadLocalWaybackItems) return;
+
+    const loadLocalImagery = () => setShouldLoadLocalWaybackItems(true);
+    if (typeof window.requestIdleCallback === "function") {
+      const idleHandle = window.requestIdleCallback(loadLocalImagery, {
+        timeout: 3000,
+      });
+      return () => window.cancelIdleCallback(idleHandle);
+    }
+
+    const timeoutHandle = window.setTimeout(loadLocalImagery, 1500);
+    return () => window.clearTimeout(timeoutHandle);
+  }, [DeadwoodMapStyle, shouldLoadLocalWaybackItems]);
 
   // update on bounds change after geocoder search
   useEffect(() => {
@@ -1100,6 +1117,9 @@ const DeadtreesMap = () => {
       setDeadwoodMapStyle((currentStyle) =>
         currentStyle === style ? "none" : style,
       );
+      if (style === "wayback") {
+        setShouldLoadLocalWaybackItems(true);
+      }
     },
     [setDeadwoodMapStyle],
   );
@@ -1331,22 +1351,26 @@ const DeadtreesMap = () => {
           isTracking={userLocation.isTracking}
           hasLocationFix={userLocation.hasFix}
           onLocate={() => locateUser(true)}
-          onOpenPanel={(panel) =>
+          onOpenPanel={(panel) => {
+            if (panel === "time") {
+              setShouldLoadLocalWaybackItems(true);
+            }
             setMobileMapPanel((currentPanel) =>
               currentPanel === panel ? null : panel,
-            )
-          }
+            );
+          }}
         />
 
         <MobileTimePill
           year={selectedYear}
           active={mobileMapPanel === "time"}
           hidden={hideMobileFloatingControls}
-          onClick={() =>
+          onClick={() => {
+            setShouldLoadLocalWaybackItems(true);
             setMobileMapPanel((currentPanel) =>
               currentPanel === "time" ? null : "time",
-            )
-          }
+            );
+          }}
         />
 
         <MobileAddTreeButton

--- a/frontend/src/components/ListItem.tsx
+++ b/frontend/src/components/ListItem.tsx
@@ -1,6 +1,6 @@
 import { Button, Tag, Tooltip } from "antd";
 import { useNavigate } from "react-router-dom";
-import { IDataset } from "../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../types/dataset";
 import { Settings } from "../config";
 import countryList from "../utils/countryList";
 import { useDatasetDetailsMap } from "../hooks/useDatasetDetailsMapProvider";
@@ -11,7 +11,7 @@ import {
 } from "../utils/biomeDisplay";
 
 interface ListItemProps {
-  item: IDataset;
+  item: IDataset | IDatasetArchiveItem;
   index: number;
   setHoveredItem: ((id: number | null) => void) | undefined;
   hoveredItem: number | null;
@@ -49,7 +49,7 @@ const ListItem = ({
     }
   };
 
-  const onClickHandler = (item: IDataset) => {
+  const onClickHandler = (item: IDataset | IDatasetArchiveItem) => {
     setNavigationSource("dataset");
     navigate(`/dataset/${item.id}`);
   };

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -49,6 +49,7 @@ export const Settings = {
 
   DATA_TABLE_FULL: "v2_full_dataset_view", // For admin/audit use (includes excluded datasets)
   DATA_TABLE_PUBLIC: "v2_full_dataset_view_public", // For public use (excludes excluded datasets)
+  DATASET_ARCHIVE_ITEMS_VIEW: "public_dataset_archive_items",
   HOME_STATS_VIEW: "public_home_stats",
   HOME_DATASET_TEASERS_VIEW: "public_home_dataset_teasers",
   THUMBNAILS_TABLE: "v2_thumbnails",

--- a/frontend/src/hooks/useDataProvider.tsx
+++ b/frontend/src/hooks/useDataProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo, useState } from "react";
-import { usePublicDatasets, useUserDatasets, useAuthors } from "./useDatasets";
-import { IDataset, IThumbnail } from "../types/dataset";
+import { usePublicDatasetArchiveItems, usePublicDatasets, useUserDatasets, useAuthors } from "./useDatasets";
+import { IDataset, IDatasetArchiveItem, IThumbnail } from "../types/dataset";
 import { useLocation } from "react-router-dom";
 
 interface DataProviderProps {
@@ -13,7 +13,7 @@ interface AuthorOption {
 }
 
 type DataContextType = {
-  data: IDataset[] | undefined;
+  data: Array<IDataset | IDatasetArchiveItem> | undefined;
   filter: string;
   setFilter: (filter: string) => void;
   setFilterTag: (filterTag: string) => void;
@@ -47,9 +47,19 @@ const DataProvider = ({ children }: DataProviderProps) => {
     return false;
   }, [location.pathname]);
 
-  const { data: rawData, isLoading: isLoadingRawData } = usePublicDatasets({ enabled: shouldFetchDataContext });
+  const shouldFetchArchiveContext = location.pathname === "/dataset";
+  const shouldFetchFullPublicContext = shouldFetchDataContext && !shouldFetchArchiveContext;
+  const shouldFetchUserDatasets = location.pathname.startsWith("/profile");
+  const { data: publicData, isLoading: isLoadingPublicData } = usePublicDatasets({
+    enabled: shouldFetchFullPublicContext,
+  });
+  const { data: archiveData, isLoading: isLoadingArchiveData } = usePublicDatasetArchiveItems({
+    enabled: shouldFetchArchiveContext,
+  });
+  const rawData = shouldFetchArchiveContext ? archiveData : publicData;
+  const isLoadingRawData = shouldFetchArchiveContext ? isLoadingArchiveData : isLoadingPublicData;
   const { data: authors } = useAuthors({ enabled: shouldFetchDataContext });
-  const { data: userData } = useUserDatasets({ enabled: shouldFetchDataContext });
+  const { data: userData } = useUserDatasets({ enabled: shouldFetchUserDatasets });
 
   const [filter, setFilter] = useState<string>("");
   const [filterTag, setFilterTag] = useState<string>("");

--- a/frontend/src/hooks/useDatasets.ts
+++ b/frontend/src/hooks/useDatasets.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "./useAuthProvider";
 import { supabase } from "./useSupabase";
 import { Settings } from "../config";
-import { IDataset } from "../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../types/dataset";
 import { fixTextEncoding } from "../utils/textUtils";
 
 interface DatasetQueryOptions {
@@ -40,6 +40,26 @@ export function usePublicDatasets(options: DatasetQueryOptions = {}) {
     enabled: (options.enabled ?? true) && status !== "checking",
     staleTime: 5 * 60 * 1000, // 5 minutes - data is fresh for 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache for 10 minutes
+  });
+}
+
+// Public archive hook - narrow rows for the /dataset archive list, timeline, filters, and map
+export function usePublicDatasetArchiveItems(options: DatasetQueryOptions = {}) {
+  const { status } = useAuth();
+
+  return useQuery({
+    queryKey: ["public-dataset-archive-items"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(Settings.DATASET_ARCHIVE_ITEMS_VIEW)
+        .select("*")
+        .order("id", { ascending: false });
+      if (error) throw error;
+      return data as IDatasetArchiveItem[];
+    },
+    enabled: (options.enabled ?? true) && status !== "checking",
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 }
 
@@ -104,7 +124,7 @@ export function useUserDatasets(options: DatasetQueryOptions = {}) {
 
 // Authors list - based on public datasets only
 export function useAuthors(options: DatasetQueryOptions = {}) {
-  const { data: datasets } = usePublicDatasets({ enabled: options.enabled });
+  const { data: datasets } = usePublicDatasetArchiveItems({ enabled: options.enabled });
 
   return useQuery({
     queryKey: ["authors"],

--- a/frontend/src/hooks/useFilteredDatasets.ts
+++ b/frontend/src/hooks/useFilteredDatasets.ts
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
-import { IDataset } from "../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../types/dataset";
 import { useDatasetFilter } from "./useDatasetFilterProvider";
 
-export function useFilteredDatasets(datasets: IDataset[] | undefined) {
+type FilterableDataset = IDataset | IDatasetArchiveItem;
+
+export function useFilteredDatasets<TDataset extends FilterableDataset>(datasets: TDataset[] | undefined) {
   const { filter, filterTag, advancedFilters } = useDatasetFilter();
 
   const filteredData = useMemo(() => {

--- a/frontend/src/hooks/useUploadTimeline.ts
+++ b/frontend/src/hooks/useUploadTimeline.ts
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { IDataset } from "../types/dataset";
+import { IDataset, IDatasetArchiveItem } from "../types/dataset";
+
+type TimelineDataset = IDataset | IDatasetArchiveItem;
 
 type ParsedDataset = {
-  dataset: IDataset;
+  dataset: TimelineDataset;
   createdAtMs: number;
   year: number;
   quarter: number;
@@ -37,12 +39,12 @@ interface UploadTimelineResult {
   periods: string[];
   selectedPeriod: string;
   setSelectedPeriod: (period: string) => void;
-  displayData: IDataset[] | null;
+  displayData: TimelineDataset[] | null;
   cumulativeCount: number;
   addedInQuarter: number;
 }
 
-export function useUploadTimeline(processedData: IDataset[] | null): UploadTimelineResult {
+export function useUploadTimeline(processedData: TimelineDataset[] | null): UploadTimelineResult {
   const [selectedPeriod, setSelectedPeriod] = useState<string>("");
 
   const parsedDatasets = useMemo<ParsedDataset[] | null>(() => {
@@ -134,7 +136,7 @@ export function useUploadTimeline(processedData: IDataset[] | null): UploadTimel
 
   const selectedMeta = selectedPeriod ? periodByKey[selectedPeriod] : undefined;
 
-  const displayData = useMemo<IDataset[] | null>(() => {
+  const displayData = useMemo<TimelineDataset[] | null>(() => {
     if (!processedData) return null;
     if (!parsedDatasets || !selectedMeta) return processedData;
 

--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -18,11 +18,10 @@ import DatasetMapOL, {
 import DatasetTimelineControl from "../components/DatasetMap/DatasetTimelineControl";
 import { useNavigate } from "react-router-dom";
 import { useFilteredDatasets } from "../hooks/useFilteredDatasets";
-import { usePublicDatasets } from "../hooks/useDatasets";
+import { usePublicDatasetArchiveItems } from "../hooks/useDatasets";
 import { useUploadTimeline } from "../hooks/useUploadTimeline";
 import FilterModal, { AdvancedFilters } from "../components/FilterModal";
 import { useDatasetFilter } from "../hooks/useDatasetFilterProvider";
-import { isDatasetViewable } from "../utils/datasetVisibility";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useDesktopOnlyFeature } from "../hooks/useDesktopOnlyFeature";
 import { useAnalytics } from "../hooks/useAnalytics";
@@ -42,7 +41,7 @@ const FLOAT_BUTTON_SIZE_PX = 36;
 
 export default function Dataset() {
   const navigate = useNavigate();
-  const { data: allData } = usePublicDatasets();
+  const { data: allData } = usePublicDatasetArchiveItems();
   const { filteredData } = useFilteredDatasets(allData);
 
   // Get filter state from context
@@ -132,9 +131,6 @@ export default function Dataset() {
     if (!filteredData) return null;
 
     const filtered = filteredData.filter((d) => {
-      // Use centralized visibility check
-      if (!isDatasetViewable(d)) return false;
-
       // If no search value, return true for the base condition
       if (!searchValue.trim()) return true;
 

--- a/frontend/src/types/dataset.ts
+++ b/frontend/src/types/dataset.ts
@@ -108,6 +108,42 @@ export interface IDataset {
   show_forest_cover_predictions: boolean;
 }
 
+export type IDatasetArchiveItem = Pick<
+  IDataset,
+  | "id"
+  | "created_at"
+  | "license"
+  | "platform"
+  | "authors"
+  | "aquisition_year"
+  | "aquisition_month"
+  | "aquisition_day"
+  | "bbox"
+  | "thumbnail_path"
+  | "admin_level_1"
+  | "admin_level_2"
+  | "admin_level_3"
+  | "biome_name"
+  | "has_labels"
+  | "has_deadwood_prediction"
+> &
+  Partial<
+    Pick<
+      IDataset,
+      | "is_cog_done"
+      | "is_thumbnail_done"
+      | "is_metadata_done"
+      | "has_error"
+      | "is_deadwood_done"
+      | "is_forest_cover_done"
+      | "is_audited"
+      | "final_assessment"
+      | "deadwood_quality"
+      | "forest_cover_quality"
+      | "has_major_issue"
+    >
+  >;
+
 export interface ILabels {
   id: number;
   dataset_id: number;

--- a/supabase/migrations/20260622080000_add_public_dataset_archive_items.sql
+++ b/supabase/migrations/20260622080000_add_public_dataset_archive_items.sql
@@ -1,0 +1,110 @@
+drop view if exists "public"."public_dataset_archive_items";
+
+create or replace view "public"."public_dataset_archive_items" as
+with latest_status as (
+  select distinct on (dataset_id)
+    dataset_id,
+    is_cog_done,
+    is_thumbnail_done,
+    is_deadwood_done,
+    is_forest_cover_done,
+    is_metadata_done,
+    has_error
+  from v2_statuses
+  order by dataset_id, updated_at desc, id desc
+),
+archive_base as (
+  select
+    d.id,
+    d.created_at,
+    d.license,
+    d.platform,
+    d.authors,
+    d.aquisition_year,
+    d.aquisition_month,
+    d.aquisition_day,
+    o.bbox,
+    thumb.thumbnail_path,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_1'::text) as admin_level_1,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_2'::text) as admin_level_2,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_3'::text) as admin_level_3,
+    ((meta.metadata ->> 'biome'::text)::jsonb ->> 'biome_name'::text) as biome_name,
+    s.is_cog_done,
+    s.is_thumbnail_done,
+    s.is_metadata_done,
+    s.has_error,
+    s.is_deadwood_done,
+    s.is_forest_cover_done
+  from v2_datasets d
+  join latest_status s on s.dataset_id = d.id
+  join v2_orthos o on o.dataset_id = d.id
+  left join v2_thumbnails thumb on thumb.dataset_id = d.id
+  left join v2_metadata meta on meta.dataset_id = d.id
+  where d.data_access <> 'private'::access
+    and d.archived = false
+),
+label_info as (
+  select
+    dataset.id as dataset_id,
+    exists (
+      select 1
+      from v2_labels
+      where v2_labels.dataset_id = dataset.id
+        and v2_labels.label_source = 'visual_interpretation'::"LabelSource"
+        and v2_labels.label_data = 'deadwood'::"LabelData"
+    ) as has_labels,
+    exists (
+      select 1
+      from v2_labels
+      where v2_labels.dataset_id = dataset.id
+        and v2_labels.label_source = 'model_prediction'::"LabelSource"
+        and v2_labels.label_data = 'deadwood'::"LabelData"
+    ) as has_deadwood_prediction
+  from v2_datasets dataset
+  where dataset.data_access <> 'private'::access
+    and dataset.archived = false
+),
+audit_data as (
+  select
+    da.dataset_id,
+    da.final_assessment
+  from dataset_audit da
+)
+select
+  base.id,
+  base.created_at,
+  base.license,
+  base.platform,
+  base.authors,
+  base.aquisition_year,
+  base.aquisition_month,
+  base.aquisition_day,
+  base.bbox,
+  base.thumbnail_path,
+  base.admin_level_1,
+  base.admin_level_2,
+  base.admin_level_3,
+  base.biome_name,
+  coalesce(label_info.has_labels, false) as has_labels,
+  coalesce(label_info.has_deadwood_prediction, false) as has_deadwood_prediction
+from archive_base base
+left join label_info on label_info.dataset_id = base.id
+left join audit_data on audit_data.dataset_id = base.id
+where base.is_cog_done = true
+  and base.is_thumbnail_done = true
+  and base.is_metadata_done = true
+  and base.admin_level_1 is not null
+  and (
+    base.has_error = false
+    or (base.is_deadwood_done = true and base.is_forest_cover_done = false)
+  )
+  and (
+    audit_data.final_assessment is null
+    or audit_data.final_assessment <> 'exclude_completely'::text
+  );
+
+alter view public.public_dataset_archive_items set (security_invoker = true);
+
+grant select on table "public"."public_dataset_archive_items" to "anon";
+grant select on table "public"."public_dataset_archive_items" to "authenticated";
+grant select on table "public"."public_dataset_archive_items" to "service_role";

--- a/supabase/seeds/qa/qa-base.sql
+++ b/supabase/seeds/qa/qa-base.sql
@@ -265,15 +265,16 @@ insert into public.v2_orthos (
 	ortho_file_name,
 	version,
 	sha256,
+	bbox,
 	ortho_upload_runtime,
 	ortho_file_size,
 	ortho_info
 )
 values
-	(91001, 'qa-public-complete.tif', 1, 'qa-public-complete-sha256', 0.1, 123456, '{}'::jsonb),
-	(91002, 'qa-public-audited.tif', 1, 'qa-public-audited-sha256', 0.1, 123456, '{}'::jsonb),
-	(91003, 'qa-private-contributor.tif', 1, 'qa-private-contributor-sha256', 0.1, 123456, '{}'::jsonb),
-	(91004, 'qa-processing-error.tif', 1, 'qa-processing-error-sha256', 0.1, 123456, '{}'::jsonb);
+	(91001, 'qa-public-complete.tif', 1, 'qa-public-complete-sha256', 'BOX(7.80 47.95,7.88 48.02)'::box2d, 0.1, 123456, '{}'::jsonb),
+	(91002, 'qa-public-audited.tif', 1, 'qa-public-audited-sha256', 'BOX(8.60 50.08,8.72 50.18)'::box2d, 0.1, 123456, '{}'::jsonb),
+	(91003, 'qa-private-contributor.tif', 1, 'qa-private-contributor-sha256', 'BOX(7.70 47.90,7.76 47.96)'::box2d, 0.1, 123456, '{}'::jsonb),
+	(91004, 'qa-processing-error.tif', 1, 'qa-processing-error-sha256', 'BOX(9.00 48.70,9.05 48.75)'::box2d, 0.1, 123456, '{}'::jsonb);
 
 insert into public.v2_cogs (
 	dataset_id,
@@ -307,10 +308,10 @@ insert into public.v2_metadata (
 	processing_runtime
 )
 values
-	(91001, '{"qa": true, "admin_level_1": "Germany", "admin_level_2": "Bavaria", "admin_level_3": "QA Forest"}'::jsonb, 1, 0.1),
-	(91002, '{"qa": true, "admin_level_1": "Germany", "admin_level_2": "Hesse", "admin_level_3": "QA Audited Forest"}'::jsonb, 1, 0.1),
-	(91003, '{"qa": true, "admin_level_1": "Germany", "admin_level_2": "Private QA", "admin_level_3": "QA Contributor Forest"}'::jsonb, 1, 0.1),
-	(91004, '{"qa": true, "admin_level_1": "Germany", "admin_level_2": "Error QA", "admin_level_3": "QA Processing Forest"}'::jsonb, 1, 0.1);
+	(91001, '{"qa": true, "gadm": {"admin_level_1": "Germany", "admin_level_2": "Bavaria", "admin_level_3": "QA Forest"}, "biome": {"biome_name": "Temperate Broadleaf and Mixed Forests"}}'::jsonb, 1, 0.1),
+	(91002, '{"qa": true, "gadm": {"admin_level_1": "Germany", "admin_level_2": "Hesse", "admin_level_3": "QA Audited Forest"}, "biome": {"biome_name": "Temperate Broadleaf and Mixed Forests"}}'::jsonb, 1, 0.1),
+	(91003, '{"qa": true, "gadm": {"admin_level_1": "Germany", "admin_level_2": "Private QA", "admin_level_3": "QA Contributor Forest"}, "biome": {"biome_name": "Temperate Broadleaf and Mixed Forests"}}'::jsonb, 1, 0.1),
+	(91004, '{"qa": true, "gadm": {"admin_level_1": "Germany", "admin_level_2": "Error QA", "admin_level_3": "QA Processing Forest"}, "biome": {"biome_name": "Temperate Broadleaf and Mixed Forests"}}'::jsonb, 1, 0.1);
 
 insert into public.dataset_audit (
 	dataset_id,


### PR DESCRIPTION
## What changed
- Adds `public_dataset_archive_items`, a narrow public archive read model that applies public/archive visibility in SQL.
- Switches `/dataset` and archive authors/filter data to the narrow archive hook while keeping dataset detail pages on the full public row hook.
- Defers `/deadtrees` Wayback local release/metadata loading until browser idle or explicit imagery intent, while the default selected imagery still paints immediately.
- Extends the read-only Playwright smoke to catch archive full-view `select=*` regressions and early Wayback metadata fanout.
- Updates QA seed metadata/bbox shape so local archive read-model browser smoke has visible rows.

## Why
DT-547: `/dataset` was blocked by `v2_full_dataset_view_public?select=*` (16.8 MB, ~3.7s in-browser), and `/deadtrees` painted quickly but fanned out Wayback metadata before user intent.

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- `scripts/qa/env.sh up`
- `scripts/qa/env.sh reset`
- `scripts/qa/validate-isolated-env.sh`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:59373 PLAYWRIGHT_PORT=59373 npm --prefix frontend run test:e2e -- e2e/data-factory-readonly.spec.ts -g "archive journey|satellite map"`
- `scripts/test-api-smoke.sh` (114 passed)
- Local route probe: `/dataset` first list item 1278 ms, archive map viewport 1294 ms; `/deadtrees` controls 812 ms; `/dataset/91001` detail controls/download 1195-1197 ms. Probe assertions: archive uses `public_dataset_archive_items`, avoids `v2_full_dataset_view_public?select=*`, and has 0 early Wayback metadata requests before controls.
- Production-shaped read-only SQL sizing: old `v2_full_dataset_view_public` JSON 15.43 MiB / 7,329 rows; new archive projection 3.82 MiB / 7,148 rows (~75% reduction).

## Risk / limitations
- Live `/dataset` timing improvement can only be measured after this migration deploys; the PR includes production-shaped SQL payload evidence and local browser readiness evidence.
- The archive route no longer receives full audit/status fields; that is intentional because current archive list/search/filter/timeline/map controls do not render those fields.

Linear: https://linear.app/geosense-ufr/issue/DT-547/optimize-dataset-archive-and-satellite-map-loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dataset archive view with integrated search and filtering capabilities
  * Improved map performance by deferring imagery requests until explicitly triggered during map interaction

* **Tests**
  * Added end-to-end tests validating archive dataset navigation and map functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->