### PR TITLE
docs(scripts): clarify queue priority ordering

### DIFF
--- a/scripts/requeue_datasets_via_api.py
+++ b/scripts/requeue_datasets_via_api.py
@@ -107,7 +107,7 @@ def main() -> int:
 		required=True,
 		help="Comma-separated dataset ids, e.g. 8046,8037,6479,6073",
 	)
-	parser.add_argument("--priority", type=int, default=5, help="1=highest, 5=lowest (default: 5)")
+	parser.add_argument("--priority", type=int, default=5, help="5=highest, 1=lowest (default: 5)")
 	parser.add_argument(
 		"--task-types",
 		default=",".join(DEFAULT_TASK_TYPES),
@@ -174,4 +174,3 @@ def main() -> int:
 
 if __name__ == "__main__":
 	raise SystemExit(main())
-

--- a/scripts/rerun_segmentation.py
+++ b/scripts/rerun_segmentation.py
@@ -15,7 +15,7 @@ from shared.logger import logger
 BASE_PATH = Path('/Users/januschvajna-jehle/projects/deadwood-upload-labels/data')
 CSV_PATH = BASE_PATH / 'rerun_segmentation/rerun_deadwood_segmentation.csv'
 FORCE_REPROCESS = False  # Set to True to reprocess already processed datasets
-PRIORITY = 2  # Processing priority (1-5, where 1 is highest)
+PRIORITY = 2  # Processing priority (1-5, where 5 is highest)
 
 # File to track processed datasets
 PROCESSED_FILE = BASE_PATH / 'rerun_segmentation/rerun_segmentation_processed.txt'


### PR DESCRIPTION
## What changed
- Corrected helper-script priority wording to consistently say `5=highest, 1=lowest`.
- Aligns `scripts/requeue_datasets_via_api.py` and `scripts/rerun_segmentation.py` with the API schema, tests, and `v2_queue_positions` ordering.

## Why
The requeue helper had the priority meaning reversed, which made it easy to accidentally enqueue operational backfills at the highest priority when intending the lowest.

## Validation
- `python3 -m py_compile scripts/requeue_datasets_via_api.py scripts/rerun_segmentation.py`
- `rg` check for contradictory priority wording
- `git diff --check`