### PR TITLE
Simplify combined v2 segmentation polygons at 10cm

### DIFF
--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -230,11 +230,12 @@ class CombinedInference:
     def _filter_polygons(self, polygons, inference_crs, orig_crs):
         polygons = filter_polygons_by_area(polygons, MINIMUM_POLYGON_AREA)
         # Simplify while still in the metric inference CRS so the tolerance is in metres.
+        # Keep the original polygon on the rare chance simplify collapses it, so the
+        # feature count stays stable and no label is silently dropped.
         simplified = []
         for polygon in polygons:
             simple = polygon.simplify(SIMPLIFY_TOLERANCE, preserve_topology=True)
-            if not simple.is_empty:
-                simplified.append(simple)
+            simplified.append(polygon if simple.is_empty else simple)
         print(f'Simplified {len(polygons)} polygons at {SIMPLIFY_TOLERANCE}m tolerance.')
         polygons = reproject_polygons(simplified, inference_crs, orig_crs)
         return polygons

--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -36,6 +36,12 @@ MINIMUM_POLYGON_AREA = 0.1  # m²
 TILE_SIZE = 1024
 PADDING = 256
 
+# Douglas-Peucker simplification tolerance (metres) applied to both the deadwood
+# and treecover polygons. Pixel-traced masks at 5cm carry huge runs of redundant
+# near-collinear staircase vertices; simplifying at 10cm removes ~6x of them with
+# no visible change, keeping the stored geometry (and MVT/exports) light.
+SIMPLIFY_TOLERANCE = 0.10  # metres
+
 
 def _build_transform():
     return transforms.Compose(
@@ -223,5 +229,12 @@ class CombinedInference:
 
     def _filter_polygons(self, polygons, inference_crs, orig_crs):
         polygons = filter_polygons_by_area(polygons, MINIMUM_POLYGON_AREA)
-        polygons = reproject_polygons(polygons, inference_crs, orig_crs)
+        # Simplify while still in the metric inference CRS so the tolerance is in metres.
+        simplified = []
+        for polygon in polygons:
+            simple = polygon.simplify(SIMPLIFY_TOLERANCE, preserve_topology=True)
+            if not simple.is_empty:
+                simplified.append(simple)
+        print(f'Simplified {len(polygons)} polygons at {SIMPLIFY_TOLERANCE}m tolerance.')
+        polygons = reproject_polygons(simplified, inference_crs, orig_crs)
         return polygons

--- a/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_filtering.py
+++ b/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_filtering.py
@@ -15,10 +15,11 @@ def _num_points(polygon):
 	return len(polygon.exterior.coords) + sum(len(r.coords) for r in polygon.interiors)
 
 
-def test_filter_polygons_does_not_simplify(monkeypatch):
-	"""Forest cover is no longer simplified: vertex counts must be preserved,
-	only area filtering and reprojection happen."""
-	polygon = Point(0, 0).buffer(10, resolution=128)
+def test_filter_polygons_simplifies(monkeypatch):
+	"""_filter_polygons now applies a SIMPLIFY_TOLERANCE Douglas-Peucker pass:
+	vertex counts drop while the feature is preserved and reprojected."""
+	# Dense circle (~1024 vertices, ~6cm spacing) so a 10cm tolerance reduces it.
+	polygon = Point(0, 0).buffer(10, resolution=256)
 	inference_crs = CRS.from_epsg(32634)
 	orig_crs = CRS.from_epsg(4326)
 
@@ -32,17 +33,26 @@ def test_filter_polygons_does_not_simplify(monkeypatch):
 	monkeypatch.setattr(combined_inference, 'reproject_polygons', fake_reproject_polygons)
 
 	inference = CombinedInference.__new__(CombinedInference)
-
 	result = inference._filter_polygons([polygon], inference_crs, orig_crs)
 
 	assert len(result) == 1
-	# No vertex reduction: simplification has been removed.
-	assert _num_points(result[0]) == _num_points(polygon)
+	# Simplification removed redundant vertices.
+	assert _num_points(result[0]) < _num_points(polygon)
+	# Simplify happens in the metric inference CRS, then reprojection to the original CRS.
 	assert reproject_call['src_crs'] == inference_crs
 	assert reproject_call['dst_crs'] == orig_crs
 
 
-def test_simplification_feature_fully_removed():
-	"""The removed simplification feature must not leave behind helpers/attributes."""
-	assert not hasattr(combined_inference, 'FOREST_COVER_SIMPLIFICATION_TOLERANCE_M')
-	assert not hasattr(combined_inference, 'simplify_polygons_preserving_topology')
+def test_filter_polygons_preserves_feature_count_when_simplify_is_aggressive(monkeypatch):
+	"""Even with a tolerance far larger than the polygon, the feature is never
+	silently dropped (it falls back to the original on collapse)."""
+	polygon = Point(0, 0).buffer(10, resolution=128)
+
+	monkeypatch.setattr(combined_inference, 'reproject_polygons', lambda polys, s, d: polys)
+	monkeypatch.setattr(combined_inference, 'SIMPLIFY_TOLERANCE', 1e6)
+
+	inference = CombinedInference.__new__(CombinedInference)
+	result = inference._filter_polygons([polygon], CRS.from_epsg(32634), CRS.from_epsg(4326))
+
+	assert len(result) == 1
+	assert not result[0].is_empty


### PR DESCRIPTION
## Summary
The combined deadwood+treecover **v2** model polygonizes its class masks at the 5 cm inference grid with no simplification. Pixel-traced boundaries therefore carry long runs of redundant near-collinear staircase vertices. Forest cover is the worst case — a single orthomosaic produced **~2.0 M vertices**, including one **944 K-vertex** polygon — which bloats stored geometry, on-the-fly MVT tile generation, and GeoPackage/zip exports.

This applies a **10 cm Douglas–Peucker (topology-preserving) simplify** to both the deadwood and treecover polygons in `_filter_polygons`, while still in the metric inference CRS so the tolerance is in metres.

## Effectiveness (measured on a real dataset)
| layer | before | after | reduction |
|---|---|---|---|
| forest_cover | 2,022,738 verts | 339,538 | **6.0×** |
| deadwood | 230,277 verts | 31,025 | **7.4×** |

Polygon/feature counts are unchanged (simplify thins vertices, it doesn't drop polygons). 10 cm is sub-pixel-pair at 5 cm native resolution, so there's no visible change. Topology-preserving vs plain Douglas–Peucker agree to <0.5% at this tolerance.

## Why simplify-on-save (vs coarser polygonization or MVT-only)
- Coarser polygonization keeps a staircase boundary, so it needs ~50 cm resolution to match the vertex savings 10 cm simplify gives — i.e. ~5× more spatial detail discarded for the same budget.
- The MVT function already simplifies per tile, but that cost is paid live per request, recomputed for every tile the giant polygon touches, and stops helping at high zoom. Reducing vertices at the source makes the DB, tiles, and exports all cheaper at once.

## Testing
Reprocessed two datasets end-to-end in the local dev stack; vertex counts above are the actual stored results, matching the PostGIS `ST_SimplifyPreserveTopology` estimate (340,762 @ 10 cm) within 0.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polygon post-processing during inference by simplifying polygon shapes before reprojecting them back to the original coordinate system.
  * Prevented results from being dropped when simplification is overly aggressive, ensuring outputs remain non-empty when appropriate.
  * Added logging to report how many polygons were simplified for easier tracking.
* **Tests**
  * Updated filtering/inference tests to verify vertex reduction while preserving features and correct reprojection behavior.
  * Added coverage for very large simplification tolerances to ensure geometry is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->