### PR TITLE
fix(frontend): defer Wayback candidate probing

### DIFF
--- a/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
+++ b/frontend/src/components/DeadwoodMap/DeadtreesMap.tsx
@@ -618,21 +618,6 @@ const DeadtreesMap = () => {
 
   // effects -----------------------------------------------------------
 
-  useEffect(() => {
-    if (DeadwoodMapStyle !== "wayback" || shouldLoadLocalWaybackItems) return;
-
-    const loadLocalImagery = () => setShouldLoadLocalWaybackItems(true);
-    if (typeof window.requestIdleCallback === "function") {
-      const idleHandle = window.requestIdleCallback(loadLocalImagery, {
-        timeout: 3000,
-      });
-      return () => window.cancelIdleCallback(idleHandle);
-    }
-
-    const timeoutHandle = window.setTimeout(loadLocalImagery, 1500);
-    return () => window.clearTimeout(timeoutHandle);
-  }, [DeadwoodMapStyle, shouldLoadLocalWaybackItems]);
-
   // update on bounds change after geocoder search
   useEffect(() => {
     if (map && bounds.length > 0) {
@@ -1112,9 +1097,6 @@ const DeadtreesMap = () => {
       setDeadwoodMapStyle((currentStyle) =>
         currentStyle === style ? "none" : style,
       );
-      if (style === "wayback") {
-        setShouldLoadLocalWaybackItems(true);
-      }
     },
     [setDeadwoodMapStyle],
   );
@@ -1390,7 +1372,11 @@ const DeadtreesMap = () => {
               isLoading={isWaybackLoading}
               isWaybackActive={DeadwoodMapStyle === "wayback"}
               autoMatchImagery={autoMatchImagery}
-              onAutoMatchChange={setAutoMatchImagery}
+              onAutoMatchChange={(enabled) => {
+                setShouldLoadLocalWaybackItems(true);
+                setAutoMatchImagery(enabled);
+              }}
+              onRequestLocalImagery={() => setShouldLoadLocalWaybackItems(true)}
               showForest={showForest}
               showDeadwood={showDeadwood}
               compactMode={isMobile}

--- a/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
+++ b/frontend/src/components/DeadwoodMap/YearImagerySelector.tsx
@@ -110,6 +110,8 @@ interface YearImagerySelectorProps {
   autoMatchImagery?: boolean;
   /** Callback when auto-match setting changes */
   onAutoMatchChange?: (enabled: boolean) => void;
+  /** Callback when the user asks for local imagery candidates */
+  onRequestLocalImagery?: () => void;
   /** Whether tree cover layer is shown */
   showForest?: boolean;
   /** Whether standing deadwood layer is shown */
@@ -137,6 +139,7 @@ const YearImagerySelector = ({
   isWaybackActive = true,
   autoMatchImagery = false,
   onAutoMatchChange,
+  onRequestLocalImagery,
   showForest = false,
   showDeadwood = false,
   compactMode = false,
@@ -251,6 +254,8 @@ const YearImagerySelector = ({
 
   // Navigation: ← goes to older (lower index), → goes to newer (higher index)
   const handleImageryPrev = () => {
+    onRequestLocalImagery?.();
+
     if (isSelectionOutsideCandidates && waybackItems.length > 0) {
       if (autoMatchImagery) onAutoMatchChange?.(false);
       onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
@@ -264,6 +269,8 @@ const YearImagerySelector = ({
   };
 
   const handleImageryNext = () => {
+    onRequestLocalImagery?.();
+
     if (isSelectionOutsideCandidates && waybackItems.length > 0) {
       if (autoMatchImagery) onAutoMatchChange?.(false);
       onImageryChange(waybackItems[waybackItems.length - 1].releaseNum);
@@ -342,7 +349,10 @@ const YearImagerySelector = ({
                 size="small"
                 type={autoMatchImagery ? "primary" : "default"}
                 icon={<LinkOutlined />}
-                onClick={() => onAutoMatchChange?.(!autoMatchImagery)}
+                onClick={() => {
+                  onRequestLocalImagery?.();
+                  onAutoMatchChange?.(!autoMatchImagery);
+                }}
                 className="ml-1"
               />
             </Tooltip>

--- a/frontend/src/hooks/useWaybackItems.test.ts
+++ b/frontend/src/hooks/useWaybackItems.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { WaybackItem, WaybackMetadata } from "@esri/wayback-core";
-import { loadWaybackItemsWithMetadata } from "./useWaybackItems";
+import type { WaybackItem } from "@esri/wayback-core";
+import { loadGlobalWaybackItems, loadLocalWaybackItems } from "./useWaybackItems";
 
 const point = { longitude: 10.451526, latitude: 51.165691 };
 
@@ -19,25 +19,35 @@ const waybackItem = (
   releaseDatetime: new Date(releaseDateLabel).getTime(),
 });
 
-const metadata = (date: string): WaybackMetadata => ({
-  date: new Date(date).getTime(),
-  provider: "Vantor",
-  source: "WV02",
-  resolution: 0.3,
-  accuracy: 5,
-});
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("loadWaybackItemsWithMetadata", () => {
+describe("loadGlobalWaybackItems", () => {
+  it("loads release-list candidates without local tile probing", async () => {
+    const getItems = vi
+      .fn()
+      .mockResolvedValue([
+        waybackItem(100, "2020-01-01"),
+        waybackItem(300, "2022-01-01"),
+        waybackItem(200, "2021-01-01"),
+      ]);
+
+    const result = await loadGlobalWaybackItems({ getItems });
+
+    expect(getItems).toHaveBeenCalledTimes(1);
+    expect(result.map((item) => item.releaseNum)).toEqual([100, 200, 300]);
+    expect(result.every((item) => item.metadata === undefined)).toBe(true);
+  });
+});
+
+describe("loadLocalWaybackItems", () => {
   it("keeps discovery timeouts retryable instead of caching empty imagery", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     const startedAt = Date.now();
     await expect(
-      loadWaybackItemsWithMetadata(point, 12, {
+      loadLocalWaybackItems(point, 12, {
         itemsTimeoutMs: 10,
         getItemsWithLocalChanges: () =>
           new Promise<WaybackItem[]>(() => undefined),
@@ -47,35 +57,36 @@ describe("loadWaybackItemsWithMetadata", () => {
     expect(Date.now() - startedAt).toBeLessThan(250);
   });
 
-  it("keeps imagery usable when metadata exceeds the timeout", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const item = waybackItem(31144);
+  it("returns local candidates without eager metadata fetching", async () => {
+    const getItemsWithLocalChanges = vi
+      .fn()
+      .mockResolvedValue([waybackItem(31144)]);
 
-    const startedAt = Date.now();
-    const result = await loadWaybackItemsWithMetadata(point, 12, {
-      metadataTimeoutMs: 10,
-      getItemsWithLocalChanges: async () => [item],
-      getItemMetadata: () =>
-        new Promise<WaybackMetadata | null>(() => undefined),
+    const result = await loadLocalWaybackItems(point, 12, {
+      getItemsWithLocalChanges,
     });
 
-    expect(Date.now() - startedAt).toBeLessThan(250);
     expect(result).toHaveLength(1);
     expect(result[0].releaseNum).toBe(31144);
     expect(result[0].metadata).toBeUndefined();
     expect(result[0].provider).toBeUndefined();
   });
 
-  it("uses accurate local Wayback duplicate detection", async () => {
+  it("uses size-only local Wayback duplicate detection", async () => {
     const getItemsWithLocalChanges = vi
       .fn()
       .mockResolvedValue([waybackItem(31144)]);
 
-    await loadWaybackItemsWithMetadata(point, 12, {
+    await loadLocalWaybackItems(point, 12, {
       getItemsWithLocalChanges,
-      getItemMetadata: async () => metadata("2022-10-04"),
     });
 
-    expect(getItemsWithLocalChanges).toHaveBeenCalledWith(point, 12);
+    expect(getItemsWithLocalChanges).toHaveBeenCalledWith(
+      point,
+      12,
+      expect.objectContaining({
+        onlyUseSizeToFilterDuplicates: true,
+      }),
+    );
   });
 });

--- a/frontend/src/hooks/useWaybackItems.ts
+++ b/frontend/src/hooks/useWaybackItems.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
+  getWaybackItems,
   getWaybackItemsWithLocalChanges,
   getMetadata,
+  long2tile,
+  lat2tile,
   type WaybackItem,
   type WaybackMetadata,
 } from "@esri/wayback-core";
@@ -33,8 +36,10 @@ type WaybackPoint = {
 interface LoadWaybackItemsOptions {
   itemsTimeoutMs?: number;
   metadataTimeoutMs?: number;
+  getItems?: typeof getWaybackItems;
   getItemsWithLocalChanges?: typeof getWaybackItemsWithLocalChanges;
   getItemMetadata?: typeof getMetadata;
+  signal?: AbortSignal;
 }
 
 const withTimeout = async <T>(
@@ -71,52 +76,24 @@ const toWaybackItemWithMetadata = (
   resolution: metadata?.resolution,
 });
 
-export const loadWaybackItemsWithMetadata = async (
-  point: WaybackPoint,
-  zoomLevel: number,
-  {
-    itemsTimeoutMs = WAYBACK_ITEMS_TIMEOUT_MS,
-    metadataTimeoutMs = WAYBACK_METADATA_TIMEOUT_MS,
-    getItemsWithLocalChanges = getWaybackItemsWithLocalChanges,
-    getItemMetadata = getMetadata,
-  }: LoadWaybackItemsOptions = {},
-): Promise<WaybackItemWithMetadata[]> => {
-  let items: WaybackItem[];
+const toWaybackItemWithoutMetadata = (
+  item: WaybackItem,
+): WaybackItemWithMetadata => toWaybackItemWithMetadata(item, undefined);
 
-  try {
-    items = await withTimeout(
-      getItemsWithLocalChanges(point, zoomLevel),
-      itemsTimeoutMs,
-      `Wayback imagery discovery timed out after ${itemsTimeoutMs}ms`,
-    );
-  } catch (error) {
-    console.warn("Failed to load local Wayback imagery", error);
-    throw error;
-  }
+const sortWaybackItemsAscending = (
+  items: WaybackItemWithMetadata[],
+): WaybackItemWithMetadata[] =>
+  [...items].sort((a, b) => {
+    const dateA = a.acquisitionDate?.getTime() || a.releaseDatetime || 0;
+    const dateB = b.acquisitionDate?.getTime() || b.releaseDatetime || 0;
+    return dateA - dateB;
+  });
 
-  if (items.length === 0) return [];
-
-  const itemsWithMetadata = await Promise.all(
-    items.map(async (item): Promise<WaybackItemWithMetadata> => {
-      try {
-        const metadata = await withTimeout(
-          getItemMetadata(point, zoomLevel, item.releaseNum),
-          metadataTimeoutMs,
-          `Wayback metadata timed out after ${metadataTimeoutMs}ms for release ${item.releaseNum}`,
-        );
-        return toWaybackItemWithMetadata(item, metadata);
-      } catch (error) {
-        console.warn(
-          `Failed to fetch metadata for release ${item.releaseNum}:`,
-          error,
-        );
-        return toWaybackItemWithMetadata(item, undefined);
-      }
-    }),
-  );
-
+const dedupeWaybackItems = (
+  items: WaybackItemWithMetadata[],
+): WaybackItemWithMetadata[] => {
   const dateMap = new Map<string, WaybackItemWithMetadata>();
-  itemsWithMetadata.forEach((item) => {
+  items.forEach((item) => {
     const dateKey =
       item.acquisitionDate?.toISOString() ||
       item.releaseDateLabel ||
@@ -127,12 +104,74 @@ export const loadWaybackItemsWithMetadata = async (
     }
   });
 
-  return Array.from(dateMap.values()).sort((a, b) => {
-    const dateA = a.acquisitionDate?.getTime() || a.releaseDatetime || 0;
-    const dateB = b.acquisitionDate?.getTime() || b.releaseDatetime || 0;
-    return dateA - dateB;
-  });
+  return sortWaybackItemsAscending(Array.from(dateMap.values()));
 };
+
+export const loadGlobalWaybackItems = async ({
+  itemsTimeoutMs = WAYBACK_ITEMS_TIMEOUT_MS,
+  getItems = getWaybackItems,
+}: Pick<
+  LoadWaybackItemsOptions,
+  "itemsTimeoutMs" | "getItems"
+> = {}): Promise<WaybackItemWithMetadata[]> => {
+  const items = await withTimeout(
+    getItems(),
+    itemsTimeoutMs,
+    `Wayback release list timed out after ${itemsTimeoutMs}ms`,
+  );
+
+  return dedupeWaybackItems(items.map(toWaybackItemWithoutMetadata));
+};
+
+export const loadLocalWaybackItems = async (
+  point: WaybackPoint,
+  zoomLevel: number,
+  {
+    itemsTimeoutMs = WAYBACK_ITEMS_TIMEOUT_MS,
+    getItemsWithLocalChanges = getWaybackItemsWithLocalChanges,
+    signal,
+  }: LoadWaybackItemsOptions = {},
+): Promise<WaybackItemWithMetadata[]> => {
+  let items: WaybackItem[];
+
+  try {
+    items = await withTimeout(
+      getItemsWithLocalChanges(point, zoomLevel, {
+        signal,
+        onlyUseSizeToFilterDuplicates: true,
+      }),
+      itemsTimeoutMs,
+      `Wayback imagery discovery timed out after ${itemsTimeoutMs}ms`,
+    );
+  } catch (error) {
+    console.warn("Failed to load local Wayback imagery", error);
+    throw error;
+  }
+
+  if (items.length === 0) return [];
+
+  return dedupeWaybackItems(items.map(toWaybackItemWithoutMetadata));
+};
+
+export const loadWaybackMetadata = async (
+  point: WaybackPoint,
+  zoomLevel: number,
+  releaseNum: number,
+  {
+    metadataTimeoutMs = WAYBACK_METADATA_TIMEOUT_MS,
+    getItemMetadata = getMetadata,
+  }: Pick<
+    LoadWaybackItemsOptions,
+    "metadataTimeoutMs" | "getItemMetadata"
+  > = {},
+): Promise<WaybackMetadata | null> =>
+  withTimeout(
+    getItemMetadata(point, zoomLevel, releaseNum),
+    metadataTimeoutMs,
+    `Wayback metadata timed out after ${metadataTimeoutMs}ms for release ${releaseNum}`,
+  );
+
+export const loadWaybackItemsWithMetadata = loadLocalWaybackItems;
 
 /**
  * Calculate distance between two coordinates in meters (Haversine formula)
@@ -158,14 +197,14 @@ export const WAYBACK_CANDIDATE_THROTTLE_MS = 10_000;
  * Hook to fetch Wayback items with actual imagery changes at this location.
  *
  * Pipeline:
- * 1. Fetches items using getWaybackItemsWithLocalChanges (unique imagery at location)
- * 2. Fetches metadata for ALL items in parallel (acquisition date, provider, source)
- * 3. Deduplicates by acquisition date (same satellite capture = same image)
- * 4. Sorts by acquisition date ascending (oldest left, newest right)
+ * 1. Fetches the global Wayback release list for immediate, cheap candidates.
+ * 2. Optionally refines with local-change candidates after the user asks for it.
+ * 3. Deduplicates by release date and sorts ascending (oldest left, newest right).
  *
- * Only re-fetches when location changes significantly (>2km). Zoom changes do
- * not invalidate candidate discovery because the active basemap release should
- * stay stable while the map requests normal tiles for the new view.
+ * Local refinement only re-fetches when location changes significantly (>2km)
+ * and is cached by the coarse Wayback tile key. Zoom changes do not invalidate
+ * candidate discovery because the active basemap release should stay stable
+ * while the map requests normal tiles for the new view.
  */
 export const useWaybackItemsDebounced = (
   longitude: number | undefined,
@@ -178,6 +217,14 @@ export const useWaybackItemsDebounced = (
   const debounceHandleRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const throttleHandleRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const [stableCoords, setStableCoords] = useState<{ lon: number; lat: number } | null>(null);
+  const stableTileKey =
+    stableCoords !== null
+      ? {
+          level: WAYBACK_CANDIDATE_DISCOVERY_ZOOM,
+          column: long2tile(stableCoords.lon, WAYBACK_CANDIDATE_DISCOVERY_ZOOM),
+          row: lat2tile(stableCoords.lat, WAYBACK_CANDIDATE_DISCOVERY_ZOOM),
+        }
+      : null;
 
   useEffect(() => {
     if (!enabled || longitude === undefined || latitude === undefined) return;
@@ -232,25 +279,46 @@ export const useWaybackItemsDebounced = (
     };
   }, [longitude, latitude, enabled]);
 
-  return useQuery({
+  const globalItemsQuery = useQuery({
+    queryKey: ["wayback-items-global"],
+    queryFn: () => loadGlobalWaybackItems(),
+    enabled,
+    staleTime: 24 * 60 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+  });
+
+  const localItemsQuery = useQuery({
     queryKey: [
-      "wayback-items-with-metadata",
-      stableCoords?.lon,
-      stableCoords?.lat,
-      WAYBACK_CANDIDATE_DISCOVERY_ZOOM,
+      "wayback-items-local",
+      stableTileKey?.level,
+      stableTileKey?.column,
+      stableTileKey?.row,
     ],
-    queryFn: async (): Promise<WaybackItemWithMetadata[]> => {
+    queryFn: async ({ signal }): Promise<WaybackItemWithMetadata[]> => {
       if (!stableCoords) return [];
 
       const point = { longitude: stableCoords.lon, latitude: stableCoords.lat };
 
-      return loadWaybackItemsWithMetadata(
+      return loadLocalWaybackItems(
         point,
         WAYBACK_CANDIDATE_DISCOVERY_ZOOM,
+        { signal },
       );
     },
     enabled: enabled && stableCoords !== null,
     staleTime: 30 * 60 * 1000, // Cache for 30 minutes
     gcTime: 60 * 60 * 1000, // Keep in cache for 1 hour
   });
+
+  const localItems = localItemsQuery.data ?? [];
+  const globalItems = globalItemsQuery.data ?? [];
+  const data = localItems.length > 0 ? localItems : globalItems;
+
+  return {
+    ...globalItemsQuery,
+    data,
+    isLoading: globalItemsQuery.isLoading && data.length === 0,
+    isFetching: globalItemsQuery.isFetching || localItemsQuery.isFetching,
+    error: localItemsQuery.error ?? globalItemsQuery.error,
+  };
 };


### PR DESCRIPTION
## What changed

- Load the global Esri Wayback release list as the initial imagery candidate set instead of probing local tile changes immediately.
- Stop starting local Wayback candidate discovery from page load, idle callbacks, basemap toggles, zoom, or pan.
- Trigger local candidate refinement only from explicit imagery controls, using Esri's size-only duplicate filtering.
- Keep metadata lazy instead of fetching metadata for every candidate.

## Why

Clemens observed that the map became visually stable much sooner than the ArcGIS request stream stopped. The remaining tail came from local Wayback candidate discovery and metadata fanout, not from the visible basemap itself.

## Validation

- `npm --prefix frontend test -- useWaybackItems.test.ts YearImagerySelector.test.ts`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- Local browser/network smoke on `http://127.0.0.1:5174/deadtrees`: after 30s idle, ArcGIS stayed flat at 24 requests, all visible basemap tiles for release 31144; no tilemap requests, metadata requests, or multi-release probing tail.
