### PR TITLE
fix(audit): decouple audit-ready gate from v2 segmentation pipeline

### DIFF
--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -45,7 +45,7 @@ import { useDatasetLogs, useProcessingOverview, ProcessingOverviewRow, Processin
 import { getAcquisitionPeriod } from "../utils/phenologyUtils";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useAnalytics } from "../hooks/useAnalytics";
-import { isDatasetProcessingComplete } from "../utils/processingSteps";
+import { isDatasetReadyForAudit } from "../utils/processingSteps";
 
 const { Title, Text } = Typography;
 
@@ -85,9 +85,11 @@ const formatHours = (value: number | null | undefined): string => {
 	return `${value.toFixed(1)}h`;
 };
 
-// Helper function to check if dataset processing is complete
+// Helper function to check if a dataset is ready to be audited.
+// Auditing only depends on the legacy pipeline; it must not be gated on the v2
+// combined segmentation model, AOI generation, or the current processing status.
 const isProcessingComplete = (dataset: IDataset) => {
-	return dataset.is_thumbnail_done && isDatasetProcessingComplete(dataset);
+	return isDatasetReadyForAudit(dataset);
 };
 
 // Helper to format location

--- a/frontend/src/utils/processingSteps.test.ts
+++ b/frontend/src/utils/processingSteps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   calculateProcessingProgress,
   isDatasetProcessingComplete,
+  isDatasetReadyForAudit,
   type DatasetProgress,
 } from "./processingSteps";
 
@@ -131,5 +132,66 @@ describe("processing step completion", () => {
 
     expect(isDatasetProcessingComplete(dataset)).toBe(false);
     expect(isDatasetProcessingComplete({ ...dataset, is_odm_done: true })).toBe(true);
+  });
+});
+
+const auditReadyCore: DatasetProgress = {
+  ...completeCore,
+  is_thumbnail_done: true,
+  is_deadwood_done: true,
+  is_forest_cover_done: true,
+};
+
+describe("audit readiness", () => {
+  it("is ready once the legacy pipeline (incl. thumbnail + legacy predictions) is done", () => {
+    expect(isDatasetReadyForAudit(auditReadyCore)).toBe(true);
+  });
+
+  it("is not gated on the v2 segmentation pipeline", () => {
+    // Ready regardless of where v2 segmentation is: running, queued/required, errored, or done.
+    expect(
+      isDatasetReadyForAudit({
+        ...auditReadyCore,
+        current_status: "deadwood_treecover_combined_segmentation",
+        is_combined_model_done: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isDatasetReadyForAudit({
+        ...auditReadyCore,
+        current_status: "aoi_segmentation",
+        is_aoi_required: true,
+        is_aoi_done: false,
+      }),
+    ).toBe(true);
+
+    expect(isDatasetReadyForAudit({ ...auditReadyCore, has_error: true })).toBe(true);
+  });
+
+  it("requires the thumbnail", () => {
+    expect(isDatasetReadyForAudit({ ...auditReadyCore, is_thumbnail_done: false })).toBe(false);
+  });
+
+  it("requires legacy predictions and ignores combined-model-only output", () => {
+    expect(
+      isDatasetReadyForAudit({
+        ...auditReadyCore,
+        is_deadwood_done: false,
+        is_forest_cover_done: false,
+        is_combined_model_done: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires ODM completion only for raw image ZIP workflows", () => {
+    const dataset: DatasetProgress = {
+      ...auditReadyCore,
+      file_name: "raw-images.zip",
+      is_odm_done: false,
+    };
+
+    expect(isDatasetReadyForAudit(dataset)).toBe(false);
+    expect(isDatasetReadyForAudit({ ...dataset, is_odm_done: true })).toBe(true);
   });
 });

--- a/frontend/src/utils/processingSteps.ts
+++ b/frontend/src/utils/processingSteps.ts
@@ -51,6 +51,7 @@ export interface DatasetProgress {
   is_ortho_done?: boolean;
   is_metadata_done?: boolean;
   is_cog_done?: boolean;
+  is_thumbnail_done?: boolean;
   is_deadwood_done?: boolean;
   is_forest_cover_done?: boolean;
   is_combined_model_done?: boolean;
@@ -107,6 +108,30 @@ export function isDatasetProcessingComplete(dataset: DatasetProgress): boolean {
     dataset.is_cog_done &&
     isPredictionProcessingComplete(dataset) &&
     (!dataset.is_aoi_required || dataset.is_aoi_done)
+  );
+}
+
+/**
+ * Whether a dataset is ready to be audited.
+ *
+ * Auditing only concerns the legacy processing pipeline (ortho, metadata, COG,
+ * thumbnail, and the legacy deadwood + tree cover predictions). It is intentionally
+ * independent of the v2 combined segmentation model, AOI generation, and whatever
+ * processing status the dataset currently has: a dataset must be auditable as soon
+ * as its legacy outputs exist, regardless of whether/where v2 segmentation is in
+ * its pipeline (running, queued, errored, or done).
+ */
+export function isDatasetReadyForAudit(dataset: DatasetProgress): boolean {
+  const odmComplete = !isOdmWorkflow(dataset) || dataset.is_odm_done;
+
+  return !!(
+    dataset.is_upload_done &&
+    odmComplete &&
+    dataset.is_ortho_done &&
+    dataset.is_metadata_done &&
+    dataset.is_cog_done &&
+    dataset.is_thumbnail_done &&
+    isLegacyPredictionProcessingComplete(dataset)
   );
 }
 


### PR DESCRIPTION
## Problem

On the audit page (`/audit`), datasets stayed stuck in the **Pending** tab regardless of the v2 segmentation model's status. The Pending filter (and the "Start Audit" button gate) used `isDatasetProcessingComplete()` — the *full* v2 pipeline completion check — which mixes v2 state into audit readiness:

- `!hasActiveProcessingStatus` hid datasets while `current_status` was `deadwood_treecover_combined_segmentation` or `aoi_segmentation`.
- `isPredictionProcessingComplete` accepted the v2 combined model as a substitute for legacy predictions.
- `(!is_aoi_required || is_aoi_done)` gated readiness on the v2 AOI step.

So datasets whose **legacy** outputs were fully done were treated as not-ready-to-audit whenever v2 segmentation was running, queued, or required.

## Fix

- Add `isDatasetReadyForAudit()` in `processingSteps.ts`, depending only on the legacy pipeline (upload, ODM-if-zip, ortho, metadata, COG, thumbnail, legacy deadwood + tree-cover predictions). It ignores the combined model, AOI, `current_status`, and `has_error`, so v2 segmentation state — running, queued, errored, or done — never influences the audit queue.
- `DatasetAudit.tsx` now uses `isDatasetReadyForAudit` for the Pending filter, pending count, and Start-Audit gate.
- Added `is_thumbnail_done` to the `DatasetProgress` type.

## Behavior notes

- A **v2-only** dataset (combined model done, no legacy deadwood/forest-cover) is now treated as *not* audit-ready, since there are no legacy outputs to audit — consistent with "v2 output is not shown in the audit."
- The `has_error` gate was dropped so a v2-segmentation failure can't hide an otherwise-auditable dataset.

## Tests

5 new tests in `processingSteps.test.ts` (ready on legacy completion; ready regardless of v2 running/required/errored; thumbnail required; combined-model-only not auditable; ODM gate for ZIP). `vitest` 12/12 pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)