### PR TITLE
chore(scripts): quiet expected self-intersection NOTICEs in hole backfill

### DIFF
--- a/scripts/sql/filter_geometry_holes.sql
+++ b/scripts/sql/filter_geometry_holes.sql
@@ -46,6 +46,11 @@
 
 BEGIN;
 SET LOCAL statement_timeout = '10min';
+-- Pre-existing invalid geometries (self-intersecting rings) make PostGIS emit a
+-- flood of "Self-intersection" NOTICEs from ST_IsValid/ST_Buffer/ST_MakePolygon.
+-- They are expected and handled (such rows are skipped), so quiet them; the
+-- skipped-rows report below still surfaces the affected ids and reasons.
+SET LOCAL client_min_messages = warning;
 
 CREATE TEMP TABLE _hole_filter_candidate ON COMMIT DROP AS
 WITH params AS (


### PR DESCRIPTION
Raises `client_min_messages` to `warning` inside the backfill transaction so the expected flood of self-intersection NOTICEs (from pre-existing invalid geometries, which are detected and skipped) doesn't drown the output. The skipped-rows report still lists the affected ids and `ST_IsValidReason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy database NOTICE messages during geometry repair processing, making backfill runs easier to monitor.
  * Kept skipped-row reporting intact so affected records and reasons still surface clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->