### PR TITLE
Fix/tcd gpu inference

### DIFF
--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -59,3 +59,16 @@ services:
       - /dev/nvidia-modeset:/dev/nvidia-modeset
       - /dev/nvidia-uvm:/dev/nvidia-uvm
       - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+
+  # Build-only service for the TCD tree-cover inference image. The processor
+  # never runs this via compose — it launches `deadtrees-tcd:latest` ad-hoc
+  # through the mounted Docker socket. Declaring it here makes the image part of
+  # the standard deploy build (`docker compose build processor tcd`) so it is
+  # rebuilt from version control and can't drift onto a stale (e.g. wrong-CUDA,
+  # CPU-only) image. The `build` profile keeps it out of `docker compose up`.
+  tcd:
+    image: deadtrees-tcd:latest
+    profiles: ["build"]
+    build:
+      context: ./processor/src/treecover_segmentation_oam_tcd
+      dockerfile: Dockerfile

--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -55,13 +55,23 @@ host-local cron setup on `processing-server`:
 - fetches `origin/main`
 - compares local `HEAD` with `origin/main`
 - runs `git pull origin main` when a new commit is available
-- runs `docker compose -f docker-compose.processor.yaml build processor`
+- runs `docker compose -f docker-compose.processor.yaml build processor tcd`
 - writes status to `/home/jj1049/prod/deadtrees/auto-deploy.log`
 
 `docker-compose.processor.yaml` builds the processor locally on the processing
 server and bind-mounts `./processor`, `./shared`, `./assets`, `/data`, and the
 Docker socket. It uses the NVIDIA runtime and does not consume the API image
 published by the release workflow.
+
+The `tcd` service is a build-only service (gated behind the `build` profile, so
+`docker compose up` never starts it). It exists solely so the deploy rebuilds the
+`deadtrees-tcd:latest` tree-cover inference image — which the processor launches
+ad-hoc through the Docker socket — from version control. Without `tcd` in the
+build command, a Dockerfile change under
+`processor/src/treecover_segmentation_oam_tcd/` (e.g. the torch CUDA build) never
+reaches production and the processor keeps launching a stale image. The TCD image
+build is heavy but layer-cached, so it only does real work when that Dockerfile or
+its base image changes.
 
 Useful verification commands:
 

--- a/processor/src/treecover_segmentation_oam_tcd/Dockerfile
+++ b/processor/src/treecover_segmentation_oam_tcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.7.1-cuda11.8-cudnn9-runtime
 ENV TZ=Europe/Zurich
 
 # set bash as current shell
@@ -46,17 +46,14 @@ ENV PATH=/home/deadtrees/.local/bin:$PATH
 # Switch to root to install packages system-wide (for root access like ODM)
 USER root
 
-# Pin torch/torchvision to a CUDA 12.1 build. tcd's requirements only ask for
-# `torch>=2` with unpinned torchvision, so an unconstrained install pulls the
-# latest cu130 wheel — too new for CUDA 12.x host drivers, which makes torch
-# silently disable CUDA and run inference on CPU. A cu121 build is portable
-# across the GPU fleet (any driver supporting CUDA >= 12.1 runs it).
-RUN python -m pip install --no-cache-dir \
-    torch==2.3.0+cu121 torchvision==0.18.0+cu121 \
-    --index-url https://download.pytorch.org/whl/cu121
-
-# Constrain the rest of the install so the unpinned deps can't upgrade torch.
-RUN printf 'torch==2.3.0\ntorchvision==0.18.0\n' > /tmp/torch-constraints.txt
+# The base image ships torch 2.7.1 built for CUDA 11.8 (cu118). tcd requires
+# torch>=2.7.0, so the base already satisfies it and pip won't upgrade torch —
+# avoiding the latest cu130 wheel, which is too new for the GPU host drivers
+# (prod CUDA 12.2, dev 12.8) and would make torch silently fall back to CPU. cu118
+# runs on any driver >= 11.8, covering the whole GPU fleet. The constraint locks
+# torch's CUDA build so an unpinned transitive dep (e.g. torchvision) can't quietly
+# pull a cu126/cu128/cu130 wheel the prod driver can't run.
+RUN printf 'torch==2.7.1\n' > /tmp/torch-constraints.txt
 RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt python -m pip install --no-cache-dir -r requirements.txt
 RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt python -m pip install --no-cache-dir -e .
 

--- a/processor/src/treecover_segmentation_oam_tcd/Dockerfile
+++ b/processor/src/treecover_segmentation_oam_tcd/Dockerfile
@@ -45,8 +45,20 @@ ENV PATH=/home/deadtrees/.local/bin:$PATH
 
 # Switch to root to install packages system-wide (for root access like ODM)
 USER root
-RUN python -m pip install --no-cache-dir -r requirements.txt
-RUN python -m pip install --no-cache-dir -e .
+
+# Pin torch/torchvision to a CUDA 12.1 build. tcd's requirements only ask for
+# `torch>=2` with unpinned torchvision, so an unconstrained install pulls the
+# latest cu130 wheel — too new for CUDA 12.x host drivers, which makes torch
+# silently disable CUDA and run inference on CPU. A cu121 build is portable
+# across the GPU fleet (any driver supporting CUDA >= 12.1 runs it).
+RUN python -m pip install --no-cache-dir \
+    torch==2.3.0+cu121 torchvision==0.18.0+cu121 \
+    --index-url https://download.pytorch.org/whl/cu121
+
+# Constrain the rest of the install so the unpinned deps can't upgrade torch.
+RUN printf 'torch==2.3.0\ntorchvision==0.18.0\n' > /tmp/torch-constraints.txt
+RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt python -m pip install --no-cache-dir -r requirements.txt
+RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt python -m pip install --no-cache-dir -e .
 
 # Create the entrypoint script
 COPY --chown=deadtrees:deadtrees entrypoint.sh /home/deadtrees/entrypoint.sh

--- a/processor/src/treecover_segmentation_oam_tcd/predict_treecover.py
+++ b/processor/src/treecover_segmentation_oam_tcd/predict_treecover.py
@@ -397,12 +397,14 @@ def _run_tcd_pipeline_container(volume_name: str, dataset_id: int, token: str) -
 					)
 
 		try:
-			container_output = _run_and_wait(device_requests=None)
+			container_output = _run_and_wait(
+				device_requests=[docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])]
+			)
 		except _TCDContainerTimeout:
 			raise
 		except Exception as gpu_err:
 			logger.warning(
-				f'TCD container execution failed, retrying once: {gpu_err}',
+				f'TCD container GPU execution failed, retrying once on CPU: {gpu_err}',
 				LogContext(category=LogCategory.TREECOVER, token=token, dataset_id=dataset_id),
 			)
 			container_output = _run_and_wait(device_requests=None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tree cover detection now attempts GPU execution first, with automatic CPU fallback if GPU processing fails.

* **Documentation**
  * Updated deployment documentation to reflect the latest build process for tree cover detection service.

* **Chores**
  * Updated PyTorch and CUDA dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->