### PR TITLE
chore(processor): make container CPU/memory limits host-configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhY
 PROCESSOR_PASSWORD=processor
 # Optional override; use a stable unique value per processor host.
 PROCESSOR_WORKER_ID=
+# Per-host resource caps for the production processor container
+# (docker-compose.processor.yaml). On machines smaller than the defaults, lower
+# PROCESSOR_CPU_LIMIT to <= the host's CPU core count. Defaults: 30 CPUs / 96G.
+PROCESSOR_CPU_LIMIT=30
+PROCESSOR_MEMORY_LIMIT=96G
 STORAGE_SERVER_USERNAME=root
 STORAGE_SERVER_DATA_PATH=/data
 SSH_PRIVATE_KEY_PASSPHRASE=

--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -21,8 +21,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '30'
-          memory: '96G'
+          # Per-host caps so the same compose file deploys on machines of
+          # different sizes. Override in .env; PROCESSOR_CPU_LIMIT must be <= the
+          # host's CPU core count. Defaults match the original production sizing.
+          cpus: ${PROCESSOR_CPU_LIMIT:-30}
+          memory: ${PROCESSOR_MEMORY_LIMIT:-96G}
     runtime: nvidia
     volumes:
       - ./processor:/app/processor

--- a/docs/playbooks/processor-worker-setup.md
+++ b/docs/playbooks/processor-worker-setup.md
@@ -17,6 +17,10 @@ storage server, Docker runtime, and required model/assets volume.
 - The repository checkout is clean and tracks `origin/main`.
 - Required assets and model files are present under the paths mounted by
   `docker-compose.processor.yaml`.
+- On hosts smaller than the defaults, set `PROCESSOR_CPU_LIMIT` (and optionally
+  `PROCESSOR_MEMORY_LIMIT`) in `.env` so the processor container's caps fit the
+  machine. `PROCESSOR_CPU_LIMIT` must be `<=` the host's CPU core count, or
+  `docker compose up` fails with a "range of CPUs" error. Defaults: `30` / `96G`.
 
 ## Worker Identity
 


### PR DESCRIPTION
## Problem

`docker-compose.processor.yaml` hard-codes the processor container limits:

```yaml
cpus: '30'
memory: '96G'
```

On a host with fewer cores this fails at container create:

```
Error response from daemon: range of CPUs is from 0.01 to 12.00, as there are only 12 CPUs available
```

This blocks bringing up an additional processor worker on a smaller machine.

## Change

Parameterize both caps via env vars, with defaults that preserve the original production sizing:

```yaml
cpus: ${PROCESSOR_CPU_LIMIT:-30}
memory: ${PROCESSOR_MEMORY_LIMIT:-96G}
```

- Same compose file now deploys on machines of different sizes — a host just sets `PROCESSOR_CPU_LIMIT` (and optionally `PROCESSOR_MEMORY_LIMIT`) in its `.env`.
- **No behavior change for existing hosts**: they set neither var and resolve to the same `30` / `96G`.
- Documented in `.env.example` and the processor-worker-setup playbook preconditions (`PROCESSOR_CPU_LIMIT` must be `<=` the host's core count).

Verified with `docker compose config`: unset → `cpus 30 / 96 GiB`; `PROCESSOR_CPU_LIMIT=10 PROCESSOR_MEMORY_LIMIT=64G` → `cpus 10 / 64 GiB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable resource limit defaults for the processor service, with per-host overrides for CPU and memory.
* **Documentation**
  * Updated setup guidance for smaller hosts, including how to adjust processor limits to match available CPU cores.
* **Bug Fixes**
  * Improved processor deployment startup reliability by avoiding fixed resource caps that could fail on machines with fewer cores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->