### PR TITLE
feat(processor): VW 0.0625 + Chaikin x1 polygon postprocessing for v2

### DIFF
--- a/processor/requirements.txt
+++ b/processor/requirements.txt
@@ -29,6 +29,8 @@ debugpy
 xarray>=2023.1.0
 zarr>=2.13.0
 numpy>=1.24.0
+# Visvalingam-Whyatt polygon simplification (deadwood_treecover_combined_v2 postprocessing)
+simplification>=0.7,<2
 # Pin to 4.x: transformers 5.0 renamed SegFormer state-dict keys
 # (encoder.block.* -> stages.*, decode_head.linear_c -> linear_projections),
 # which breaks load_state_dict(strict=True) for the AOI and combined-model

--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -96,9 +96,11 @@ def _vw_simplify_polygon(polygon, area_threshold):
         return None
     holes = []
     for ring in polygon.interiors:
-        hole = simplify_coords_vw(np.asarray(ring.coords), area_threshold)
-        if len(hole) >= 4:
-            holes.append(hole)
+        coords = np.asarray(ring.coords)
+        hole = simplify_coords_vw(coords, area_threshold)
+        # Keep the original ring if VW collapses it below a triangle, so a valid hole
+        # (it already passed the area filter) is never silently filled in.
+        holes.append(hole if len(hole) >= 4 else coords)
     simplified = Polygon(ext, holes)
     return simplified if simplified.is_valid else simplified.buffer(0)
 
@@ -314,6 +316,10 @@ class CombinedInference:
         simplified = []
         for polygon in polygons:
             simplified.extend(_simplify_and_smooth(polygon))
+        # Re-filter by area: a buffer(0) repair can split one polygon into several,
+        # and VW/Chaikin can shrink one below the threshold, so sub-area slivers must
+        # not slip past the pre-simplification filter.
+        simplified = filter_polygons_by_area(simplified, MINIMUM_POLYGON_AREA)
         print(f'Simplified {len(polygons)} polygons (VW {VW_AREA_THRESHOLD}m² + Chaikin x{CHAIKIN_ITERATIONS}).')
         polygons = reproject_polygons(simplified, inference_crs, orig_crs)
         return polygons

--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn.functional as F
 from rasterio.windows import Window as RioWindow
 from safetensors import safe_open
+from shapely.geometry import MultiPolygon, Polygon
+from simplification.cutil import simplify_coords_vw
 from torch.utils.data import DataLoader
 from torchvision.transforms import transforms
 from torchvision.transforms.functional import crop
@@ -36,11 +38,88 @@ MINIMUM_POLYGON_AREA = 0.1  # m²
 TILE_SIZE = 1024
 PADDING = 256
 
-# Douglas-Peucker simplification tolerance (metres) applied to both the deadwood
-# and treecover polygons. Pixel-traced masks at 5cm carry huge runs of redundant
-# near-collinear staircase vertices; simplifying at 10cm removes ~6x of them with
-# no visible change, keeping the stored geometry (and MVT/exports) light.
-SIMPLIFY_TOLERANCE = 0.10  # metres
+# Polygon postprocessing applied to both deadwood and treecover polygons.
+# Pixel-traced masks at 5cm carry huge runs of redundant near-collinear staircase
+# vertices. The Auwald simplification study (temp/auwald_simplification_study.*)
+# compared methods on real forest-cover; "VW 0.0625 + Chaikin x1" won: ~82% vertex
+# savings (on par with Douglas-Peucker 10cm) but with smoother, less staircased
+# boundaries and fewer spurious tiny features/holes. We run it in two passes, both
+# in the metric inference CRS so the area threshold is in m²:
+#   1. Visvalingam-Whyatt simplification at a 0.0625 m² effective-area threshold.
+#   2. One Chaikin corner-cutting smoothing pass.
+VW_AREA_THRESHOLD = 0.0625  # m² — Visvalingam-Whyatt effective-area threshold
+CHAIKIN_ITERATIONS = 1      # corner-cutting smoothing passes after VW
+
+
+def _explode_polygons(geom):
+    """Flatten a geometry into its constituent (non-empty) Polygons."""
+    if geom is None or geom.is_empty:
+        return []
+    if geom.geom_type == 'Polygon':
+        return [geom]
+    if geom.geom_type in ('MultiPolygon', 'GeometryCollection'):
+        return [p for g in geom.geoms for p in _explode_polygons(g)]
+    return []
+
+
+def _chaikin_ring(coords, iterations):
+    """Chaikin corner-cutting on a single closed ring; returns a closed coord list."""
+    pts = [tuple(c) for c in coords]
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts = pts[:-1]
+    for _ in range(iterations):
+        new_pts = []
+        n = len(pts)
+        for i in range(n):
+            p0 = pts[i]
+            p1 = pts[(i + 1) % n]
+            new_pts.append((0.75 * p0[0] + 0.25 * p1[0], 0.75 * p0[1] + 0.25 * p1[1]))
+            new_pts.append((0.25 * p0[0] + 0.75 * p1[0], 0.25 * p0[1] + 0.75 * p1[1]))
+        pts = new_pts
+    pts.append(pts[0])
+    return pts
+
+
+def _chaikin_polygon(polygon, iterations):
+    """Apply Chaikin smoothing to a polygon's exterior and interior rings."""
+    ext = _chaikin_ring(polygon.exterior.coords, iterations)
+    holes = [_chaikin_ring(r.coords, iterations) for r in polygon.interiors if len(r.coords) >= 4]
+    smoothed = Polygon(ext, holes)
+    return smoothed if smoothed.is_valid else smoothed.buffer(0)
+
+
+def _vw_simplify_polygon(polygon, area_threshold):
+    """Visvalingam-Whyatt simplification of a polygon's rings; None if the exterior
+    collapses below a triangle."""
+    ext = simplify_coords_vw(np.asarray(polygon.exterior.coords), area_threshold)
+    if len(ext) < 4:
+        return None
+    holes = []
+    for ring in polygon.interiors:
+        hole = simplify_coords_vw(np.asarray(ring.coords), area_threshold)
+        if len(hole) >= 4:
+            holes.append(hole)
+    simplified = Polygon(ext, holes)
+    return simplified if simplified.is_valid else simplified.buffer(0)
+
+
+def _simplify_and_smooth(polygon):
+    """VW simplification + Chaikin smoothing for one polygon (both in metric CRS).
+
+    Returns a list of Polygons. Falls back to ``[polygon]`` unchanged if the pipeline
+    collapses or errors, so no feature is silently dropped. A ``buffer(0)`` repair may
+    split a polygon into several, hence the list return.
+    """
+    try:
+        simplified = _vw_simplify_polygon(polygon, VW_AREA_THRESHOLD)
+        if simplified is None or simplified.is_empty:
+            return [polygon]
+        smoothed = []
+        for part in _explode_polygons(simplified):
+            smoothed.extend(_explode_polygons(_chaikin_polygon(part, CHAIKIN_ITERATIONS)))
+        return smoothed if smoothed else [polygon]
+    except Exception:
+        return [polygon]
 
 
 def _build_transform():
@@ -229,13 +308,12 @@ class CombinedInference:
 
     def _filter_polygons(self, polygons, inference_crs, orig_crs):
         polygons = filter_polygons_by_area(polygons, MINIMUM_POLYGON_AREA)
-        # Simplify while still in the metric inference CRS so the tolerance is in metres.
-        # Keep the original polygon on the rare chance simplify collapses it, so the
-        # feature count stays stable and no label is silently dropped.
+        # Simplify + smooth while still in the metric inference CRS so the VW area
+        # threshold is in m². Each input polygon yields one or more output polygons;
+        # on collapse it falls back to the original so no label is silently dropped.
         simplified = []
         for polygon in polygons:
-            simple = polygon.simplify(SIMPLIFY_TOLERANCE, preserve_topology=True)
-            simplified.append(polygon if simple.is_empty else simple)
-        print(f'Simplified {len(polygons)} polygons at {SIMPLIFY_TOLERANCE}m tolerance.')
+            simplified.extend(_simplify_and_smooth(polygon))
+        print(f'Simplified {len(polygons)} polygons (VW {VW_AREA_THRESHOLD}m² + Chaikin x{CHAIKIN_ITERATIONS}).')
         polygons = reproject_polygons(simplified, inference_crs, orig_crs)
         return polygons

--- a/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_filtering.py
+++ b/processor/tests/deadwood_treecover_combined_v2/test_combined_inference_filtering.py
@@ -1,6 +1,6 @@
 import pytest
 from rasterio.crs import CRS
-from shapely.geometry import Point
+from shapely.geometry import Point, Polygon
 
 pytest.importorskip('safetensors')
 pytest.importorskip('torch')
@@ -16,9 +16,9 @@ def _num_points(polygon):
 
 
 def test_filter_polygons_simplifies(monkeypatch):
-	"""_filter_polygons now applies a SIMPLIFY_TOLERANCE Douglas-Peucker pass:
-	vertex counts drop while the feature is preserved and reprojected."""
-	# Dense circle (~1024 vertices, ~6cm spacing) so a 10cm tolerance reduces it.
+	"""_filter_polygons applies VW simplification + Chaikin smoothing: vertex counts
+	drop while the feature is preserved and reprojected."""
+	# Dense circle (~1024 vertices, ~6cm spacing) so VW 0.0625m² reduces it.
 	polygon = Point(0, 0).buffer(10, resolution=256)
 	inference_crs = CRS.from_epsg(32634)
 	orig_crs = CRS.from_epsg(4326)
@@ -36,23 +36,47 @@ def test_filter_polygons_simplifies(monkeypatch):
 	result = inference._filter_polygons([polygon], inference_crs, orig_crs)
 
 	assert len(result) == 1
-	# Simplification removed redundant vertices.
+	# Simplification removed redundant vertices despite the Chaikin pass.
 	assert _num_points(result[0]) < _num_points(polygon)
 	# Simplify happens in the metric inference CRS, then reprojection to the original CRS.
 	assert reproject_call['src_crs'] == inference_crs
 	assert reproject_call['dst_crs'] == orig_crs
 
 
-def test_filter_polygons_preserves_feature_count_when_simplify_is_aggressive(monkeypatch):
-	"""Even with a tolerance far larger than the polygon, the feature is never
+def test_filter_polygons_preserves_feature_count_when_vw_is_aggressive(monkeypatch):
+	"""Even with an area threshold far larger than the polygon, the feature is never
 	silently dropped (it falls back to the original on collapse)."""
 	polygon = Point(0, 0).buffer(10, resolution=128)
 
 	monkeypatch.setattr(combined_inference, 'reproject_polygons', lambda polys, s, d: polys)
-	monkeypatch.setattr(combined_inference, 'SIMPLIFY_TOLERANCE', 1e6)
+	monkeypatch.setattr(combined_inference, 'VW_AREA_THRESHOLD', 1e6)
 
 	inference = CombinedInference.__new__(CombinedInference)
 	result = inference._filter_polygons([polygon], CRS.from_epsg(32634), CRS.from_epsg(4326))
 
 	assert len(result) == 1
 	assert not result[0].is_empty
+
+
+def test_simplify_and_smooth_preserves_holes():
+	"""A polygon with a sizeable hole keeps its hole through VW + Chaikin."""
+	exterior = Point(0, 0).buffer(10, resolution=128)
+	hole = Point(0, 0).buffer(3, resolution=128)
+	polygon = Polygon(exterior.exterior.coords, [hole.exterior.coords])
+
+	result = combined_inference._simplify_and_smooth(polygon)
+
+	assert len(result) == 1
+	assert len(result[0].interiors) == 1
+	assert result[0].is_valid
+
+
+def test_simplify_and_smooth_returns_polygons():
+	"""Output geometries are always Polygons (never Multi*), matching the
+	one-Polygon-in / list-of-Polygons-out contract downstream relies on."""
+	polygon = Point(0, 0).buffer(10, resolution=256)
+
+	result = combined_inference._simplify_and_smooth(polygon)
+
+	assert result
+	assert all(g.geom_type == 'Polygon' and not g.is_empty for g in result)


### PR DESCRIPTION
## Summary

Replaces the Douglas-Peucker 10cm polygon simplification in the combined deadwood+treecover **v2** model with **Visvalingam–Whyatt (0.0625 m²) + one Chaikin smoothing pass**, applied to both the deadwood and treecover polygons.

This is the `VW 0.0625 + Chaikin x1` method from the Auwald simplification study: it matches DP 10cm on vertex savings (~82%) but produces smoother, less staircased boundaries and fewer spurious tiny features/holes.

## Changes

- `processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py`
  - New helpers: `_vw_simplify_polygon`, `_chaikin_ring`/`_chaikin_polygon`, `_explode_polygons`, `_simplify_and_smooth`.
  - Both passes run in the metric inference CRS so the VW area threshold is in m².
  - Contract: one input polygon → one-or-more output polygons (a `buffer(0)` validity repair can split a polygon); falls back to the original on collapse so no label is silently dropped.
  - Replaced `SIMPLIFY_TOLERANCE` with `VW_AREA_THRESHOLD = 0.0625` and `CHAIKIN_ITERATIONS = 1`.
- `processor/requirements.txt`: pin `simplification>=0.7,<2` (provides `simplify_coords_vw`).
- `processor/tests/.../test_combined_inference_filtering.py`: updated for the new pipeline + added hole-preservation and Polygon-output-contract tests.

## Testing

Ran the full local processing pipeline on two real orthos (3691, 6177) through the v2 model:

- Postprocessing executed cleanly on both layers, e.g. `Simplified 1182 polygons (VW 0.0625m² + Chaikin x1)`.
- All resulting geometries valid in the DB (`ST_IsValid` = true for all ~5,900 deadwood + forest polygons).
- The `buffer(0)`-split path is exercised in practice (one ortho's forest layer went 3011 simplified → 3014 stored, i.e. repairs split a few polygons; no labels lost).

> Note: the v2 filtering tests require `transformers`, which is only present in the processor Docker image, so they skip in a bare venv but run in CI / the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved polygon post-processing for deadwood and tree cover outputs with smoother, cleaner boundaries.
  * Added more robust handling so geometries are preserved even when simplification is aggressive or encounters issues.

* **Bug Fixes**
  * Reduced the chance of features disappearing during polygon cleanup.
  * Preserved holes and valid shapes more reliably while simplifying and smoothing results.

* **Tests**
  * Expanded coverage for polygon simplification, smoothing, and geometry preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->