### PR TITLE
fix(dataset): decouple "DB as of" timeline from filters and search

### DIFF
--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -44,7 +44,21 @@ const FLOAT_BUTTON_SIZE_PX = 36;
 export default function Dataset() {
   const navigate = useNavigate();
   const { data: allData } = usePublicDatasetArchiveItems();
-  const { filteredData } = useFilteredDatasets(allData);
+
+  // The "DB as of" timeline axis is derived from the full, unfiltered dataset so
+  // that no filter (tag, advanced, or text search) ever changes the available
+  // periods. The timeline is applied first; all filters apply on top of the
+  // time-limited slice below.
+  const {
+    periods,
+    selectedPeriod,
+    setSelectedPeriod,
+    displayData: timeFilteredData,
+    cumulativeCount,
+    addedInQuarter,
+  } = useUploadTimeline(allData ?? null);
+
+  const { filteredData } = useFilteredDatasets(timeFilteredData ?? undefined);
 
   // Get filter state from context
   const {
@@ -136,7 +150,10 @@ export default function Dataset() {
     });
   };
 
-  const processedData = useMemo(() => {
+  // Text/semantic search and sorting are applied on top of the already
+  // filtered data, so they affect only which datasets are shown — never the
+  // timeline.
+  const displayData = useMemo(() => {
     if (!filteredData) return null;
 
     const filtered = filteredData.filter((d) => {
@@ -182,15 +199,6 @@ export default function Dataset() {
       return sortDirection === "asc" ? a.id - b.id : b.id - a.id;
     });
   }, [filteredData, searchValue, sortDirection, semantic.scores]);
-
-  const {
-    periods,
-    selectedPeriod,
-    setSelectedPeriod,
-    displayData,
-    cumulativeCount,
-    addedInQuarter,
-  } = useUploadTimeline(processedData);
 
   // Reset visibleFeatures when data changes
   useEffect(() => {
@@ -292,7 +300,7 @@ export default function Dataset() {
           {semantic.query && (
             <div className="flex items-center justify-between px-1 text-xs text-gray-500">
               <span>
-                Ranked by “{semantic.query}” · {processedData?.length ?? 0} matches
+                Ranked by “{semantic.query}” · {displayData?.length ?? 0} matches
               </span>
               <Button
                 type="link"

--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -300,7 +300,7 @@ export default function Dataset() {
           {semantic.query && (
             <div className="flex items-center justify-between px-1 text-xs text-gray-500">
               <span>
-                Ranked by “{semantic.query}” · {displayData?.length ?? 0} matches
+                Ranked by “{semantic.query}” · {semantic.scores?.size ?? 0} matches
               </span>
               <Button
                 type="link"


### PR DESCRIPTION
## Problem

In the dataset view, applying a text search (or any filter) changed the **"DB as of"** timeline below it, so the set of visible datasets differed before vs. after searching.

**Root cause:** the timeline period axis was computed from the already search/filter-narrowed dataset. Searching shrank the available quarters, and the timeline's auto-reset effect snapped the selected period down to the new (older) "latest" period. Clearing the search restored the full period list, but the now-stale selected period was still a *valid* (just earlier) quarter, so it never snapped back — silently hiding every dataset added after it.

## Fix

Reordered the data pipeline so the timeline is derived from the **full unfiltered `allData`** and applied **first**:

```
allData ─▶ useUploadTimeline (periods + "DB as of" axis, time-limited slice)
            └─▶ useFilteredDatasets (tag + advanced filters)
                  └─▶ search + sort + semantic ranking
                        └─▶ displayData
```

No filter — tag, advanced, or text search — can now alter the available periods or the selected one. The cumulative / +added counts in the control reflect the full database at the selected quarter (the true "DB as of" meaning), and filters only affect what's shown in the list/map.

## Testing

- `tsc --noEmit` ✓
- `npm run lint` ✓
- `npm run test` — 113 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline navigation now stays based on the full dataset, so filtering no longer changes the available time range.
  * Text search now filters results after the timeline slice is applied, improving consistency across views.
  * Semantic search results are now ranked by relevance and limited to matching items more reliably.
  * The “Ranked by … · … matches” label now shows the correct match count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->