### PR TITLE
fix(frontend): bound Wayback imagery loading

### DIFF
--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -201,9 +201,6 @@ const DeadtreesMap = () => {
   >(null);
   const [flagDescription, setFlagDescription] = useState("");
   const [showFlagsLayer, setShowFlagsLayer] = useState(true);
-  const [currentZoom, setCurrentZoom] = useState<number>(
-    DeadwoodMapViewport.zoom || 10,
-  );
   const [flagCanFinish, setFlagCanFinish] = useState(false);
   const flagsLayerRef = useRef<VectorLayer<
     VectorSource<Feature<Polygon>>
@@ -257,7 +254,7 @@ const DeadtreesMap = () => {
   const [selectedReleaseNum, setSelectedReleaseNum] = useState<number | null>(
     DEFAULT_WAYBACK_RELEASE,
   );
-  const [autoMatchImagery, setAutoMatchImagery] = useState(true); // Auto-match imagery to prediction year
+  const [autoMatchImagery, setAutoMatchImagery] = useState(false); // Manual imagery selection by default
   const [shouldLoadLocalWaybackItems, setShouldLoadLocalWaybackItems] =
     useState(false);
 
@@ -274,13 +271,13 @@ const DeadtreesMap = () => {
     return null;
   });
 
-  // Fetch wayback items with actual imagery changes at current location (fast, no metadata)
-  // Uses debouncing: only re-fetches when user moves > 2km or zoom changes > 3 levels
+  // Fetch wayback items with actual imagery changes at current location.
+  // Candidate discovery is debounced and location-based; zooming should not
+  // replace the currently rendered basemap release.
   const { data: localWaybackItems = [], isLoading: isWaybackLoading } =
     useWaybackItemsDebounced(
       mapCenterLonLat?.lon,
       mapCenterLonLat?.lat,
-      currentZoom,
       DeadwoodMapStyle === "wayback" && shouldLoadLocalWaybackItems,
     );
 
@@ -580,8 +577,6 @@ const DeadtreesMap = () => {
             zoom,
           });
         }
-        setCurrentZoom(zoom || 10);
-
         // Update lon/lat center for wayback queries
         if (center) {
           const [lon, lat] = toLonLat(center);

--- a/frontend/src/components/DeadwoodMap/YearImagerySelector.test.ts
+++ b/frontend/src/components/DeadwoodMap/YearImagerySelector.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { WaybackItemWithMetadata } from "../../hooks/useWaybackItems";
+import { findClosestImagery } from "./YearImagerySelector";
+
+const item = (
+  releaseNum: number,
+  releaseDateLabel: string,
+  acquisitionDate?: string,
+): WaybackItemWithMetadata => ({
+  itemID: `item-${releaseNum}`,
+  itemTitle: `World Imagery (Wayback ${releaseDateLabel})`,
+  itemURL: `https://example.com/${releaseNum}/{level}/{row}/{col}`,
+  metadataLayerUrl: `https://metadata.example.com/${releaseNum}`,
+  metadataLayerItemID: `metadata-${releaseNum}`,
+  layerIdentifier: `WB_${releaseNum}`,
+  releaseNum,
+  releaseDateLabel,
+  releaseDatetime: new Date(releaseDateLabel).getTime(),
+  acquisitionDate: acquisitionDate ? new Date(acquisitionDate) : undefined,
+});
+
+describe("findClosestImagery", () => {
+  it("uses release dates when metadata acquisition dates are unavailable", () => {
+    const closest = findClosestImagery(
+      [
+        item(100, "1999-01-15", "1999-01-15"),
+        item(200, "2022-10-04"),
+        item(300, "2024-08-20"),
+      ],
+      2025,
+    );
+
+    expect(closest?.releaseNum).toBe(300);
+  });
+});

--- a/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
+++ b/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
@@ -49,6 +49,19 @@ const formatResolution = (resolution: number | undefined): string => {
   return `${resolution}m`;
 };
 
+export const getImageryDate = (
+  item: WaybackItemWithMetadata | null | undefined,
+): Date | undefined => {
+  if (!item) return undefined;
+  if (item.acquisitionDate) return item.acquisitionDate;
+  if (item.releaseDatetime) return new Date(item.releaseDatetime);
+  if (item.releaseDateLabel) return new Date(item.releaseDateLabel);
+  return undefined;
+};
+
+const getImageryYear = (item: WaybackItemWithMetadata): number | undefined =>
+  getImageryDate(item)?.getFullYear();
+
 /**
  * Find the closest imagery to a target year, preferring older over newer
  */
@@ -59,8 +72,8 @@ export const findClosestImagery = (
   if (items.length === 0) return null;
 
   return items.reduce((closest, item) => {
-    const itemYear = item.acquisitionDate?.getFullYear() || 0;
-    const closestYear = closest.acquisitionDate?.getFullYear() || 0;
+    const itemYear = getImageryYear(item) || 0;
+    const closestYear = getImageryYear(closest) || 0;
 
     const itemDiff = itemYear - targetYear;
     const closestDiff = closestYear - targetYear;
@@ -122,7 +135,7 @@ const YearImagerySelector = ({
   waybackItems,
   isLoading = false,
   isWaybackActive = true,
-  autoMatchImagery = true,
+  autoMatchImagery = false,
   onAutoMatchChange,
   showForest = false,
   showDeadwood = false,
@@ -144,7 +157,7 @@ const YearImagerySelector = ({
   const yearsWithImagery = useMemo(() => {
     const years = new Set<string>();
     waybackItems.forEach((item) => {
-      const year = item.acquisitionDate?.getFullYear().toString();
+      const year = getImageryYear(item)?.toString();
       if (year) years.add(year);
     });
     return years;
@@ -172,46 +185,32 @@ const YearImagerySelector = ({
     [yearsWithImagery],
   );
 
-  // Check if current selection is valid (exists in current waybackItems)
-  const isSelectionValid =
-    selectedReleaseNum !== null &&
-    waybackItems.some((item) => item.releaseNum === selectedReleaseNum);
-
-  // Auto-select imagery when items load or when current selection becomes invalid
+  // Auto-select imagery when items load, when the prediction year changes, or
+  // when no basemap has been selected yet. Manual mode keeps the active
+  // basemap sticky even if it is outside the local candidate list.
   useEffect(() => {
-    if (waybackItems.length > 0 && (!selectedReleaseNum || !isSelectionValid)) {
-      if (autoMatchImagery) {
-        const targetYear = parseInt(predictionYear);
-        const closestItem = findClosestImagery(waybackItems, targetYear);
-        if (closestItem) {
-          onImageryChange(closestItem.releaseNum);
-        }
-      } else {
-        // Select the newest (rightmost) item
-        onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
+    if (waybackItems.length === 0) return;
+
+    if (autoMatchImagery) {
+      const targetYear = parseInt(predictionYear);
+      const closestItem = findClosestImagery(waybackItems, targetYear);
+      if (closestItem && closestItem.releaseNum !== selectedReleaseNum) {
+        onImageryChange(closestItem.releaseNum);
       }
+      return;
+    }
+
+    if (!selectedReleaseNum) {
+      // Select the newest (rightmost) item
+      onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
     }
   }, [
     waybackItems,
     selectedReleaseNum,
-    isSelectionValid,
     onImageryChange,
     autoMatchImagery,
     predictionYear,
   ]);
-
-  // Auto-match imagery when prediction year changes (if enabled)
-  useEffect(() => {
-    if (!autoMatchImagery || waybackItems.length === 0 || !selectedReleaseNum)
-      return;
-
-    const targetYear = parseInt(predictionYear);
-    const closestItem = findClosestImagery(waybackItems, targetYear);
-    if (closestItem && closestItem.releaseNum !== selectedReleaseNum) {
-      onImageryChange(closestItem.releaseNum);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [predictionYear, autoMatchImagery]); // Only trigger on year change or toggle change
 
   // Navigation for prediction year
   const predictionIndex = PREDICTION_YEARS.indexOf(predictionYear);
@@ -236,27 +235,55 @@ const YearImagerySelector = ({
   );
   const selectedItem =
     currentImageryIndex >= 0 ? waybackItems[currentImageryIndex] : null;
+  const hasSelectedBasemap = selectedReleaseNum !== null;
+  const isUsingDefaultBasemap = hasSelectedBasemap && !selectedItem;
   const hasMultipleImages = waybackItems.length > 1;
-  const isImageryFirst = currentImageryIndex <= 0;
-  const isImageryLast = currentImageryIndex >= waybackItems.length - 1;
+  const canNavigateImagery =
+    waybackItems.length > 0 && (hasMultipleImages || currentImageryIndex < 0);
+  const isSelectionOutsideCandidates = currentImageryIndex < 0;
+  const isImageryFirst =
+    waybackItems.length === 0 ||
+    (!isSelectionOutsideCandidates && currentImageryIndex <= 0);
+  const isImageryLast =
+    waybackItems.length === 0 ||
+    (!isSelectionOutsideCandidates &&
+      currentImageryIndex >= waybackItems.length - 1);
 
   // Navigation: ← goes to older (lower index), → goes to newer (higher index)
   const handleImageryPrev = () => {
+    if (isSelectionOutsideCandidates && waybackItems.length > 0) {
+      if (autoMatchImagery) onAutoMatchChange?.(false);
+      onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
+      return;
+    }
+
     if (!isImageryFirst && waybackItems[currentImageryIndex - 1]) {
+      if (autoMatchImagery) onAutoMatchChange?.(false);
       onImageryChange(waybackItems[currentImageryIndex - 1].releaseNum);
     }
   };
 
   const handleImageryNext = () => {
+    if (isSelectionOutsideCandidates && waybackItems.length > 0) {
+      if (autoMatchImagery) onAutoMatchChange?.(false);
+      onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
+      return;
+    }
+
     if (!isImageryLast && waybackItems[currentImageryIndex + 1]) {
+      if (autoMatchImagery) onAutoMatchChange?.(false);
       onImageryChange(waybackItems[currentImageryIndex + 1].releaseNum);
     }
   };
 
-  const hasNoImagery = waybackItems.length === 0 && !isLoading;
+  const shouldShowBlockingLoading = isLoading && !hasSelectedBasemap;
+  const hasNoImagery = waybackItems.length === 0 && !isLoading && !hasSelectedBasemap;
 
   // Get the base map year for display
-  const baseMapYear = selectedItem?.acquisitionDate?.getFullYear();
+  const selectedImageryDate = selectedItem
+    ? getImageryDate(selectedItem)
+    : undefined;
+  const baseMapYear = selectedImageryDate?.getFullYear();
   const yearsMatch = baseMapYear?.toString() === predictionYear;
   const compactTopButtonClass =
     "flex h-7 w-7 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-300";
@@ -367,7 +394,7 @@ const YearImagerySelector = ({
             )}
 
           <div className="flex w-full items-center justify-center gap-2 overflow-x-auto">
-            {isLoading ? (
+            {shouldShowBlockingLoading ? (
               <div className="flex items-center gap-2 text-gray-400">
                 <Spin
                   indicator={<LoadingOutlined style={{ fontSize: 14 }} spin />}
@@ -383,7 +410,7 @@ const YearImagerySelector = ({
             ) : (
               <>
                 {/* Navigation arrow: ← older */}
-                {hasMultipleImages && (
+                {canNavigateImagery && (
                   <button
                     onClick={handleImageryPrev}
                     disabled={isImageryFirst}
@@ -407,7 +434,7 @@ const YearImagerySelector = ({
                         <div className="text-center">
                           <div className="font-medium">Satellite Imagery</div>
                           <div className="mt-1">
-                            Captured: {formatDate(selectedItem.acquisitionDate)}
+                            Date: {formatDate(selectedImageryDate)}
                           </div>
                           {selectedItem.provider && (
                             <div>Provider: {selectedItem.provider}</div>
@@ -433,7 +460,7 @@ const YearImagerySelector = ({
                     >
                       <div className="flex cursor-help items-center gap-1.5 text-xs">
                         <span className="font-medium text-gray-700">
-                          {formatDate(selectedItem.acquisitionDate)}
+                          {formatDate(selectedImageryDate)}
                         </span>
                         {!compactMode && selectedItem.provider && (
                           <span className="text-gray-400">·</span>
@@ -459,14 +486,24 @@ const YearImagerySelector = ({
                       </div>
                     </Tooltip>
                   ) : (
-                    <span className="text-xs text-gray-400">
-                      No imagery selected
-                    </span>
+                    <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                      <span>Satellite basemap active</span>
+                      {isLoading && !compactMode && (
+                        <span className="text-gray-400">
+                          checking local imagery dates
+                        </span>
+                      )}
+                      {!isLoading && isUsingDefaultBasemap && !compactMode && (
+                        <span className="text-gray-400">
+                          local imagery dates unavailable
+                        </span>
+                      )}
+                    </div>
                   )}
                 </div>
 
                 {/* Navigation arrow: → newer */}
-                {hasMultipleImages && (
+                {canNavigateImagery && (
                   <button
                     onClick={handleImageryNext}
                     disabled={isImageryLast}

--- a/frontend/src/components/DeadwoodMap/mobile/MobileTimeCard.tsx
+++ b/frontend/src/components/DeadwoodMap/mobile/MobileTimeCard.tsx
@@ -10,6 +10,7 @@ import {
 import type { WaybackItemWithMetadata } from "../../../hooks/useWaybackItems";
 import {
   findClosestImagery,
+  getImageryDate,
   PREDICTION_YEARS,
 } from "../YearImagerySelector";
 
@@ -69,8 +70,14 @@ const MobileTimeCard = ({
     (item) => item.releaseNum === selectedReleaseNum,
   );
   const selectedImagery = imageryIndex >= 0 ? waybackItems[imageryIndex] : null;
+  const isSelectionOutsideCandidates =
+    selectedReleaseNum !== null && imageryIndex < 0 && waybackItems.length > 0;
+  const canStepToOlder = isSelectionOutsideCandidates || imageryIndex > 0;
+  const canStepToNewer =
+    isSelectionOutsideCandidates ||
+    (imageryIndex >= 0 && imageryIndex < waybackItems.length - 1);
 
-  const imageryDate = formatDate(selectedImagery?.acquisitionDate);
+  const imageryDate = formatDate(getImageryDate(selectedImagery));
   const imageryPosition =
     imageryIndex >= 0 ? `${imageryIndex + 1} of ${waybackItems.length}` : null;
   // Date is the headline when known; otherwise fall back to the position so
@@ -97,6 +104,16 @@ const MobileTimeCard = ({
   };
 
   const stepImagery = (offset: number) => {
+    if (isSelectionOutsideCandidates) {
+      // Enter the discovered candidate list at its newest image while keeping
+      // the default basemap sticky until the user explicitly steps.
+      const newestCandidate = waybackItems[waybackItems.length - 1];
+      if (!newestCandidate) return;
+      if (autoMatchImagery) onAutoMatchChange(false);
+      onImageryChange(newestCandidate.releaseNum);
+      return;
+    }
+
     const item = waybackItems[imageryIndex + offset];
     if (!item) return;
     // Hand-picking an image breaks the link to the prediction year.
@@ -171,7 +188,7 @@ const MobileTimeCard = ({
             <div className={stepperRowClass}>
               <Button
                 icon={<LeftOutlined />}
-                disabled={imageryIndex <= 0}
+                disabled={!canStepToOlder}
                 onClick={() => stepImagery(-1)}
                 aria-label="Older satellite image"
                 className="!h-11 !w-11"
@@ -186,9 +203,7 @@ const MobileTimeCard = ({
               </div>
               <Button
                 icon={<RightOutlined />}
-                disabled={
-                  imageryIndex < 0 || imageryIndex >= waybackItems.length - 1
-                }
+                disabled={!canStepToNewer}
                 onClick={() => stepImagery(1)}
                 aria-label="Newer satellite image"
                 className="!h-11 !w-11"

--- a/frontend/src/components/DeadwoodMap/mobile/useMobileImageryAutoSelect.ts
+++ b/frontend/src/components/DeadwoodMap/mobile/useMobileImageryAutoSelect.ts
@@ -26,47 +26,27 @@ export const useMobileImageryAutoSelect = ({
   autoMatchImagery,
   predictionYear,
 }: Params) => {
-  const isSelectionValid =
-    selectedReleaseNum !== null &&
-    waybackItems.some((item) => item.releaseNum === selectedReleaseNum);
-
-  // Select imagery when items load or when the current selection is invalid.
+  // Select imagery when items load or when the prediction year changes. Manual
+  // mode keeps the active basemap sticky even if it is outside the local
+  // candidate list.
   useEffect(() => {
     if (!enabled) return;
     if (waybackItems.length === 0) return;
-    if (selectedReleaseNum && isSelectionValid) return;
 
     if (autoMatchImagery) {
       const closest = findClosestImagery(waybackItems, parseInt(predictionYear));
-      if (closest) onImageryChange(closest.releaseNum);
-    } else {
+      if (closest && closest.releaseNum !== selectedReleaseNum) {
+        onImageryChange(closest.releaseNum);
+      }
+    } else if (!selectedReleaseNum) {
       onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
     }
   }, [
     enabled,
     waybackItems,
     selectedReleaseNum,
-    isSelectionValid,
     autoMatchImagery,
     predictionYear,
     onImageryChange,
-  ]);
-
-  // Re-match imagery when the prediction year changes (if auto-match is on).
-  useEffect(() => {
-    if (!enabled || !autoMatchImagery) return;
-    if (waybackItems.length === 0 || !selectedReleaseNum) return;
-
-    const closest = findClosestImagery(waybackItems, parseInt(predictionYear));
-    if (closest && closest.releaseNum !== selectedReleaseNum) {
-      onImageryChange(closest.releaseNum);
-    }
-  }, [
-    enabled,
-    waybackItems,
-    selectedReleaseNum,
-    onImageryChange,
-    predictionYear,
-    autoMatchImagery,
   ]);
 };

--- a/frontend/src/hooks/useWaybackItems.test.ts
+++ b/frontend/src/hooks/useWaybackItems.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WaybackItem, WaybackMetadata } from "@esri/wayback-core";
+import { loadWaybackItemsWithMetadata } from "./useWaybackItems";
+
+const point = { longitude: 10.451526, latitude: 51.165691 };
+
+const waybackItem = (
+  releaseNum: number,
+  releaseDateLabel = "2022-10-04",
+): WaybackItem => ({
+  itemID: `item-${releaseNum}`,
+  itemTitle: `World Imagery (Wayback ${releaseDateLabel})`,
+  itemURL: `https://example.com/${releaseNum}/{level}/{row}/{col}`,
+  metadataLayerUrl: `https://metadata.example.com/${releaseNum}`,
+  metadataLayerItemID: `metadata-${releaseNum}`,
+  layerIdentifier: `WB_${releaseNum}`,
+  releaseNum,
+  releaseDateLabel,
+  releaseDatetime: new Date(releaseDateLabel).getTime(),
+});
+
+const metadata = (date: string): WaybackMetadata => ({
+  date: new Date(date).getTime(),
+  provider: "Vantor",
+  source: "WV02",
+  resolution: 0.3,
+  accuracy: 5,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadWaybackItemsWithMetadata", () => {
+  it("keeps discovery timeouts retryable instead of caching empty imagery", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const startedAt = Date.now();
+    await expect(
+      loadWaybackItemsWithMetadata(point, 12, {
+        itemsTimeoutMs: 10,
+        getItemsWithLocalChanges: () =>
+          new Promise<WaybackItem[]>(() => undefined),
+      }),
+    ).rejects.toThrow("Wayback imagery discovery timed out");
+
+    expect(Date.now() - startedAt).toBeLessThan(250);
+  });
+
+  it("keeps imagery usable when metadata exceeds the timeout", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const item = waybackItem(31144);
+
+    const startedAt = Date.now();
+    const result = await loadWaybackItemsWithMetadata(point, 12, {
+      metadataTimeoutMs: 10,
+      getItemsWithLocalChanges: async () => [item],
+      getItemMetadata: () =>
+        new Promise<WaybackMetadata | null>(() => undefined),
+    });
+
+    expect(Date.now() - startedAt).toBeLessThan(250);
+    expect(result).toHaveLength(1);
+    expect(result[0].releaseNum).toBe(31144);
+    expect(result[0].metadata).toBeUndefined();
+    expect(result[0].provider).toBeUndefined();
+  });
+
+  it("uses accurate local Wayback duplicate detection", async () => {
+    const getItemsWithLocalChanges = vi
+      .fn()
+      .mockResolvedValue([waybackItem(31144)]);
+
+    await loadWaybackItemsWithMetadata(point, 12, {
+      getItemsWithLocalChanges,
+      getItemMetadata: async () => metadata("2022-10-04"),
+    });
+
+    expect(getItemsWithLocalChanges).toHaveBeenCalledWith(point, 12);
+  });
+});

--- a/frontend/src/hooks/useWaybackItems.ts
+++ b/frontend/src/hooks/useWaybackItems.ts
@@ -7,6 +7,9 @@ import {
   type WaybackMetadata,
 } from "@esri/wayback-core";
 
+export const WAYBACK_ITEMS_TIMEOUT_MS = 8_000;
+export const WAYBACK_METADATA_TIMEOUT_MS = 3_000;
+
 /**
  * Extended WaybackItem with actual acquisition metadata
  */
@@ -21,6 +24,115 @@ export interface WaybackItemWithMetadata extends WaybackItem {
   /** Resolution in meters */
   resolution?: number;
 }
+
+type WaybackPoint = {
+  longitude: number;
+  latitude: number;
+};
+
+interface LoadWaybackItemsOptions {
+  itemsTimeoutMs?: number;
+  metadataTimeoutMs?: number;
+  getItemsWithLocalChanges?: typeof getWaybackItemsWithLocalChanges;
+  getItemMetadata?: typeof getMetadata;
+}
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timeoutHandle = globalThis.setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        globalThis.clearTimeout(timeoutHandle);
+        resolve(value);
+      },
+      (error) => {
+        globalThis.clearTimeout(timeoutHandle);
+        reject(error);
+      },
+    );
+  });
+
+const toWaybackItemWithMetadata = (
+  item: WaybackItem,
+  metadata: WaybackMetadata | null | undefined,
+): WaybackItemWithMetadata => ({
+  ...item,
+  metadata: metadata ?? undefined,
+  acquisitionDate: metadata?.date ? new Date(metadata.date) : undefined,
+  provider: metadata?.provider,
+  source: metadata?.source,
+  resolution: metadata?.resolution,
+});
+
+export const loadWaybackItemsWithMetadata = async (
+  point: WaybackPoint,
+  zoomLevel: number,
+  {
+    itemsTimeoutMs = WAYBACK_ITEMS_TIMEOUT_MS,
+    metadataTimeoutMs = WAYBACK_METADATA_TIMEOUT_MS,
+    getItemsWithLocalChanges = getWaybackItemsWithLocalChanges,
+    getItemMetadata = getMetadata,
+  }: LoadWaybackItemsOptions = {},
+): Promise<WaybackItemWithMetadata[]> => {
+  let items: WaybackItem[];
+
+  try {
+    items = await withTimeout(
+      getItemsWithLocalChanges(point, zoomLevel),
+      itemsTimeoutMs,
+      `Wayback imagery discovery timed out after ${itemsTimeoutMs}ms`,
+    );
+  } catch (error) {
+    console.warn("Failed to load local Wayback imagery", error);
+    throw error;
+  }
+
+  if (items.length === 0) return [];
+
+  const itemsWithMetadata = await Promise.all(
+    items.map(async (item): Promise<WaybackItemWithMetadata> => {
+      try {
+        const metadata = await withTimeout(
+          getItemMetadata(point, zoomLevel, item.releaseNum),
+          metadataTimeoutMs,
+          `Wayback metadata timed out after ${metadataTimeoutMs}ms for release ${item.releaseNum}`,
+        );
+        return toWaybackItemWithMetadata(item, metadata);
+      } catch (error) {
+        console.warn(
+          `Failed to fetch metadata for release ${item.releaseNum}:`,
+          error,
+        );
+        return toWaybackItemWithMetadata(item, undefined);
+      }
+    }),
+  );
+
+  const dateMap = new Map<string, WaybackItemWithMetadata>();
+  itemsWithMetadata.forEach((item) => {
+    const dateKey =
+      item.acquisitionDate?.toISOString() ||
+      item.releaseDateLabel ||
+      String(item.releaseNum);
+    const existing = dateMap.get(dateKey);
+    if (!existing || item.releaseNum > existing.releaseNum) {
+      dateMap.set(dateKey, item);
+    }
+  });
+
+  return Array.from(dateMap.values()).sort((a, b) => {
+    const dateA = a.acquisitionDate?.getTime() || a.releaseDatetime || 0;
+    const dateB = b.acquisitionDate?.getTime() || b.releaseDatetime || 0;
+    return dateA - dateB;
+  });
+};
 
 /**
  * Calculate distance between two coordinates in meters (Haversine formula)
@@ -38,8 +150,9 @@ const getDistanceInMeters = (lon1: number, lat1: number, lon2: number, lat2: num
 
 // Distance threshold for re-fetching (2km - imagery doesn't change much spatially)
 const REFETCH_DISTANCE_METERS = 2000;
-// Zoom threshold for re-fetching
-const REFETCH_ZOOM_LEVELS = 3;
+export const WAYBACK_CANDIDATE_DISCOVERY_ZOOM = 12;
+export const WAYBACK_CANDIDATE_DEBOUNCE_MS = 1_000;
+export const WAYBACK_CANDIDATE_THROTTLE_MS = 10_000;
 
 /**
  * Hook to fetch Wayback items with actual imagery changes at this location.
@@ -50,88 +163,91 @@ const REFETCH_ZOOM_LEVELS = 3;
  * 3. Deduplicates by acquisition date (same satellite capture = same image)
  * 4. Sorts by acquisition date ascending (oldest left, newest right)
  *
- * Only re-fetches when location changes significantly (>2km or >3 zoom levels)
+ * Only re-fetches when location changes significantly (>2km). Zoom changes do
+ * not invalidate candidate discovery because the active basemap release should
+ * stay stable while the map requests normal tiles for the new view.
  */
 export const useWaybackItemsDebounced = (
   longitude: number | undefined,
   latitude: number | undefined,
-  zoom: number | undefined,
   enabled: boolean = true,
 ) => {
   // Track the last fetched location
-  const lastFetchRef = useRef<{ lon: number; lat: number; zoom: number } | null>(null);
-  const [stableCoords, setStableCoords] = useState<{ lon: number; lat: number; zoom: number } | null>(null);
+  const lastFetchRef = useRef<{ lon: number; lat: number } | null>(null);
+  const lastFetchAtRef = useRef(0);
+  const debounceHandleRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const throttleHandleRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const [stableCoords, setStableCoords] = useState<{ lon: number; lat: number } | null>(null);
 
   useEffect(() => {
-    if (longitude === undefined || latitude === undefined || zoom === undefined) return;
+    if (!enabled || longitude === undefined || latitude === undefined) return;
 
     const last = lastFetchRef.current;
+    const nextCoords = { lon: longitude, lat: latitude };
     const shouldFetch =
       !last ||
-      getDistanceInMeters(last.lon, last.lat, longitude, latitude) > REFETCH_DISTANCE_METERS ||
-      Math.abs(last.zoom - zoom) > REFETCH_ZOOM_LEVELS;
+      getDistanceInMeters(last.lon, last.lat, longitude, latitude) >
+        REFETCH_DISTANCE_METERS;
 
-    if (shouldFetch) {
-      lastFetchRef.current = { lon: longitude, lat: latitude, zoom };
-      setStableCoords({ lon: longitude, lat: latitude, zoom });
+    if (!shouldFetch) return;
+
+    if (debounceHandleRef.current) {
+      globalThis.clearTimeout(debounceHandleRef.current);
     }
-  }, [longitude, latitude, zoom]);
+    if (throttleHandleRef.current) {
+      globalThis.clearTimeout(throttleHandleRef.current);
+    }
+
+    const applyNextCoords = () => {
+      lastFetchRef.current = nextCoords;
+      lastFetchAtRef.current = Date.now();
+      setStableCoords(nextCoords);
+    };
+
+    debounceHandleRef.current = globalThis.setTimeout(() => {
+      const elapsedSinceFetch = Date.now() - lastFetchAtRef.current;
+      if (
+        lastFetchAtRef.current === 0 ||
+        elapsedSinceFetch >= WAYBACK_CANDIDATE_THROTTLE_MS
+      ) {
+        applyNextCoords();
+        return;
+      }
+
+      throttleHandleRef.current = globalThis.setTimeout(
+        applyNextCoords,
+        WAYBACK_CANDIDATE_THROTTLE_MS - elapsedSinceFetch,
+      );
+    }, WAYBACK_CANDIDATE_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceHandleRef.current) {
+        globalThis.clearTimeout(debounceHandleRef.current);
+        debounceHandleRef.current = null;
+      }
+      if (throttleHandleRef.current) {
+        globalThis.clearTimeout(throttleHandleRef.current);
+        throttleHandleRef.current = null;
+      }
+    };
+  }, [longitude, latitude, enabled]);
 
   return useQuery({
-    queryKey: ["wayback-items-with-metadata", stableCoords?.lon, stableCoords?.lat, stableCoords?.zoom],
+    queryKey: [
+      "wayback-items-with-metadata",
+      stableCoords?.lon,
+      stableCoords?.lat,
+      WAYBACK_CANDIDATE_DISCOVERY_ZOOM,
+    ],
     queryFn: async (): Promise<WaybackItemWithMetadata[]> => {
       if (!stableCoords) return [];
 
       const point = { longitude: stableCoords.lon, latitude: stableCoords.lat };
-      const zoomLevel = Math.round(stableCoords.zoom);
 
-      // Step 1: Get items with actual local changes (unique imagery)
-      const items = await getWaybackItemsWithLocalChanges(point, zoomLevel);
-
-      if (items.length === 0) return [];
-
-      // Step 2: Fetch metadata for ALL items in parallel
-      const metadataPromises = items.map(async (item): Promise<WaybackItemWithMetadata> => {
-        try {
-          const metadata = (await getMetadata(point, zoomLevel, item.releaseNum)) ?? undefined;
-          return {
-            ...item,
-            metadata,
-            acquisitionDate: metadata?.date ? new Date(metadata.date) : undefined,
-            provider: metadata?.provider,
-            source: metadata?.source,
-            resolution: metadata?.resolution,
-          };
-        } catch (error) {
-          console.warn(`Failed to fetch metadata for release ${item.releaseNum}:`, error);
-          return { ...item };
-        }
-      });
-
-      const itemsWithMetadata = await Promise.all(metadataPromises);
-
-      // Step 3: DEDUPLICATE by acquisition date - keep only one item per unique capture date
-      // This removes duplicates where same satellite image was re-processed multiple times
-      const dateMap = new Map<string, WaybackItemWithMetadata>();
-      itemsWithMetadata.forEach((item) => {
-        // Use acquisition date as key, or release date as fallback
-        const dateKey = item.acquisitionDate?.toISOString() || item.releaseDateLabel || String(item.releaseNum);
-        // Keep the item with highest releaseNum (most recent processing) for each date
-        const existing = dateMap.get(dateKey);
-        if (!existing || item.releaseNum > existing.releaseNum) {
-          dateMap.set(dateKey, item);
-        }
-      });
-      const deduplicated = Array.from(dateMap.values());
-
-      // Step 4: Sort by acquisition date ASCENDING (oldest first for left→right navigation)
-      const sorted = deduplicated.sort((a, b) => {
-        const dateA = a.acquisitionDate?.getTime() || 0;
-        const dateB = b.acquisitionDate?.getTime() || 0;
-        return dateA - dateB; // Ascending: oldest first (left), newest last (right)
-      });
-
-      return sorted;
+      return loadWaybackItemsWithMetadata(
+        point,
+        WAYBACK_CANDIDATE_DISCOVERY_ZOOM,
+      );
     },
     enabled: enabled && stableCoords !== null,
     staleTime: 30 * 60 * 1000, // Cache for 30 minutes


### PR DESCRIPTION
## Summary
- Bound local Wayback imagery discovery and metadata lookups so slow Esri responses cannot block the DeadTrees map controls indefinitely.
- Keep the default satellite basemap/product visualization usable while local imagery metadata is still loading or unavailable.
- Use Wayback release dates as fallback dates when acquisition metadata times out.
- Leave prediction-year and basemap sync off by default; users can explicitly enable the link button when they want auto-matching.
- Decouple candidate discovery from map zoom: zooming only requests tiles for the selected basemap release, while candidate discovery is debounced/throttled and location-based.
- Keep manual basemap selection sticky even when the selected release is not present in the newest local candidate list.

## Validation
- `npm --prefix frontend test` — 22 files / 120 tests passed
- `npm --prefix frontend run lint -- --quiet` — passed
- `npm --prefix frontend run build` — passed, with existing Vite chunk/dynamic-import warnings
- `scripts/lint-ast-grep.sh` — passed
- Browser validation at `http://127.0.0.1:5174/deadtrees`: reload, wait past Wayback timeout, and switch years; the blocking “Finding basemap imagery...” message did not appear and the map controls stayed responsive.
- Browser validation after default-sync change: fresh reload starts with the link button off; switching `2025 -> 2024` changes the prediction year while keeping the basemap fixed.
- Browser CDP network validation after zoom change: initial candidate discovery requested multiple Wayback releases; after zooming, new Wayback requests were only for selected release `31144`, with no multi-release rediscovery sweep.

## Risk
- Metadata timeouts now show release-date fallback information instead of waiting indefinitely for acquisition metadata.
- Wayback discovery timeouts remain retryable query failures instead of cacheable “no imagery” results.
- Candidate discovery now uses a fixed internal zoom and refreshes only after meaningful center movement, so the candidate list is intentionally less twitchy during zoom-only interaction.
- Wayback metadata timeout warnings may appear in dev logs when Esri is slow; the user-facing map remains usable.
