### PR TITLE
fix(search): expose semantic search safely

### DIFF
--- a/api/src/routers/search.py
+++ b/api/src/routers/search.py
@@ -13,12 +13,15 @@ lifetime (see ``shared.embedding_model.get_text_bundle``).
 
 import logging
 from collections import defaultdict, deque
+from functools import lru_cache
+from ipaddress import ip_address, ip_network
 from threading import Lock
 from time import monotonic
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from shared.settings import settings
 from shared.embedding_model import EMBEDDING_DIM, embed_text
 
 logger = logging.getLogger(__name__)
@@ -43,18 +46,53 @@ class EmbedResponse(BaseModel):
 	dim: int = Field(..., description='Embedding dimensionality')
 
 
+@lru_cache(maxsize=16)
+def _trusted_proxy_networks(config: str) -> tuple:
+	networks = []
+	for raw_entry in config.split(','):
+		entry = raw_entry.strip()
+		if not entry:
+			continue
+		try:
+			networks.append(ip_network(entry, strict=False))
+		except ValueError:
+			logger.warning('Ignoring invalid trusted proxy entry for search rate limit')
+	return tuple(networks)
+
+
+def _is_trusted_proxy(host: str | None) -> bool:
+	if not host:
+		return False
+	try:
+		address = ip_address(host)
+	except ValueError:
+		return False
+	return any(address in network for network in _trusted_proxy_networks(settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES))
+
+
+def _parse_ip(host: str) -> bool:
+	try:
+		ip_address(host)
+	except ValueError:
+		return False
+	return True
+
+
 def _search_client_key(request: Request) -> str:
-	"""Best-effort client key for the public embedding rate limit."""
-	real_ip = request.headers.get('x-real-ip', '').strip()
-	if real_ip:
-		return real_ip
+	"""Client key for the public embedding rate limit.
 
-	forwarded_for = request.headers.get('x-forwarded-for', '').strip()
-	if forwarded_for:
-		return forwarded_for.split(',')[0].strip()
+	Only trust ``X-Real-IP`` from configured proxy peers. Host nginx overwrites
+	that header with ``$remote_addr``; ``X-Forwarded-For`` is appendable and can
+	preserve client-supplied spoofed hops, so it is not used for limiter keys.
+	"""
+	client_host = request.client.host if request.client else None
+	if _is_trusted_proxy(client_host):
+		real_ip = request.headers.get('x-real-ip', '').strip()
+		if real_ip and _parse_ip(real_ip):
+			return real_ip
 
-	if request.client:
-		return request.client.host
+	if client_host:
+		return client_host
 
 	return 'unknown'
 

--- a/api/tests/test_search_embed.py
+++ b/api/tests/test_search_embed.py
@@ -16,6 +16,7 @@ from api.src.routers.search import (
 	EmbedRequest,
 	MAX_QUERY_LENGTH,
 	_check_search_embed_rate_limit,
+	_trusted_proxy_networks,
 	_search_client_key,
 	embed_query,
 )
@@ -37,9 +38,13 @@ def _guard_model(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _reset_rate_limit():
+	trusted_proxies = search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES
 	search_module._search_embed_requests.clear()
+	_trusted_proxy_networks.cache_clear()
 	yield
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = trusted_proxies
 	search_module._search_embed_requests.clear()
+	_trusted_proxy_networks.cache_clear()
 
 
 def _request(host='127.0.0.1', headers=None):
@@ -117,16 +122,42 @@ def test_model_failure_returns_503(monkeypatch):
 	assert exc.value.status_code == 503
 
 
-def test_client_key_prefers_nginx_real_ip_header():
+def test_client_key_ignores_spoofable_forwarded_headers():
 	request = _request(host='10.0.0.2', headers={'x-real-ip': '198.51.100.10'})
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = '127.0.0.1,::1'
 
-	assert _search_client_key(request) == '198.51.100.10'
+	assert _search_client_key(request) == '10.0.0.2'
 
 
-def test_client_key_uses_first_forwarded_for_when_real_ip_missing():
+def test_client_key_ignores_spoofable_x_forwarded_for_header():
 	request = _request(host='10.0.0.2', headers={'x-forwarded-for': '198.51.100.10, 10.0.0.2'})
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = '127.0.0.1,::1'
+
+	assert _search_client_key(request) == '10.0.0.2'
+
+
+def test_client_key_trusts_real_ip_from_configured_proxy():
+	request = _request(host='172.18.0.1', headers={'x-real-ip': '198.51.100.10'})
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = '172.16.0.0/12'
+	_trusted_proxy_networks.cache_clear()
 
 	assert _search_client_key(request) == '198.51.100.10'
+
+
+def test_client_key_ignores_forwarded_for_even_from_configured_proxy():
+	request = _request(host='172.18.0.1', headers={'x-forwarded-for': '198.51.100.10, 172.18.0.1'})
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = '172.16.0.0/12'
+	_trusted_proxy_networks.cache_clear()
+
+	assert _search_client_key(request) == '172.18.0.1'
+
+
+def test_client_key_ignores_invalid_real_ip_from_configured_proxy():
+	request = _request(host='172.18.0.1', headers={'x-real-ip': 'not an ip'})
+	search_module.settings.SEARCH_RATE_LIMIT_TRUSTED_PROXIES = '172.16.0.0/12'
+	_trusted_proxy_networks.cache_clear()
+
+	assert _search_client_key(request) == '172.18.0.1'
 
 
 def test_search_rate_limit_blocks_same_client_before_model(monkeypatch):

--- a/docker-compose.api.yaml
+++ b/docker-compose.api.yaml
@@ -33,6 +33,11 @@ services:
       UVICORN_ROOT_PATH: /api/v1
       UVICORN_PORT: 40831
       UVICORN_HOST: 0.0.0.0
+      # Host nginx reaches the API through Docker's bridge gateway, so only
+      # trusted proxy peers may supply X-Real-IP / X-Forwarded-For for public
+      # endpoint rate limiting. Host nginx applies the primary public edge limit;
+      # this preserves per-client backend buckets across Docker gateway subnets.
+      SEARCH_RATE_LIMIT_TRUSTED_PROXIES: ${SEARCH_RATE_LIMIT_TRUSTED_PROXIES:-127.0.0.1,::1,172.16.0.0/12}
       # Reference export configuration
       REFERENCE_EXPORT_UUID: ${REFERENCE_EXPORT_UUID}
       NGINX_COG_URL: ${NGINX_COG_URL}

--- a/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
+++ b/frontend/src/components/DatasetDetailsMap/BaseMap.tsx
@@ -110,6 +110,7 @@ export default function BaseMap({
 	} = useMapCore({
 		containerRef: mapContainerRef,
 		cogPath: data?.cog_path,
+		thumbnailPath: data?.thumbnail_path,
 		// When arriving from the dataset list, ignore the persisted viewport and let
 		// the map fit the new orthophoto's extent. useMapCore reads initialViewport
 		// once at init, so the previous (stale) viewport would otherwise leave the

--- a/frontend/src/components/DatasetDetailsMap/hooks/useBaseLayers.ts
+++ b/frontend/src/components/DatasetDetailsMap/hooks/useBaseLayers.ts
@@ -4,7 +4,6 @@ import LayerGroup from "ol/layer/Group";
 import TileLayer from "ol/layer/Tile";
 import { XYZ } from "ol/source";
 import type { Map as OLMap } from "ol";
-import type TileLayerWebGL from "ol/layer/WebGLTile.js";
 
 import {
 	createOpenFreeMapLibertyLayerGroup,
@@ -25,7 +24,7 @@ export interface UseBaseLayersOptions {
 	/** Whether drone imagery (ortho) is visible */
 	showDroneImagery?: boolean;
 	/** Ortho layer ref (from useMapCore) */
-	orthoLayer?: TileLayerWebGL | null;
+	orthoLayer?: BaseLayer | null;
 }
 
 export interface UseBaseLayersReturn {

--- a/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
+++ b/frontend/src/components/DatasetDetailsMap/hooks/useMapCore.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { Map, View, Overlay } from "ol";
 import type BaseLayer from "ol/layer/Base";
+import ImageLayer from "ol/layer/Image";
 import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { GeoTIFF } from "ol/source";
+import StaticImageSource from "ol/source/ImageStatic";
 import type { Layer } from "ol/layer";
 
 import { Settings } from "../../../config";
@@ -21,6 +23,8 @@ export interface UseMapCoreOptions {
 	containerRef: React.RefObject<HTMLDivElement | null>;
 	/** COG path (relative to base URL) */
 	cogPath: string | null | undefined;
+	/** Thumbnail path used as a static no-WebGL fallback */
+	thumbnailPath?: string | null;
 	/** Initial viewport state */
 	initialViewport?: Viewport;
 	/** Callback when viewport changes */
@@ -47,7 +51,7 @@ export interface UseMapCoreReturn {
 	/** Whether map is initialized */
 	isMapReady: boolean;
 	/** Ortho COG layer */
-	orthoLayer: TileLayerWebGL | null;
+	orthoLayer: BaseLayer | null;
 	/** GeoTIFF extent (for fit view) */
 	extent: number[] | null;
 	/** Add a layer to the map */
@@ -72,6 +76,32 @@ type DisposableLayer = BaseLayer & {
 	dispose?: () => void;
 };
 
+const disposeLayerWithSource = (layer: DisposableLayer) => {
+	const source = layer.getSource?.();
+	if (source) {
+		if ("clear" in source && typeof source.clear === "function") source.clear();
+		if ("dispose" in source && typeof source.dispose === "function") source.dispose();
+	}
+	layer.dispose?.();
+};
+
+const browserSupportsWebGL = () => {
+	if (typeof document === "undefined") return false;
+
+	const canvas = document.createElement("canvas");
+	try {
+		const context = (
+			canvas.getContext("webgl2") ||
+				canvas.getContext("webgl") ||
+				canvas.getContext("experimental-webgl")
+		) as WebGLRenderingContext | WebGL2RenderingContext | null;
+		context?.getExtension("WEBGL_lose_context")?.loseContext();
+		return Boolean(context);
+	} catch {
+		return false;
+	}
+};
+
 /**
  * Core map initialization hook
  * 
@@ -84,6 +114,7 @@ type DisposableLayer = BaseLayer & {
 export function useMapCore({
 	containerRef,
 	cogPath,
+	thumbnailPath,
 	initialViewport,
 	onViewportChange,
 	onMapReady,
@@ -95,7 +126,7 @@ export function useMapCore({
 	disableRotation = false,
 }: UseMapCoreOptions): UseMapCoreReturn {
 	const mapRef = useRef<Map | null>(null);
-	const orthoLayerRef = useRef<TileLayerWebGL | null>(null);
+	const orthoLayerRef = useRef<BaseLayer | null>(null);
 	const [isMapReady, setIsMapReady] = useState(false);
 	const [extent, setExtent] = useState<number[] | null>(null);
 
@@ -104,6 +135,7 @@ export function useMapCore({
 	const onMapReadyRef = useRef(onMapReady);
 	const onOrthoLayerReadyRef = useRef(onOrthoLayerReady);
 	const onFirstInteractionRef = useRef(onFirstInteraction);
+	const thumbnailPathRef = useRef(thumbnailPath);
 	// Read via ref so a post-init change (isMobile flips false on first render)
 	// configures interactions without rebuilding the whole map.
 	const disableRotationRef = useRef(disableRotation);
@@ -116,6 +148,7 @@ export function useMapCore({
 		onMapReadyRef.current = onMapReady;
 		onOrthoLayerReadyRef.current = onOrthoLayerReady;
 		onFirstInteractionRef.current = onFirstInteraction;
+		thumbnailPathRef.current = thumbnailPath;
 		disableRotationRef.current = disableRotation;
 	});
 
@@ -161,30 +194,35 @@ export function useMapCore({
 			return;
 		}
 
-		// Create ortho COG layer
-		const orthoCogLayer = new TileLayerWebGL({
-			source: new GeoTIFF({
-				sources: [{
-					url: Settings.COG_BASE_URL + cogPath,
-					nodata: 0,
-					bands: [1, 2, 3],
-				}],
-				convertToRGB: true,
-				sourceOptions: COG_SOURCE_OPTIONS,
-			}),
-			maxZoom: 23,
-			cacheSize: 4096,
-			preload: 0,
+		let isDisposed = false;
+		const orthoCogSource = new GeoTIFF({
+			sources: [{
+				url: Settings.COG_BASE_URL + cogPath,
+				nodata: 0,
+				bands: [1, 2, 3],
+			}],
+			convertToRGB: true,
+			sourceOptions: COG_SOURCE_OPTIONS,
 		});
+
+		// The orthophoto COG uses OpenLayers' WebGL tile renderer. Some embedded
+		// browsers disable WebGL; in that case keep the map usable with a static
+		// thumbnail fallback, vector layers, AOI, and tile-search overlays.
+		const supportsWebGL = browserSupportsWebGL();
+		const orthoCogLayer = supportsWebGL
+			? new TileLayerWebGL({
+					source: orthoCogSource,
+					maxZoom: 23,
+					cacheSize: 4096,
+					preload: 0,
+				})
+			: null;
 
 		orthoLayerRef.current = orthoCogLayer;
 
 		// Get view from GeoTIFF extent
-		const orthoCogSource = orthoCogLayer.getSource();
-		if (!orthoCogSource) return;
-
 		orthoCogSource.getView().then((viewOptions) => {
-			if (!viewOptions?.extent || !containerRef.current) return;
+			if (isDisposed || !viewOptions?.extent || !containerRef.current) return;
 
 			const cogExtent = viewOptions.extent as number[];
 			setExtent(cogExtent);
@@ -201,10 +239,26 @@ export function useMapCore({
 				constrainOnlyCenter: true,
 			});
 
-			// Create map with only the ortho layer (others added by consuming code)
+			const fallbackThumbnailPath = thumbnailPathRef.current;
+			const fallbackOrthoLayer =
+				!supportsWebGL && fallbackThumbnailPath
+					? new ImageLayer({
+							source: new StaticImageSource({
+								url: Settings.THUMBNAIL_URL + fallbackThumbnailPath,
+								imageExtent: cogExtent as [number, number, number, number],
+								projection: "EPSG:3857",
+								crossOrigin: "anonymous",
+							}),
+						})
+					: null;
+			const displayOrthoLayer = orthoCogLayer ?? fallbackOrthoLayer;
+			orthoLayerRef.current = displayOrthoLayer;
+
+			// Create map with the COG layer when WebGL is available; otherwise the
+			// georeferenced thumbnail fallback occupies the same display layer slot.
 				const newMap = new Map({
 					target: containerRef.current,
-					layers: [orthoCogLayer],
+					layers: displayOrthoLayer ? [displayOrthoLayer] : [],
 					view: mapView,
 					controls: createStandardMapControls(),
 					interactions: createMapInteractions({
@@ -240,35 +294,40 @@ export function useMapCore({
 			mapRef.current = newMap;
 			setIsMapReady(true);
 			onMapReadyRef.current?.(newMap);
-			onOrthoLayerReadyRef.current?.(orthoCogLayer);
+			if (orthoCogLayer) {
+				onOrthoLayerReadyRef.current?.(orthoCogLayer);
+			}
 		}).catch((err) => {
 			console.error("Failed to get GeoTIFF view:", err);
 		});
 
-		// Cleanup
-		return () => {
-			if (mapRef.current) {
-				// Remove all layers
+			// Cleanup
+			return () => {
+				isDisposed = true;
+				if (mapRef.current) {
+					// Remove all layers
 					mapRef.current.getLayers().forEach((layer) => {
-						const disposableLayer = layer as DisposableLayer;
-						const source = disposableLayer.getSource?.();
-						if (source) {
-							if ("clear" in source && typeof source.clear === "function") source.clear();
-							if ("dispose" in source && typeof source.dispose === "function") source.dispose();
-						}
-						disposableLayer.dispose?.();
+						disposeLayerWithSource(layer as DisposableLayer);
 					});
 
-				mapRef.current.setTarget(undefined);
+					mapRef.current.setTarget(undefined);
 				mapRef.current.dispose();
 				mapRef.current = null;
 				orthoLayerRef.current = null;
 				hasSeenInitialMoveEndRef.current = false;
 				hasTrackedInteractionRef.current = false;
-				setIsMapReady(false);
-				setExtent(null);
-			}
-		};
+					setIsMapReady(false);
+					setExtent(null);
+				}
+				if (!mapRef.current && orthoLayerRef.current) {
+					disposeLayerWithSource(orthoLayerRef.current as DisposableLayer);
+					orthoLayerRef.current = null;
+				}
+				if (!orthoCogLayer) {
+					orthoCogSource.clear();
+					orthoCogSource.dispose();
+				}
+			};
 	// Note: callbacks/disableRotation are accessed via refs to avoid triggering
 	// re-runs. mapEnabled is latched (only ever false->true). The map therefore
 	// rebuilds only when the dataset (cogPath) or container changes — not on the

--- a/frontend/src/pages/Dataset.tsx
+++ b/frontend/src/pages/Dataset.tsx
@@ -26,7 +26,6 @@ import { useIsMobile } from "../hooks/useIsMobile";
 import { useDesktopOnlyFeature } from "../hooks/useDesktopOnlyFeature";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { useSemanticSearch } from "../hooks/useSemanticSearch";
-import { useCanAudit } from "../hooks/useUserPrivileges";
 
 type FilterTag =
   | "platform"
@@ -74,10 +73,8 @@ export default function Dataset() {
   // Incremented on explicit filter actions to trigger map zoom
   const [filterZoomTrigger, setFilterZoomTrigger] = useState(0);
 
-  // Open-vocabulary (CLIP) search. Coexists with the text filter above: when a
-  // semantic query is active the list is restricted to and ranked by matches.
-  // Gated to the core team (can_audit) for now while it's being refined.
-  const { canAudit } = useCanAudit();
+  // Open-vocabulary (CLIP) search is public; backend rate limiting protects the
+  // embedding endpoint instead of hiding the feature behind auditor privileges.
   const semantic = useSemanticSearch();
   const [semanticInput, setSemanticInput] = useState("");
 
@@ -265,7 +262,6 @@ export default function Dataset() {
       </div>
 
       <div className="flex flex-col gap-2 pb-4">
-        {canAudit && (
         <div className="flex flex-col gap-1">
           <Input.Search
             placeholder="AI search, e.g. 'standing dead trees', 'clearcut'"
@@ -311,7 +307,6 @@ export default function Dataset() {
             <div className="px-1 text-xs text-red-500">{semantic.error}</div>
           )}
         </div>
-        )}
         <div className="flex flex-col gap-2 sm:flex-row">
           <Input
             placeholder="Search by Authors or Location (Region, Province, City)"

--- a/frontend/src/pages/DatasetDetails.tsx
+++ b/frontend/src/pages/DatasetDetails.tsx
@@ -504,9 +504,9 @@ export default function DatasetDetails() {
           />
         </Suspense>
 
-        {/* Open-vocabulary search scoped to this orthophoto (highlights tiles).
-            Gated to the core team (can_audit) for now while it's being refined. */}
-        {!isEditing && dataset && canAudit && (
+        {/* Open-vocabulary search scoped to this orthophoto is public; backend
+            rate limiting protects embedding generation from automated abuse. */}
+        {!isEditing && dataset && (
           <div className="pointer-events-none absolute left-1/2 top-24 z-30 -translate-x-1/2">
             <div className="pointer-events-auto">
               <OrthoTileSearch

--- a/nginx/api-conf/storage-server.conf
+++ b/nginx/api-conf/storage-server.conf
@@ -3,6 +3,8 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+limit_req_zone $binary_remote_addr zone=search_embed_per_ip:10m rate=30r/m;
+
 server {
     server_name data2.deadtrees.earth data.deadtrees.earth;
 
@@ -16,6 +18,16 @@ server {
 
     index =401;
     # root /data;
+
+    location = /api/v1/search/embed {
+        rewrite  ^/api/v1/(.*)  /$1 break;
+        limit_req zone=search_embed_per_ip burst=10 nodelay;
+        proxy_pass http://api:40831;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     location = /api/v1/datasets/chunk {
         rewrite  ^/api/v1/(.*)  /$1 break;

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -3,6 +3,8 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+limit_req_zone $binary_remote_addr zone=search_embed_per_ip:10m rate=30r/m;
+
 server {
     server_name localhost;
     listen 80 default_server;
@@ -15,6 +17,20 @@ server {
 
     index =401;
     # root /data;
+
+
+    location = /api/v1/search/embed {
+        set $api_backend "api-test:8017";
+        rewrite  ^/api/v1/?(.*)$ /$1 break;
+        limit_req zone=search_embed_per_ip burst=10 nodelay;
+        proxy_pass http://$api_backend;
+
+        # Standard proxy headers
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
 
     location /api/v1 {

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
 	UVICORN_PORT: int = 8017 if DEV_MODE else 8000
 	UVICORN_ROOT_PATH: str = '/api/v1'
 	UVICORN_PROXY_HEADERS: bool = True
+	SEARCH_RATE_LIMIT_TRUSTED_PROXIES: str = '127.0.0.1,::1,172.16.0.0/12'
 
 	# storage server settings
 	STORAGE_SERVER_IP: str = ''


### PR DESCRIPTION
## Summary
- make dataset semantic search and detail tile search available to public users
- add a no-WebGL thumbnail fallback for embedded/browser environments that cannot render OpenLayers WebGL COG layers
- harden `/search/embed` rate limiting with an nginx edge limit and trusted-proxy backend client keys

## Why
Public users should be able to use open-vocabulary search without requiring audit privileges, while the embedding endpoint remains protected from unauthenticated automation/DoS.

## Validation
- `npm --prefix frontend run build`
- `PYTHONPATH=. venv/bin/pytest api/tests/test_search_embed.py` (`16 passed`)
- Browser plugin local checks: public dataset page shows AI search, query returns ranked matches, detail page shows tile-search input
- autoreview: `codex` + `claude:opus`, clean final run with no accepted/actionable findings

## Notes
- In-app Browser does not expose WebGL, so it uses the thumbnail fallback. Brave/normal browsers still render the real COG via WebGL.
