### PR TITLE
fix(processor): fall back to nearest valid pixel for phenology

### DIFF
--- a/processor/src/utils/phenology.py
+++ b/processor/src/utils/phenology.py
@@ -34,6 +34,47 @@ def get_phenology_path() -> Path:
 	return Path(settings.PHENOLOGY_DATA_PATH)
 
 
+def _find_nearest_valid_index(ds: xr.Dataset, x: float, y: float) -> Optional[Tuple[int, int]]:
+	"""
+	Find the (y, x) integer index of the nearest non-masked phenology pixel.
+
+	The phenology grid is gap-filled in time (each valid pixel has a full curve) but not in
+	space: ~87% of pixels are masked (ocean, projection corners, and land pixels where MODIS
+	derived no cycle). A dataset centroid near a coast/island can land on a masked pixel even
+	though valid phenology exists nearby. To guarantee every dataset gets a curve, when the
+	nearest pixel is masked we fall back to the globally nearest valid pixel, regardless of how
+	far away it is.
+
+	Args:
+	    ds: Open phenology dataset (dims y, x, day) with a boolean ``nan_mask`` (True = no data).
+	    x: Target x coordinate in MODIS sinusoidal meters.
+	    y: Target y coordinate in MODIS sinusoidal meters.
+
+	Returns:
+	    (yi, xi) of the nearest valid pixel, or None only if the grid has no valid pixels at all.
+	"""
+	xs = ds.x.values
+	ys = ds.y.values
+
+	xi = int(np.abs(xs - x).argmin())
+	yi = int(np.abs(ys - y).argmin())
+
+	# Fast path: nearest pixel already has data (true for ~94% of datasets).
+	if not bool(ds.nan_mask.isel(y=yi, x=xi).values):
+		return yi, xi
+
+	# Fallback: load the small (~7 MB) nan_mask and pick the globally nearest valid pixel.
+	mask = ds.nan_mask.values
+	valid_rows, valid_cols = np.where(~mask)
+	if valid_rows.size == 0:
+		return None
+
+	dy = valid_rows - yi
+	dx = valid_cols - xi
+	nearest = int(np.argmin(dy * dy + dx * dx))
+	return int(valid_rows[nearest]), int(valid_cols[nearest])
+
+
 def get_phenology_curve(
 	lat: float, lon: float, token: str = None, dataset_id: int = None, user_id: str = None
 ) -> Optional[List[int]]:
@@ -54,19 +95,19 @@ def get_phenology_curve(
 		# Open the dataset
 		ds = xr.open_zarr(get_phenology_path())
 
-		# Get the nearest pixel
-		ds_nearest = ds.sel(x=x, y=y, method='nearest')
+		# Get the nearest valid pixel, falling back to the globally nearest valid pixel when the
+		# nearest pixel is masked (e.g. coastal/island centroids). Only None if the grid is empty.
+		index = _find_nearest_valid_index(ds, x[0], y[0])
 
-		# Extract phenology data
-		pheno = ds_nearest.phenology.values[0][0]
-		is_nan = ds_nearest.nan_mask.values[0][0]
-
-		if is_nan:
+		if index is None:
 			logger.debug(
 				f'No phenology data available for coordinates ({lat}, {lon})',
 				LogContext(category=LogCategory.METADATA, dataset_id=dataset_id, user_id=user_id, token=token),
 			)
 			return None
+
+		yi, xi = index
+		pheno = ds.phenology.isel(y=yi, x=xi).values
 
 		# Convert to list of integers
 		phenology_curve = pheno.astype(int).tolist()

--- a/processor/tests/utils/test_phenology.py
+++ b/processor/tests/utils/test_phenology.py
@@ -1,5 +1,12 @@
+import xarray as xr
+
 import pytest
-from processor.src.utils.phenology import get_phenology_curve, get_phenology_metadata
+from processor.src.utils.phenology import (
+	get_phenology_curve,
+	get_phenology_metadata,
+	get_phenology_path,
+	_find_nearest_valid_index,
+)
 from shared.models import PhenologyMetadata
 
 pytestmark = pytest.mark.usefixtures('ensure_phenology_data')
@@ -16,8 +23,23 @@ TEST_POINTS_WITH_DATA = [
 	(50.0, 10.0),
 ]
 
-# Test points where no phenology data should exist (ocean locations)
-TEST_POINTS_NO_DATA = [
+# Coastal / island / tropical sites whose centroid lands on a masked MODIS pixel but which
+# have valid phenology nearby. These previously returned None; the nearest-valid fallback
+# should now recover them. (lat, lon) of real affected datasets.
+TEST_POINTS_FALLBACK = [
+	# Scotland (dataset 310)
+	(57.5520, -4.8183),
+	# Antigua, Caribbean (dataset 909/8164)
+	(17.0075, -61.7625),
+	# Seychelles (dataset 1167)
+	(-4.7591, 55.4808),
+	# Santiago, Chile (dataset 214)
+	(-33.4132, -70.3250),
+]
+
+# Open-ocean locations far from any land. With the unbounded nearest-valid fallback these no
+# longer return None: every coordinate resolves to the globally nearest valid (land) pixel.
+TEST_POINTS_REMOTE = [
 	# Atlantic Ocean
 	(30.0, -30.0),
 	# Pacific Ocean
@@ -38,12 +60,59 @@ def test_get_phenology_curve_with_data(lat, lon):
 	assert len(set(curve)) > 1
 
 
-@pytest.mark.parametrize('lat,lon', TEST_POINTS_NO_DATA)
-def test_get_phenology_curve_no_data(lat, lon):
-	"""Test phenology curve retrieval for ocean locations (should return None)"""
+@pytest.mark.parametrize('lat,lon', TEST_POINTS_FALLBACK)
+def test_get_phenology_curve_nearest_valid_fallback(lat, lon):
+	"""Coastal/island sites whose nearest pixel is masked should resolve via the fallback."""
 	curve = get_phenology_curve(lat, lon)
-	# Ocean locations should return None (no phenology data)
-	assert curve is None
+
+	assert isinstance(curve, list), f'Expected fallback to recover phenology at ({lat}, {lon})'
+	assert len(curve) == 366
+	assert all(isinstance(val, int) for val in curve)
+	assert all(0 <= val <= 255 for val in curve)
+	assert len(set(curve)) > 1
+
+
+@pytest.mark.parametrize('lat,lon', TEST_POINTS_REMOTE)
+def test_get_phenology_curve_always_resolves(lat, lon):
+	"""Even remote open-ocean coordinates resolve to the globally nearest valid pixel."""
+	curve = get_phenology_curve(lat, lon)
+
+	assert isinstance(curve, list), f'Expected a curve for ({lat}, {lon}); fallback should always resolve'
+	assert len(curve) == 366
+	assert all(0 <= val <= 255 for val in curve)
+
+
+def test_find_nearest_valid_index_returns_valid_pixel():
+	"""For a masked-centroid site, the helper returns an index that is not masked."""
+	from rasterio import crs, warp
+	from processor.src.utils.phenology import MODIS_CRS
+
+	# Scotland centroid (nearest pixel is masked)
+	lat, lon = 57.5520, -4.8183
+	x, y = warp.transform(crs.CRS.from_epsg(4326), MODIS_CRS, [lon], [lat])
+
+	ds = xr.open_zarr(get_phenology_path())
+	index = _find_nearest_valid_index(ds, x[0], y[0])
+
+	assert index is not None
+	yi, xi = index
+	assert not bool(ds.nan_mask.isel(y=yi, x=xi).values)
+
+
+def test_find_nearest_valid_index_open_ocean_resolves():
+	"""An open-ocean centroid still resolves to the globally nearest valid (land) pixel."""
+	from rasterio import crs, warp
+	from processor.src.utils.phenology import MODIS_CRS
+
+	lat, lon = 30.0, -30.0  # mid-Atlantic, no valid pixel nearby
+	x, y = warp.transform(crs.CRS.from_epsg(4326), MODIS_CRS, [lon], [lat])
+
+	ds = xr.open_zarr(get_phenology_path())
+	index = _find_nearest_valid_index(ds, x[0], y[0])
+
+	assert index is not None
+	yi, xi = index
+	assert not bool(ds.nan_mask.isel(y=yi, x=xi).values)
 
 
 def test_get_phenology_metadata_success():
@@ -59,12 +128,13 @@ def test_get_phenology_metadata_success():
 	assert metadata.version == '1.0'
 
 
-def test_get_phenology_metadata_no_data():
-	"""Test phenology metadata creation for ocean location (no data)"""
-	# Test with ocean coordinates (should have no data)
+def test_get_phenology_metadata_remote_resolves():
+	"""Remote ocean coordinates now resolve to nearest-land phenology instead of None."""
+	# Mid-Atlantic; with the unbounded fallback this resolves to the nearest valid pixel.
 	lat, lon = 30.0, -30.0
 	metadata = get_phenology_metadata(lat, lon)
-	assert metadata is None
+	assert isinstance(metadata, PhenologyMetadata)
+	assert len(metadata.phenology_curve) == 366
 
 
 def test_create_metadata_valid():

--- a/scripts/backfill_phenology.py
+++ b/scripts/backfill_phenology.py
@@ -1,0 +1,120 @@
+"""Backfill phenology metadata for datasets that currently have none.
+
+Some datasets have no ``phenology`` entry in ``v2_metadata.metadata`` because the dataset
+centroid landed on a masked MODIS pixel (coast/island/no-cycle area) and the old lookup gave
+up. The lookup now falls back to the globally nearest valid pixel, so this script recomputes
+phenology for the affected datasets and merges it into their existing metadata (GADM/biome are
+left untouched).
+
+Usage (from repo root, inside the processor environment / container):
+
+    python -m scripts.backfill_phenology --dry-run            # report what would change
+    python -m scripts.backfill_phenology                      # apply to all missing datasets
+    python -m scripts.backfill_phenology --dataset-ids 214 310 756   # only these
+    python -m scripts.backfill_phenology --limit 50           # cap how many are processed
+
+The script authenticates as the processor user (PROCESSOR_USERNAME/PASSWORD), so it must run in
+an environment where those credentials and the phenology asset are available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from shared.db import login, use_client
+from shared.models import Ortho
+from shared.settings import settings
+from shared.logger import logger
+from processor.src.utils.phenology import get_phenology_metadata
+
+
+def _missing_phenology_dataset_ids(client) -> list[int]:
+	"""Return dataset_ids whose metadata row exists but has no 'phenology' key."""
+	rows = client.table(settings.metadata_table).select('dataset_id, metadata').execute().data
+	missing = []
+	for row in rows:
+		metadata = row.get('metadata') or {}
+		if 'phenology' not in metadata:
+			missing.append(row['dataset_id'])
+	return missing
+
+
+def backfill(dataset_ids: Optional[list[int]], dry_run: bool, limit: Optional[int]) -> int:
+	"""Backfill phenology for the requested datasets. Returns the number updated."""
+	token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
+
+	with use_client(token) as client:
+		targets = dataset_ids if dataset_ids else _missing_phenology_dataset_ids(client)
+
+	if limit is not None:
+		targets = targets[:limit]
+
+	print(f'{len(targets)} dataset(s) to process{" (dry run)" if dry_run else ""}.')
+
+	updated = 0
+	skipped = 0
+	for dataset_id in targets:
+		# Refresh token periodically; cheap and avoids long-run expiry.
+		token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
+		with use_client(token) as client:
+			ortho_resp = client.table(settings.orthos_table).select('*').eq('dataset_id', dataset_id).execute()
+			if not ortho_resp.data:
+				print(f'  dataset {dataset_id}: no ortho row, skipping')
+				skipped += 1
+				continue
+			ortho = Ortho(**ortho_resp.data[0])
+			if not ortho.bbox:
+				print(f'  dataset {dataset_id}: no bbox, skipping')
+				skipped += 1
+				continue
+
+			lon = (ortho.bbox.left + ortho.bbox.right) / 2
+			lat = (ortho.bbox.bottom + ortho.bbox.top) / 2
+
+			phenology = get_phenology_metadata(lat=lat, lon=lon, dataset_id=dataset_id)
+			if phenology is None:
+				print(f'  dataset {dataset_id}: phenology still unavailable at ({lat:.4f}, {lon:.4f}), skipping')
+				skipped += 1
+				continue
+
+			meta_resp = client.table(settings.metadata_table).select('metadata').eq('dataset_id', dataset_id).execute()
+			if not meta_resp.data:
+				print(f'  dataset {dataset_id}: no metadata row, skipping')
+				skipped += 1
+				continue
+			metadata = meta_resp.data[0].get('metadata') or {}
+			metadata['phenology'] = phenology.model_dump()
+
+			if dry_run:
+				print(f'  dataset {dataset_id}: would add phenology (centroid {lat:.4f}, {lon:.4f})')
+			else:
+				client.table(settings.metadata_table).update({'metadata': metadata}).eq(
+					'dataset_id', dataset_id
+				).execute()
+				print(f'  dataset {dataset_id}: phenology added (centroid {lat:.4f}, {lon:.4f})')
+			updated += 1
+
+	print(f'Done. {updated} updated, {skipped} skipped.')
+	return updated
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+	parser.add_argument('--dataset-ids', type=int, nargs='*', help='Only backfill these dataset ids.')
+	parser.add_argument('--dry-run', action='store_true', help='Report changes without writing.')
+	parser.add_argument('--limit', type=int, default=None, help='Process at most this many datasets.')
+	args = parser.parse_args()
+
+	try:
+		backfill(args.dataset_ids, args.dry_run, args.limit)
+	except Exception as exc:  # noqa: BLE001 - surface a clear message for an operator-run script
+		logger.error(f'Phenology backfill failed: {exc}')
+		print(f'ERROR: {exc}', file=sys.stderr)
+		return 1
+	return 0
+
+
+if __name__ == '__main__':
+	raise SystemExit(main())


### PR DESCRIPTION
## Problem

~6% of datasets (564 of 8,826) had no `phenology` entry in `v2_metadata`. Investigation showed the cause is the phenology lookup taking only the single **nearest** MODIS pixel and giving up if that pixel is masked — even though valid phenology exists right next to it.

The MODIS phenology zarr (`modispheno_aggregated_normalized_filled.zarr`) is gap-filled in **time** (each valid pixel has a full 366-day curve) but not in **space**: ~87% of pixels are masked (ocean, projection corners, and land pixels where MODIS derived no cycle). At ~9.3 km/pixel, the centroid of a drone ortho near a coast/island/lake easily lands on a masked pixel.

The missing datasets are overwhelmingly **coastal sites, small islands** (Caribbean, Kiribati atolls, Seychelles, Hawaii) **and tropical / Southern-Hemisphere** areas. Miss-rate is 0.7–1.2% in 40–60°N (where most data lives) but 9–20% in tropical/Southern bands — confirming it's the nearest-pixel masking, not a coverage gap.

## Fix

`get_phenology_curve` now falls back to the **globally nearest valid pixel** when the nearest pixel is masked, so every dataset resolves to a curve regardless of how far the nearest valid pixel is. The valid-pixel fast path is unchanged for the ~94% of datasets whose nearest pixel already has data.

Cost: fast path ~11 ms; fallback ~75–210 ms (loads the 7 MB `nan_mask` once and picks the nearest valid pixel) — once per dataset, negligible.

## Backfill

`scripts/backfill_phenology.py` recomputes phenology for existing datasets that currently have none and merges it into their metadata (GADM/biome untouched):

```bash
python -m scripts.backfill_phenology --dry-run     # preview
python -m scripts.backfill_phenology               # apply to all missing
python -m scripts.backfill_phenology --dataset-ids 214 310 756
```

Not run yet — it writes to the database; run `--dry-run` first.

## Tests

- New: `test_get_phenology_curve_nearest_valid_fallback` (real previously-missing sites: Scotland, Antigua, Seychelles, Chile), `test_get_phenology_curve_always_resolves` + `test_find_nearest_valid_index_*` (remote ocean now resolves to nearest land).
- Phenology suite: **17/17 pass**.
- Full processor suite: 202 passed, 1 failed — the failure (`test_uint16_scaling_produces_visible_output`, GDAL band handling) also fails on `main`, pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)