### PR TITLE
chore(processor): make processor->storage SSH key path host-configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ PROCESSOR_WORKER_ID=
 # PROCESSOR_CPU_LIMIT to <= the host's CPU core count. Defaults: 30 CPUs / 96G.
 PROCESSOR_CPU_LIMIT=30
 PROCESSOR_MEMORY_LIMIT=96G
+# Path to the processor->storage private key (the .pub is derived by appending
+# .pub). Defaults to ~/.ssh/processing-to-storage. Set this to a LOCAL-disk path
+# when the home dir is on NFS with root-squash, since the root Docker daemon
+# cannot bind-mount from such a home (fails with "mkdir ...: permission denied").
+PROCESSOR_SSH_KEY_PATH=
 STORAGE_SERVER_USERNAME=root
 STORAGE_SERVER_DATA_PATH=/data
 SSH_PRIVATE_KEY_PASSPHRASE=

--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -31,8 +31,11 @@ services:
       - ./processor:/app/processor
       - ./shared:/app/shared
       - ./assets:/app/assets
-      - ~/.ssh/processing-to-storage:/tmp/ssh-keys/processing-to-storage:ro
-      - ~/.ssh/processing-to-storage.pub:/tmp/ssh-keys/processing-to-storage.pub:ro
+      # Processor->storage keypair. Override PROCESSOR_SSH_KEY_PATH in .env when
+      # the default ~/.ssh lives on a filesystem the Docker daemon (root) cannot
+      # read — e.g. an NFS home with root-squash; point it at a local-disk path.
+      - ${PROCESSOR_SSH_KEY_PATH:-~/.ssh/processing-to-storage}:/tmp/ssh-keys/processing-to-storage:ro
+      - ${PROCESSOR_SSH_KEY_PATH:-~/.ssh/processing-to-storage}.pub:/tmp/ssh-keys/processing-to-storage.pub:ro
       # CRITICAL: Mount Docker socket for ODM processing (Docker-in-Docker)
       - /var/run/docker.sock:/var/run/docker.sock
       # Stable host identity for default processor worker IDs.

--- a/docs/playbooks/processor-worker-setup.md
+++ b/docs/playbooks/processor-worker-setup.md
@@ -21,6 +21,11 @@ storage server, Docker runtime, and required model/assets volume.
   `PROCESSOR_MEMORY_LIMIT`) in `.env` so the processor container's caps fit the
   machine. `PROCESSOR_CPU_LIMIT` must be `<=` the host's CPU core count, or
   `docker compose up` fails with a "range of CPUs" error. Defaults: `30` / `96G`.
+- The processor SSH keypair must sit on a filesystem the Docker daemon (root)
+  can read. If the home directory is on NFS with root-squash, the default
+  `~/.ssh/processing-to-storage` mount fails with
+  `mkdir /…/.ssh: permission denied`. Put the key on local disk (e.g. the
+  checkout's gitignored `.local/ssh/`) and set `PROCESSOR_SSH_KEY_PATH` to it.
 
 ## Worker Identity
 


### PR DESCRIPTION
## Problem

`docker-compose.processor.yaml` hard-codes the processor->storage keypair mount:

```yaml
- ~/.ssh/processing-to-storage:/tmp/ssh-keys/processing-to-storage:ro
- ~/.ssh/processing-to-storage.pub:/tmp/ssh-keys/processing-to-storage.pub:ro
```

On a host whose home directory is on **NFS with root-squash**, the root Docker daemon can't read the home `.ssh`, so `up` fails:

```
Error response from daemon: error while creating mount source path
'/net/home/<user>/.ssh/processing-to-storage': mkdir /net/home/<user>/.ssh: permission denied
```

(Every other mount works because they're on local disk — only the NFS-home key fails.)

## Change

Parameterize the key path, default unchanged:

```yaml
- ${PROCESSOR_SSH_KEY_PATH:-~/.ssh/processing-to-storage}:/tmp/ssh-keys/processing-to-storage:ro
- ${PROCESSOR_SSH_KEY_PATH:-~/.ssh/processing-to-storage}.pub:/tmp/ssh-keys/processing-to-storage.pub:ro
```

- Such hosts set `PROCESSOR_SSH_KEY_PATH` to a **local-disk** key copy (e.g. the checkout's gitignored `.local/ssh/processing-to-storage`).
- **No behavior change for existing hosts**: var unset → `~` still expands to the home key (verified with `docker compose config`).
- Documented in `.env.example` and the processor-worker-setup playbook.

Companion to #462 (same per-host-config pattern, for the SSH key path instead of CPU/memory limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)