### PR TITLE
ci(supabase): guard migration versions

### DIFF
--- a/.github/workflows/supabase-migration-guard.yml
+++ b/.github/workflows/supabase-migration-guard.yml
@@ -1,0 +1,126 @@
+name: Supabase Migration Guard
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+      - "scripts/check_supabase_migration_versions.py"
+      - ".github/workflows/supabase-migration-guard.yml"
+  pull_request_target:
+    paths:
+      - "supabase/migrations/**"
+      - "scripts/check_supabase_migration_versions.py"
+      - ".github/workflows/supabase-migration-guard.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  migration-filename-check:
+    name: migration-filename-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Test migration guard helper
+        run: python -m unittest scripts.tests.test_check_supabase_migration_versions
+
+      - name: Check migration filenames
+        run: |
+          python scripts/check_supabase_migration_versions.py \
+            --base-ref "${{ github.event.pull_request.base.sha }}" \
+            --head-ref "${{ github.event.pull_request.head.sha }}"
+
+  production-version-check:
+    name: production-version-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'pull_request_target' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Check trusted helper availability
+        id: trusted-helper
+        run: |
+          if [[ -f scripts/check_supabase_migration_versions.py ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::notice::Trusted migration guard helper is not on the base branch yet; skipping production-version-check for this bootstrap PR."
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - uses: actions/setup-python@v6
+        if: ${{ steps.trusted-helper.outputs.available == 'true' }}
+        with:
+          python-version: "3.11"
+
+      - name: Install psql
+        if: ${{ steps.trusted-helper.outputs.available == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
+      - name: Read changed PR files
+        if: ${{ steps.trusted-helper.outputs.available == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            --jq '.[]' \
+            | jq -s '.' \
+            > "${RUNNER_TEMP}/pr-files.json"
+
+          file_count="$(jq 'length' "${RUNNER_TEMP}/pr-files.json")"
+          if [[ "${file_count}" -ge 3000 ]]; then
+            echo "::error::GitHub's pull request files API returned ${file_count} files, so the migration guard cannot prove the changed-file list is complete."
+            exit 1
+          fi
+
+      - name: Read latest production migration version
+        if: ${{ steps.trusted-helper.outputs.available == 'true' }}
+        id: production-migrations
+        shell: bash
+        env:
+          SUPABASE_DB_URL_PROD: ${{ secrets.SUPABASE_DB_URL_PROD }}
+        run: |
+          if [[ -z "${SUPABASE_DB_URL_PROD}" ]]; then
+            echo "::error::SUPABASE_DB_URL_PROD secret is required for production migration checks."
+            exit 1
+          fi
+
+          latest_version="$(
+            psql "${SUPABASE_DB_URL_PROD}" \
+              -X \
+              -v ON_ERROR_STOP=1 \
+              -Atc "select coalesce(max(version::text), '') from supabase_migrations.schema_migrations;"
+          )"
+
+          if [[ -z "${latest_version}" ]]; then
+            echo "::error::Could not read any applied production migration versions."
+            exit 1
+          fi
+
+          echo "latest_version=${latest_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check PR migrations against production
+        if: ${{ steps.trusted-helper.outputs.available == 'true' }}
+        env:
+          LATEST_APPLIED_VERSION: ${{ steps.production-migrations.outputs.latest_version }}
+        run: |
+          python scripts/check_supabase_migration_versions.py \
+            --changed-files-json "${RUNNER_TEMP}/pr-files.json" \
+            --latest-applied-version "${LATEST_APPLIED_VERSION}"

--- a/scripts/check_supabase_migration_versions.py
+++ b/scripts/check_supabase_migration_versions.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Guard Supabase migration filenames against local and production collisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MIGRATION_RE = re.compile(r'^(?P<version>\d{14})_[A-Za-z0-9][A-Za-z0-9_.-]*\.sql$')
+MIGRATION_DIR = Path('supabase/migrations')
+
+
+@dataclass(frozen=True)
+class ChangedMigration:
+	status: str
+	path: Path
+	version: str
+	kind: str
+
+
+def run_git(args: list[str]) -> str:
+	result = subprocess.run(['git', *args], check=True, capture_output=True, text=True)
+	return result.stdout
+
+
+def migration_version(path: Path) -> str | None:
+	match = MIGRATION_RE.match(path.name)
+	if not match:
+		return None
+	return match.group('version')
+
+
+def invalid_changed_migration_message(path: Path) -> str:
+	return (
+		f'Invalid changed migration filename: {path}. Expected '
+		'<14-digit timestamp>_<description>.sql, for example '
+		'20260625093000_add_example_table.sql.'
+	)
+
+
+def check_all_migration_filenames(migrations_dir: Path) -> list[str]:
+	"""Validate the full migration directory so old hygiene drift blocks new migration work early."""
+	errors: list[str] = []
+	versions: dict[str, Path] = {}
+
+	for path in sorted(migrations_dir.glob('*.sql')):
+		version = migration_version(path)
+		if version is None:
+			errors.append(
+				f'Invalid migration filename: {path}. Expected '
+				'<14-digit timestamp>_<description>.sql, for example '
+				'20260625093000_add_example_table.sql.'
+			)
+			continue
+
+		previous = versions.get(version)
+		if previous is not None:
+			errors.append(
+				f'Duplicate migration version {version}: {previous} and {path}. '
+				'Supabase migration versions must be unique.'
+			)
+		else:
+			versions[version] = path
+
+	return errors
+
+
+def changed_migration_version(path: Path, errors: list[str]) -> str | None:
+	version = migration_version(path)
+	if version is None and path.suffix == '.sql':
+		errors.append(invalid_changed_migration_message(path))
+	return version
+
+
+def parse_changed_migrations(
+	migrations_dir: Path, base_ref: str, head_ref: str
+) -> tuple[list[ChangedMigration], list[str]]:
+	diff_output = run_git(
+		[
+			'diff',
+			'--name-status',
+			'--find-renames',
+			f'{base_ref}...{head_ref}',
+			'--',
+			str(migrations_dir),
+		]
+	)
+	changes: list[ChangedMigration] = []
+	errors: list[str] = []
+
+	for line in diff_output.splitlines():
+		if not line.strip():
+			continue
+
+		parts = line.split('\t')
+		status = parts[0]
+
+		if status.startswith('R') or status.startswith('C'):
+			if len(parts) != 3:
+				raise ValueError(f'Unexpected git diff rename/copy line: {line}')
+			old_path = Path(parts[1])
+			new_path = Path(parts[2])
+			old_version = changed_migration_version(old_path, errors)
+			new_version = changed_migration_version(new_path, errors)
+			if old_version is not None:
+				changes.append(ChangedMigration(status, old_path, old_version, 'existing'))
+			if new_version is not None:
+				changes.append(ChangedMigration(status, new_path, new_version, 'new'))
+			continue
+
+		if len(parts) != 2:
+			raise ValueError(f'Unexpected git diff line: {line}')
+
+		path = Path(parts[1])
+		version = changed_migration_version(path, errors)
+		if version is None:
+			continue
+
+		kind = 'new' if status == 'A' else 'existing'
+		changes.append(ChangedMigration(status, path, version, kind))
+
+	return changes, errors
+
+
+def parse_changed_migrations_from_pr_files(
+	migrations_dir: Path, pr_files: list[dict[str, str]]
+) -> tuple[list[ChangedMigration], list[str]]:
+	changes: list[ChangedMigration] = []
+	errors: list[str] = []
+	migration_prefix = f'{migrations_dir.as_posix().rstrip("/")}/'
+
+	for pr_file in pr_files:
+		status = pr_file.get('status', '')
+		filename = pr_file.get('filename', '')
+		previous_filename = pr_file.get('previous_filename')
+		filename_is_migration = filename.startswith(migration_prefix)
+		previous_is_migration = bool(previous_filename and previous_filename.startswith(migration_prefix))
+
+		if not filename_is_migration and not previous_is_migration:
+			continue
+
+		path = Path(filename)
+		if status == 'renamed' and previous_filename:
+			if previous_is_migration:
+				previous_path = Path(previous_filename)
+				previous_version = changed_migration_version(previous_path, errors)
+				if previous_version is not None:
+					changes.append(ChangedMigration(status, previous_path, previous_version, 'existing'))
+			if filename_is_migration:
+				version = changed_migration_version(path, errors)
+				if version is not None:
+					changes.append(ChangedMigration(status, path, version, 'new'))
+			continue
+
+		if filename_is_migration:
+			version = changed_migration_version(path, errors)
+			if version is not None:
+				kind = 'new' if status in {'added', 'copied'} else 'existing'
+				changes.append(ChangedMigration(status, path, version, kind))
+
+	return changes, errors
+
+
+def check_changed_migrations(changes: list[ChangedMigration], latest_applied_version: str | None) -> list[str]:
+	errors: list[str] = []
+
+	if not latest_applied_version:
+		return errors
+
+	if not re.fullmatch(r'\d{14}', latest_applied_version):
+		return [f'Invalid latest applied production migration version: {latest_applied_version!r}.']
+
+	for change in changes:
+		if change.kind == 'new' and change.version <= latest_applied_version:
+			errors.append(
+				f'New migration {change.path} has version {change.version}, but production '
+				f'has already applied migrations through {latest_applied_version}. Create a '
+				'new migration with a later timestamp.'
+			)
+		elif change.kind == 'existing' and change.version <= latest_applied_version:
+			errors.append(
+				f'Migration {change.path} has version {change.version}, which is already '
+				'applied in production. Do not modify, rename, or delete applied migrations; '
+				'add a new follow-up migration instead.'
+			)
+
+	return errors
+
+
+def print_result(errors: list[str], changes: list[ChangedMigration]) -> int:
+	if errors:
+		print('Supabase migration version check failed:', file=sys.stderr)
+		for error in errors:
+			print(f'- {error}', file=sys.stderr)
+		return 1
+
+	if changes:
+		changed_paths = ', '.join(str(change.path) for change in changes)
+		print(f'Supabase migration version check passed for changed migrations: {changed_paths}')
+	else:
+		print('Supabase migration version check passed; no migration files changed.')
+	return 0
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument('--migrations-dir', type=Path, default=MIGRATION_DIR)
+	parser.add_argument('--base-ref', help='Base git ref for PR diff checks.')
+	parser.add_argument('--head-ref', default='HEAD', help='Head git ref for PR diff checks.')
+	parser.add_argument(
+		'--latest-applied-version',
+		help='Latest version from supabase_migrations.schema_migrations on the target database.',
+	)
+	parser.add_argument(
+		'--changed-files-json',
+		type=Path,
+		help='GitHub pull request files API JSON. Used by trusted pull_request_target workflows.',
+	)
+	return parser.parse_args()
+
+
+def main() -> int:
+	args = parse_args()
+	print(f'Checking all migration filenames in {args.migrations_dir}.')
+	errors = check_all_migration_filenames(args.migrations_dir)
+	changes: list[ChangedMigration] = []
+
+	if args.changed_files_json:
+		with args.changed_files_json.open() as file:
+			pr_files = json.load(file)
+		changes, changed_errors = parse_changed_migrations_from_pr_files(args.migrations_dir, pr_files)
+		errors.extend(changed_errors)
+		errors.extend(check_changed_migrations(changes, args.latest_applied_version))
+	elif args.base_ref:
+		changes, changed_errors = parse_changed_migrations(args.migrations_dir, args.base_ref, args.head_ref)
+		errors.extend(changed_errors)
+		errors.extend(check_changed_migrations(changes, args.latest_applied_version))
+
+	return print_result(errors, changes)
+
+
+if __name__ == '__main__':
+	raise SystemExit(main())

--- a/scripts/tests/test_check_supabase_migration_versions.py
+++ b/scripts/tests/test_check_supabase_migration_versions.py
@@ -1,0 +1,261 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.check_supabase_migration_versions import (
+	ChangedMigration,
+	check_all_migration_filenames,
+	check_changed_migrations,
+	parse_changed_migrations,
+	parse_changed_migrations_from_pr_files,
+)
+
+
+class SupabaseMigrationVersionCheckTest(unittest.TestCase):
+	def test_rejects_duplicate_migration_versions(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			migrations = Path(temp_dir) / 'migrations'
+			migrations.mkdir()
+			(migrations / '20260625090000_first.sql').write_text('select 1;\n')
+			(migrations / '20260625090000_second.sql').write_text('select 2;\n')
+
+			errors = check_all_migration_filenames(migrations)
+
+		self.assertTrue(any('Duplicate migration version 20260625090000' in error for error in errors))
+
+	def test_rejects_new_migration_older_than_production(self) -> None:
+		changes = [
+			ChangedMigration(
+				status='A',
+				path=Path('supabase/migrations/20260619073000_add-aoi-status.sql'),
+				version='20260619073000',
+				kind='new',
+			)
+		]
+
+		errors = check_changed_migrations(changes, latest_applied_version='20260620000000')
+
+		self.assertEqual(
+			errors,
+			[
+				'New migration supabase/migrations/20260619073000_add-aoi-status.sql has version '
+				'20260619073000, but production has already applied migrations through 20260620000000. '
+				'Create a new migration with a later timestamp.'
+			],
+		)
+
+	def test_rejects_modifying_already_applied_migration(self) -> None:
+		changes = [
+			ChangedMigration(
+				status='M',
+				path=Path('supabase/migrations/20260619073000_add-aoi-status.sql'),
+				version='20260619073000',
+				kind='existing',
+			)
+		]
+
+		errors = check_changed_migrations(changes, latest_applied_version='20260620000000')
+
+		self.assertEqual(
+			errors,
+			[
+				'Migration supabase/migrations/20260619073000_add-aoi-status.sql has version '
+				'20260619073000, which is already applied in production. Do not modify, rename, or '
+				'delete applied migrations; add a new follow-up migration instead.'
+			],
+		)
+
+	def test_accepts_new_migration_newer_than_production(self) -> None:
+		changes = [
+			ChangedMigration(
+				status='A',
+				path=Path('supabase/migrations/20260625093000_add-example.sql'),
+				version='20260625093000',
+				kind='new',
+			)
+		]
+
+		self.assertEqual(check_changed_migrations(changes, latest_applied_version='20260620000000'), [])
+
+	def test_accepts_empty_latest_applied_version(self) -> None:
+		changes = [
+			ChangedMigration(
+				status='A',
+				path=Path('supabase/migrations/20260625093000_add-example.sql'),
+				version='20260625093000',
+				kind='new',
+			)
+		]
+
+		self.assertEqual(check_changed_migrations(changes, latest_applied_version=None), [])
+
+	def test_rejects_malformed_latest_applied_version(self) -> None:
+		changes = [
+			ChangedMigration(
+				status='A',
+				path=Path('supabase/migrations/20260625093000_add-example.sql'),
+				version='20260625093000',
+				kind='new',
+			)
+		]
+
+		self.assertEqual(
+			check_changed_migrations(changes, latest_applied_version='not-a-version'),
+			["Invalid latest applied production migration version: 'not-a-version'."],
+		)
+
+	def test_parses_added_modified_and_renamed_migrations(self) -> None:
+		diff_output = '\n'.join(
+			[
+				'A\tsupabase/migrations/20260625093000_add-example.sql',
+				'M\tsupabase/migrations/20260619073000_existing.sql',
+				'R100\tsupabase/migrations/20260619073100_old.sql\tsupabase/migrations/20260625100000_new.sql',
+			]
+		)
+
+		with patch('scripts.check_supabase_migration_versions.run_git', return_value=diff_output):
+			changes, errors = parse_changed_migrations(Path('supabase/migrations'), 'origin/main', 'HEAD')
+
+		self.assertEqual(errors, [])
+		self.assertEqual(
+			changes,
+			[
+				ChangedMigration(
+					status='A',
+					path=Path('supabase/migrations/20260625093000_add-example.sql'),
+					version='20260625093000',
+					kind='new',
+				),
+				ChangedMigration(
+					status='M',
+					path=Path('supabase/migrations/20260619073000_existing.sql'),
+					version='20260619073000',
+					kind='existing',
+				),
+				ChangedMigration(
+					status='R100',
+					path=Path('supabase/migrations/20260619073100_old.sql'),
+					version='20260619073100',
+					kind='existing',
+				),
+				ChangedMigration(
+					status='R100',
+					path=Path('supabase/migrations/20260625100000_new.sql'),
+					version='20260625100000',
+					kind='new',
+				),
+			],
+		)
+
+	def test_rejects_invalid_changed_sql_migration_filename(self) -> None:
+		diff_output = 'A\tsupabase/migrations/not_a_timestamp.sql'
+
+		with patch('scripts.check_supabase_migration_versions.run_git', return_value=diff_output):
+			changes, errors = parse_changed_migrations(Path('supabase/migrations'), 'origin/main', 'HEAD')
+
+		self.assertEqual(changes, [])
+		self.assertEqual(
+			errors,
+			[
+				'Invalid changed migration filename: supabase/migrations/not_a_timestamp.sql. Expected '
+				'<14-digit timestamp>_<description>.sql, for example '
+				'20260625093000_add_example_table.sql.'
+			],
+		)
+
+	def test_parses_github_pr_files_without_fetching_pr_code(self) -> None:
+		pr_files = [
+			{
+				'status': 'added',
+				'filename': 'supabase/migrations/20260625093000_add-example.sql',
+			},
+			{
+				'status': 'renamed',
+				'filename': 'supabase/migrations/20260625100000_new.sql',
+				'previous_filename': 'supabase/migrations/20260619073100_old.sql',
+			},
+			{
+				'status': 'modified',
+				'filename': 'README.md',
+			},
+		]
+
+		changes, errors = parse_changed_migrations_from_pr_files(Path('supabase/migrations'), pr_files)
+
+		self.assertEqual(errors, [])
+		self.assertEqual(
+			changes,
+			[
+				ChangedMigration(
+					status='added',
+					path=Path('supabase/migrations/20260625093000_add-example.sql'),
+					version='20260625093000',
+					kind='new',
+				),
+				ChangedMigration(
+					status='renamed',
+					path=Path('supabase/migrations/20260619073100_old.sql'),
+					version='20260619073100',
+					kind='existing',
+				),
+				ChangedMigration(
+					status='renamed',
+					path=Path('supabase/migrations/20260625100000_new.sql'),
+					version='20260625100000',
+					kind='new',
+				),
+			],
+		)
+
+	def test_pr_files_parser_handles_renames_into_migrations(self) -> None:
+		pr_files = [
+			{
+				'status': 'renamed',
+				'filename': 'supabase/migrations/20260625100000_new.sql',
+				'previous_filename': 'docs/schema.sql',
+			}
+		]
+
+		changes, errors = parse_changed_migrations_from_pr_files(Path('supabase/migrations'), pr_files)
+
+		self.assertEqual(errors, [])
+		self.assertEqual(
+			changes,
+			[
+				ChangedMigration(
+					status='renamed',
+					path=Path('supabase/migrations/20260625100000_new.sql'),
+					version='20260625100000',
+					kind='new',
+				)
+			],
+		)
+
+	def test_pr_files_parser_handles_renames_out_of_migrations(self) -> None:
+		pr_files = [
+			{
+				'status': 'renamed',
+				'filename': 'docs/old.sql',
+				'previous_filename': 'supabase/migrations/20260619073100_old.sql',
+			}
+		]
+
+		changes, errors = parse_changed_migrations_from_pr_files(Path('supabase/migrations'), pr_files)
+
+		self.assertEqual(errors, [])
+		self.assertEqual(
+			changes,
+			[
+				ChangedMigration(
+					status='renamed',
+					path=Path('supabase/migrations/20260619073100_old.sql'),
+					version='20260619073100',
+					kind='existing',
+				)
+			],
+		)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Summary
- Add a PR-time Supabase migration guard for filename hygiene and production version collisions.
- Run a secret-free `pull_request` filename/helper check plus a trusted `pull_request_target` production-version check that does not execute PR-controlled code with production secrets.
- Cover collision, malformed filename, parser, and malformed production-version cases with dependency-free unit tests.

## Validation
- `python3 -m unittest scripts.tests.test_check_supabase_migration_versions`
- `python3 scripts/check_supabase_migration_versions.py --base-ref HEAD --head-ref HEAD`
- `python3 -m py_compile scripts/check_supabase_migration_versions.py scripts/tests/test_check_supabase_migration_versions.py`
- `git diff --cached --check`
- autoreview: Codex + Claude Code Opus clean, no accepted/actionable findings

## Risk
- The trusted production-version check will become active after this workflow/helper exist on the base branch. For this bootstrap PR, the job includes a base-helper availability guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to validate Supabase migration filenames and version order in pull requests.
  * Added repository checks to help prevent modifying migrations that have already been applied.

* **Bug Fixes**
  * Improved detection of invalid migration names, duplicate versions, and out-of-order migration timestamps.
  * Added validation for production-aware migration comparisons to reduce accidental conflicts.

* **Tests**
  * Added coverage for valid and invalid migration scenarios, including filename parsing and change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->