### PR TITLE
fix(frontend): show authorized private datasets in archive

### DIFF
--- a/api/tests/db/test_dataset_rls_policy.py
+++ b/api/tests/db/test_dataset_rls_policy.py
@@ -1,7 +1,15 @@
 import pytest
 from shared.db import use_anon_client, use_client, use_service_client, login
 from shared.settings import settings
-from shared.models import DatasetAccessEnum, LabelDataEnum, LabelSourceEnum, LabelTypeEnum, LicenseEnum, PlatformEnum
+from shared.models import (
+	DatasetAccessEnum,
+	LabelDataEnum,
+	LabelSourceEnum,
+	LabelTypeEnum,
+	LicenseEnum,
+	PlatformEnum,
+	StatusEnum,
+)
 from shared.testing.fixtures import test_processor_user
 
 
@@ -99,6 +107,91 @@ def datasets_with_mixed_access(auth_token, test_user, test_processor_user):
 		with use_client(auth_token) as supabase_client:
 			for dataset_id in datasets:
 				supabase_client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
+
+
+@pytest.fixture(scope='function')
+def archive_ready_private_dataset(test_user):
+	"""Create a private dataset that satisfies public_dataset_archive_items predicates."""
+	dataset_id = None
+
+	try:
+		with use_service_client() as client:
+			dataset = {
+				'file_name': 'test-private-archive-visible.tif',
+				'user_id': test_user,
+				'license': LicenseEnum.cc_by.value,
+				'platform': PlatformEnum.drone.value,
+				'authors': ['Private Archive Test Author'],
+				'data_access': DatasetAccessEnum.private.value,
+				'aquisition_year': 2024,
+				'aquisition_month': 1,
+				'aquisition_day': 1,
+			}
+			response = client.table(settings.datasets_table).insert(dataset).execute()
+			dataset_id = response.data[0]['id']
+
+			client.table(settings.orthos_table).insert(
+				{
+					'dataset_id': dataset_id,
+					'ortho_file_name': 'test-private-archive-visible.tif',
+					'version': 1,
+					'ortho_file_size': 1,
+					'bbox': 'BOX(13.4050 52.5200,13.4150 52.5300)',
+					'sha256': 'test-private-archive-visible',
+					'ortho_upload_runtime': 0.1,
+				}
+			).execute()
+			client.table(settings.thumbnails_table).insert(
+				{
+					'dataset_id': dataset_id,
+					'thumbnail_file_name': 'test-private-archive-visible.jpg',
+					'thumbnail_path': 'test-private-archive-visible.jpg',
+					'thumbnail_file_size': 1,
+					'version': 1,
+				}
+			).execute()
+			client.table(settings.metadata_table).insert(
+				{
+					'dataset_id': dataset_id,
+					'metadata': {
+						'gadm': {
+							'admin_level_1': 'DEU',
+							'admin_level_2': 'Berlin',
+							'admin_level_3': 'Berlin',
+						},
+						'biome': {
+							'biome_name': 'Temperate Broadleaf and Mixed Forests',
+						},
+					},
+					'version': 1,
+					'processing_runtime': 0.1,
+				}
+			).execute()
+			client.table(settings.statuses_table).insert(
+				{
+					'dataset_id': dataset_id,
+					'current_status': StatusEnum.idle.value,
+					'is_upload_done': True,
+					'is_ortho_done': True,
+					'is_cog_done': True,
+					'is_thumbnail_done': True,
+					'is_deadwood_done': True,
+					'is_forest_cover_done': True,
+					'is_metadata_done': True,
+					'has_error': False,
+				}
+			).execute()
+
+		yield dataset_id
+
+	finally:
+		if dataset_id:
+			with use_service_client() as client:
+				client.table(settings.statuses_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.metadata_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.thumbnails_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.orthos_table).delete().eq('dataset_id', dataset_id).execute()
+				client.table(settings.datasets_table).delete().eq('id', dataset_id).execute()
 
 
 def test_rls_policy_for_private_datasets(datasets_with_mixed_access, auth_token, setup_processor_privileges):
@@ -230,6 +323,83 @@ def test_rls_policy_for_view_with_private_datasets(datasets_with_mixed_access, a
 			public_client.from_('v2_full_dataset_view')
 			.select('*')
 			.eq('id', datasets_with_mixed_access['private_id'])
+			.execute()
+		)
+		assert len(response.data) == 0
+
+
+def test_archive_items_include_private_datasets_for_authorized_users(
+	archive_ready_private_dataset,
+	setup_processor_privileges,
+	test_processor_user,
+	test_user2,
+):
+	"""The archive map/list feed should include private rows only for authorized users."""
+	user_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	processor_token = login(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD, use_cached_session=False)
+	other_user_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_anon_client() as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
+			.execute()
+		)
+		assert len(response.data) == 0
+
+	with use_client(other_user_token) as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
+			.execute()
+		)
+		assert len(response.data) == 0
+
+	with use_client(user_token) as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
+			.execute()
+		)
+		assert len(response.data) == 1
+		assert response.data[0]['data_access'] == DatasetAccessEnum.private.value
+
+	with use_client(processor_token) as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
+			.execute()
+		)
+		assert len(response.data) == 1
+		assert response.data[0]['data_access'] == DatasetAccessEnum.private.value
+
+	with use_client(processor_token) as client:
+		client.table('dataset_audit').insert(
+			{
+				'dataset_id': archive_ready_private_dataset,
+				'audited_by': test_processor_user,
+				'final_assessment': 'exclude_completely',
+			}
+		).execute()
+
+	with use_client(user_token) as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
+			.execute()
+		)
+		assert len(response.data) == 0
+
+	with use_client(processor_token) as client:
+		response = (
+			client.from_('public_dataset_archive_items')
+			.select('id,data_access')
+			.eq('id', archive_ready_private_dataset)
 			.execute()
 		)
 		assert len(response.data) == 0

--- a/frontend/src/components/DatasetMap/DatasetMap.tsx
+++ b/frontend/src/components/DatasetMap/DatasetMap.tsx
@@ -10,7 +10,7 @@ import type { SelectEvent } from "ol/interaction/Select";
 import "ol/ol.css";
 import { fromExtent } from "ol/geom/Polygon.js";
 import { useNavigate } from "react-router-dom";
-import { IDataset, IDatasetArchiveItem } from "../../types/dataset";
+import { IDataAccess, IDataset, IDatasetArchiveItem } from "../../types/dataset";
 import parseBBox from "../../utils/parseBBox";
 import {
   applyOpenFreeMapLibertyStyle,
@@ -196,11 +196,12 @@ const formatAcquisitionDate = (dataset: DatasetMapItem): string => {
 const buildTooltipTitle = (dataset: DatasetMapItem): string => {
   const place = dataset.admin_level_3 || dataset.admin_level_2 || "";
   const country = dataset.admin_level_1 || "";
+  const suffix = dataset.data_access === IDataAccess.private ? " [Private]" : "";
 
-  if (place && country) return `${place}, ${country}`;
-  if (place) return place;
-  if (country) return country;
-  return `Dataset #${dataset.id}`;
+  if (place && country) return `${place}, ${country}${suffix}`;
+  if (place) return `${place}${suffix}`;
+  if (country) return `${country}${suffix}`;
+  return `Dataset #${dataset.id}${suffix}`;
 };
 
 interface MapRef extends Map {

--- a/frontend/src/components/ListItem.tsx
+++ b/frontend/src/components/ListItem.tsx
@@ -1,6 +1,6 @@
 import { Button, Tag, Tooltip } from "antd";
 import { useNavigate } from "react-router-dom";
-import { IDataset, IDatasetArchiveItem } from "../types/dataset";
+import { IDataAccess, IDataset, IDatasetArchiveItem } from "../types/dataset";
 import { Settings } from "../config";
 import countryList from "../utils/countryList";
 import { useDatasetDetailsMap } from "../hooks/useDatasetDetailsMapProvider";
@@ -107,6 +107,7 @@ const ListItem = ({
   const biomeLabel = biomeName || "Unknown";
   const biomeColor = getBiomeTagColor(biomeName);
   const biomeIcon = getBiomeEmoji(biomeName);
+  const isPrivate = item.data_access === IDataAccess.private;
 
   return (
     <div
@@ -169,6 +170,11 @@ const ListItem = ({
                 data-testid="dataset-semantic-score"
               >
                 {Math.round(score * 100)}% match
+              </Tag>
+            )}
+            {isPrivate && (
+              <Tag color="gold" className="mb-1 mr-0">
+                Private
               </Tag>
             )}
             <div className="pt-0.5 text-xs whitespace-nowrap">

--- a/frontend/src/hooks/useDatasets.ts
+++ b/frontend/src/hooks/useDatasets.ts
@@ -11,10 +11,10 @@ interface DatasetQueryOptions {
 
 // Base datasets hook - includes ALL datasets (for admin/audit use)
 export function useDatasets(options: DatasetQueryOptions = {}) {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
   return useQuery({
-    queryKey: ["datasets"],
+    queryKey: ["datasets", status, user?.id ?? "anonymous"],
     queryFn: async () => {
       const { data, error } = await supabase.from(Settings.DATA_TABLE_FULL).select("*");
       if (error) throw error;
@@ -28,10 +28,10 @@ export function useDatasets(options: DatasetQueryOptions = {}) {
 
 // Public datasets hook - excludes datasets marked as "exclude_completely"
 export function usePublicDatasets(options: DatasetQueryOptions = {}) {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
   return useQuery({
-    queryKey: ["public-datasets"],
+    queryKey: ["public-datasets", status, user?.id ?? "anonymous"],
     queryFn: async () => {
       const { data, error } = await supabase.from(Settings.DATA_TABLE_PUBLIC).select("*");
       if (error) throw error;
@@ -45,10 +45,10 @@ export function usePublicDatasets(options: DatasetQueryOptions = {}) {
 
 // Public archive hook - narrow rows for the /dataset archive list, timeline, filters, and map
 export function usePublicDatasetArchiveItems(options: DatasetQueryOptions = {}) {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
   return useQuery({
-    queryKey: ["public-dataset-archive-items"],
+    queryKey: ["public-dataset-archive-items", status, user?.id ?? "anonymous"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from(Settings.DATASET_ARCHIVE_ITEMS_VIEW)
@@ -65,10 +65,10 @@ export function usePublicDatasetArchiveItems(options: DatasetQueryOptions = {}) 
 
 // Public single dataset hook - optimized for dataset details page
 export function usePublicDatasetById(datasetId: number | undefined) {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
 	return useQuery({
-		queryKey: ["public-dataset-by-id", datasetId],
+		queryKey: ["public-dataset-by-id", datasetId, status, user?.id ?? "anonymous"],
 		enabled: !!datasetId && status !== "checking",
 		queryFn: async () => {
 			if (!datasetId) return null;
@@ -87,10 +87,10 @@ export function usePublicDatasetById(datasetId: number | undefined) {
 
 // Fetch a single dataset by id; minimal fields are enough for Tiles page
 export function useDatasetById(datasetId: number | undefined) {
-  const { status } = useAuth();
+  const { status, user } = useAuth();
 
   return useQuery({
-    queryKey: ["dataset-by-id", datasetId],
+    queryKey: ["dataset-by-id", datasetId, status, user?.id ?? "anonymous"],
     enabled: !!datasetId && status !== "checking",
     queryFn: async () => {
       if (!datasetId) return null;
@@ -124,10 +124,11 @@ export function useUserDatasets(options: DatasetQueryOptions = {}) {
 
 // Authors list - based on public datasets only
 export function useAuthors(options: DatasetQueryOptions = {}) {
+  const { status, user } = useAuth();
   const { data: datasets } = usePublicDatasetArchiveItems({ enabled: options.enabled });
 
   return useQuery({
-    queryKey: ["authors"],
+    queryKey: ["authors", status, user?.id ?? "anonymous"],
     enabled: (options.enabled ?? true) && !!datasets,
     queryFn: () => {
       // Flatten all authors arrays and remove duplicates

--- a/frontend/src/types/dataset.ts
+++ b/frontend/src/types/dataset.ts
@@ -118,6 +118,7 @@ export type IDatasetArchiveItem = Pick<
   | "aquisition_year"
   | "aquisition_month"
   | "aquisition_day"
+  | "data_access"
   | "bbox"
   | "thumbnail_path"
   | "admin_level_1"

--- a/supabase/migrations/20260625090400_allow_authorized_private_archive_items.sql
+++ b/supabase/migrations/20260625090400_allow_authorized_private_archive_items.sql
@@ -1,0 +1,105 @@
+create or replace view "public"."public_dataset_archive_items" as
+with latest_status as (
+  select distinct on (dataset_id)
+    dataset_id,
+    is_cog_done,
+    is_thumbnail_done,
+    is_deadwood_done,
+    is_forest_cover_done,
+    is_metadata_done,
+    has_error
+  from v2_statuses
+  order by dataset_id, updated_at desc, id desc
+),
+archive_base as (
+  select
+    d.id,
+    d.created_at,
+    d.license,
+    d.platform,
+    d.authors,
+    d.aquisition_year,
+    d.aquisition_month,
+    d.aquisition_day,
+    o.bbox,
+    thumb.thumbnail_path,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_1'::text) as admin_level_1,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_2'::text) as admin_level_2,
+    ((meta.metadata ->> 'gadm'::text)::jsonb ->> 'admin_level_3'::text) as admin_level_3,
+    ((meta.metadata ->> 'biome'::text)::jsonb ->> 'biome_name'::text) as biome_name,
+    s.is_cog_done,
+    s.is_thumbnail_done,
+    s.is_metadata_done,
+    s.has_error,
+    s.is_deadwood_done,
+    s.is_forest_cover_done,
+    d.data_access
+  from v2_datasets d
+  join latest_status s on s.dataset_id = d.id
+  join v2_orthos o on o.dataset_id = d.id
+  left join v2_thumbnails thumb on thumb.dataset_id = d.id
+  left join v2_metadata meta on meta.dataset_id = d.id
+  where (
+      d.data_access <> 'private'::access
+      or auth.uid() = d.user_id
+      or public.can_view_all_private_data()
+    )
+    and d.archived = false
+),
+label_info as (
+  select
+    base.id as dataset_id,
+    exists (
+      select 1
+      from v2_labels
+      where v2_labels.dataset_id = base.id
+        and v2_labels.label_source = 'visual_interpretation'::"LabelSource"
+        and v2_labels.label_data = 'deadwood'::"LabelData"
+    ) as has_labels,
+    exists (
+      select 1
+      from v2_labels
+      where v2_labels.dataset_id = base.id
+        and v2_labels.label_source = 'model_prediction'::"LabelSource"
+        and v2_labels.label_data = 'deadwood'::"LabelData"
+    ) as has_deadwood_prediction
+  from archive_base base
+)
+select
+  base.id,
+  base.created_at,
+  base.license,
+  base.platform,
+  base.authors,
+  base.aquisition_year,
+  base.aquisition_month,
+  base.aquisition_day,
+  base.bbox,
+  base.thumbnail_path,
+  base.admin_level_1,
+  base.admin_level_2,
+  base.admin_level_3,
+  base.biome_name,
+  coalesce(label_info.has_labels, false) as has_labels,
+  coalesce(label_info.has_deadwood_prediction, false) as has_deadwood_prediction,
+  base.data_access
+from archive_base base
+left join label_info on label_info.dataset_id = base.id
+where base.is_cog_done = true
+  and base.is_thumbnail_done = true
+  and base.is_metadata_done = true
+  and base.admin_level_1 is not null
+  and (
+    base.has_error = false
+    or (base.is_deadwood_done = true and base.is_forest_cover_done = false)
+  )
+  and not internal.is_dataset_excluded_from_public_surface(base.id);
+
+alter view public.public_dataset_archive_items set (security_invoker = true);
+
+grant select on table "public"."public_dataset_archive_items" to "anon";
+grant select on table "public"."public_dataset_archive_items" to "authenticated";
+grant select on table "public"."public_dataset_archive_items" to "service_role";
+
+drop function if exists public.is_dataset_excluded_from_archive(bigint);
+drop function if exists public.is_dataset_excluded_from_archive(integer);


### PR DESCRIPTION
## Summary
- Allow `public_dataset_archive_items` to include private datasets for owners and users with `can_view_all_private_data()` while keeping anonymous/unrelated users excluded.
- Scope archive-related React Query cache keys, including authors, by auth state/user so login refreshes private-visible data.
- Mark private archive items in the sidebar and map tooltip.
- Preserve `exclude_completely` audit filtering via the existing internal security-definer helper instead of caller-visible `dataset_audit` joins.

## Validation
- `psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/migrations/20260625090400_allow_authorized_private_archive_items.sql`
- `set -a; . .local/supabase/current.env; set +a; venv/bin/pytest api/tests/db/test_dataset_rls_policy.py -q`
- `npm run lint` in `frontend`
- `npx tsc --noEmit` in `frontend`
- `$thermo-nuclear-code-quality-review` manual pass
- `$autoreview --mode local` clean after fixes

## Risk
- User-visible change is limited to authorized users seeing private datasets on `/dataset` map/sidebar.
- Anonymous and unrelated authenticated users remain blocked by the view predicates and RLS regression tests.
