### PR TITLE
feat(processor): persistent worker draining the queue back-to-back

### DIFF
--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -5,14 +5,20 @@ services:
       context: .
       dockerfile: processor/Dockerfile
     network_mode: host
-    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m processor.src.processor
-    command: python -m processor.src.processor
-    # Self-heal if the processor container crashes (e.g. OOM collateral kill
-    # during a heavy ODM / treecover stage). Clean exits (exit 0 after finishing
-    # a task) are not restarted, so the existing cron-based polling model is
-    # preserved. Cap retries so a persistently broken container does not
-    # thrash forever.
-    restart: on-failure:5
+    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m processor.src.continuous_processor
+    # Persistent worker: drains the queue back-to-back and only backs off
+    # (PROCESSOR_IDLE_BACKOFF_SECONDS) when idle. Replaces the old
+    # one-task-per-cron-run model. The host no longer needs the per-minute
+    # `docker compose up` cron entry; auto_deploy_processor.sh should recreate
+    # this container with `up -d --build` so a new image triggers the graceful
+    # shutdown + re-queue path (see stop_grace_period / _handle_graceful_shutdown).
+    command: python -m processor.src.continuous_processor
+    # Keep the persistent worker running: restart it after a crash (e.g. OOM
+    # collateral kill during a heavy ODM / treecover stage) and after a host
+    # reboot. A poison task that repeatedly hard-crashes is failed (not retried)
+    # by the stale-active-task detection, so a restart loop makes forward
+    # progress rather than spinning on the same task forever.
+    restart: unless-stopped
     # Give the graceful-shutdown handler time to re-queue the in-flight task on a
     # deploy/restart (SIGTERM) before Docker escalates to SIGKILL. Without this,
     # the default 10s can expire mid-stage and a healthy job gets misclassified as

--- a/docs/playbooks/create-release.md
+++ b/docs/playbooks/create-release.md
@@ -42,10 +42,14 @@ an explicit workflow fix. Manual migration repair or direct production SQL
 execution should be an explicitly approved emergency action only.
 
 Processing server automation is not represented as a GitHub workflow. It is a
-host-local cron setup on `processing-server`:
+host-local cron setup on `processing-server`. The processor now runs as a
+**persistent worker** (`command: python -m processor.src.continuous_processor`,
+`restart: unless-stopped`) that drains the queue back-to-back and only backs off
+when idle — it is no longer restarted once per task. As a result the old
+per-minute `docker compose up` cron entry is unnecessary (the container stays up
+on its own via the restart policy); only the auto-deploy entry remains:
 
 ```cron
-* * * * * cd /home/jj1049/prod/deadtrees && docker compose -f docker-compose.processor.yaml up
 * * * * * /home/jj1049/prod/deadtrees/auto_deploy_processor.sh
 ```
 
@@ -56,6 +60,10 @@ host-local cron setup on `processing-server`:
 - compares local `HEAD` with `origin/main`
 - runs `git pull origin main` when a new commit is available
 - runs `docker compose -f docker-compose.processor.yaml build processor tcd`
+- runs `docker compose -f docker-compose.processor.yaml up -d --build processor`
+  so a new image recreates the running container, triggering the graceful
+  shutdown + re-queue path for any in-flight task (see `stop_grace_period` /
+  `_handle_graceful_shutdown`)
 - writes status to `/home/jj1049/prod/deadtrees/auto-deploy.log`
 
 `docker-compose.processor.yaml` builds the processor locally on the processing

--- a/processor/src/continuous_processor.py
+++ b/processor/src/continuous_processor.py
@@ -7,7 +7,15 @@ from shared.settings import settings
 
 
 def run_continuous():
-	"""Run the processor in a continuous loop, checking the queue every 10 seconds"""
+	"""Run the processor as a persistent worker.
+
+	The worker drains the queue back-to-back: as long as ``background_process``
+	reports it processed a task, the next one is claimed immediately with no
+	wait. Only when the queue has nothing processable does the worker sleep for
+	``PROCESSOR_IDLE_BACKOFF_SECONDS`` before polling again. This replaces the
+	old one-task-per-cron-run model, where every task paid the wait for the next
+	cron minute plus container startup, login and cleanup overhead.
+	"""
 	logger.info('Starting continuous processor...')
 
 	# Perform startup cleanup to recover from crashes/restarts
@@ -21,11 +29,15 @@ def run_continuous():
 
 	while True:
 		try:
-			background_process()
+			did_work = background_process()
 		except Exception as e:
 			logger.error(f'Error in processor loop: {e}')
+			did_work = False
 
-		time.sleep(10)
+		# Back off only when there was nothing to do; while a backlog exists we
+		# loop straight into the next claim so no task waits on a fixed timer.
+		if not did_work:
+			time.sleep(settings.PROCESSOR_IDLE_BACKOFF_SECONDS)
 
 
 if __name__ == '__main__':

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -800,11 +800,16 @@ def process_task(task: QueueTask, token: str):
 			shutil.rmtree(settings.processing_path, ignore_errors=True)
 
 
-def background_process():
+def background_process() -> bool:
 	"""
-	Cron-triggered processor: pick the next task from the queue and process it.
+	Process the next healthy task from the queue, if there is one.
 
-	On each run this function:
+	Returns True if a healthy task was claimed and processed, False if there was
+	nothing processable (empty queue or head task not uploaded yet). The
+	continuous worker (``continuous_processor.run_continuous``) uses this to
+	decide whether to drain the next task immediately or back off and re-poll.
+
+	On each call this function:
 	1. Logs in as the processor service account.
 	2. Installs a graceful-shutdown handler so a deploy/restart (SIGTERM) cleanly
 	   re-queues the in-flight task for retry instead of leaving it stranded.
@@ -817,7 +822,7 @@ def background_process():
 	     OOM/bug crashes are deterministic, so retrying only loops and wastes
 	     compute — we deliberately do not retry them.
 	4. Detects crashes the same way for the next waiting task, then processes the
-	   first healthy, ready task and exits.
+	   first healthy, ready task and returns.
 
 	Multiple workers can read the same waiting row, but only one can atomically
 	claim it by flipping `is_processing=false` to true and recording `claimed_by`.
@@ -890,7 +895,7 @@ def background_process():
 		task = get_next_task(token)
 		if task is None:
 			print('No tasks in the queue.')
-			return
+			return False
 
 		is_ready, has_error = is_dataset_uploaded_or_processed(task, token)
 
@@ -916,14 +921,14 @@ def background_process():
 			continue
 
 		if not is_ready:
-			# Not uploaded yet - skip, try again next cron run
+			# Not uploaded yet - skip, try again on a later poll
 			logger.info(
 				f'Skipping task {task.id} - dataset not uploaded yet; will retry later',
 				LogContext(
 					category=LogCategory.PROCESS, dataset_id=task.dataset_id, user_id=task.user_id, token=token
 				),
 			)
-			return
+			return False
 
 		claimed_task = claim_task(token, task, worker_id)
 		if claimed_task is None:
@@ -958,7 +963,7 @@ def background_process():
 			),
 		)
 		process_task(task, token=token)
-		break  # processed one task, exit for cron
+		return True  # processed one healthy task
 
 
 if __name__ == '__main__':

--- a/processor/tests/test_continuous_processor.py
+++ b/processor/tests/test_continuous_processor.py
@@ -1,0 +1,73 @@
+"""Unit tests for the persistent-worker loop in continuous_processor.
+
+These exercise the drain-vs-backoff decision without touching the real queue:
+``background_process`` and ``time.sleep`` are stubbed so we can assert exactly
+when the worker sleeps.
+"""
+
+import pytest
+
+import processor.src.continuous_processor as cp
+
+
+def _disable_startup(monkeypatch):
+	"""Stub out login + cleanup so run_continuous goes straight to the loop."""
+	monkeypatch.setattr(cp, 'login', lambda *a, **k: 'token')
+	monkeypatch.setattr(cp, 'cleanup_orphaned_resources', lambda *a, **k: None)
+	monkeypatch.setattr(cp, 'cleanup_old_temp_directories', lambda *a, **k: None)
+
+
+def _run_loop(monkeypatch, work_sequence):
+	"""Drive run_continuous over a fixed sequence, recording sleeps.
+
+	A trailing KeyboardInterrupt (BaseException, so not swallowed by the loop's
+	``except Exception``) breaks out of the otherwise-infinite ``while True``.
+	Returns the list of arguments passed to time.sleep.
+	"""
+	_disable_startup(monkeypatch)
+
+	sleeps = []
+	monkeypatch.setattr(cp.time, 'sleep', lambda s: sleeps.append(s))
+
+	seq = list(work_sequence)
+
+	def fake_background_process():
+		if not seq:
+			raise KeyboardInterrupt
+		item = seq.pop(0)
+		if isinstance(item, type) and issubclass(item, BaseException):
+			raise item
+		return item
+
+	monkeypatch.setattr(cp, 'background_process', fake_background_process)
+
+	with pytest.raises(KeyboardInterrupt):
+		cp.run_continuous()
+	return sleeps
+
+
+def test_backlog_drains_without_sleeping(monkeypatch):
+	"""Consecutive processed tasks must claim the next one with no wait."""
+	sleeps = _run_loop(monkeypatch, [True, True, True])
+	assert sleeps == []
+
+
+def test_idle_poll_backs_off(monkeypatch):
+	"""An empty poll sleeps for the configured idle backoff."""
+	monkeypatch.setattr(cp.settings, 'PROCESSOR_IDLE_BACKOFF_SECONDS', 7)
+	sleeps = _run_loop(monkeypatch, [False])
+	assert sleeps == [7]
+
+
+def test_only_idle_polls_sleep(monkeypatch):
+	"""Work then idle then work: exactly one sleep, only for the idle poll."""
+	monkeypatch.setattr(cp.settings, 'PROCESSOR_IDLE_BACKOFF_SECONDS', 5)
+	sleeps = _run_loop(monkeypatch, [True, False, True])
+	assert sleeps == [5]
+
+
+def test_exception_is_treated_as_idle(monkeypatch):
+	"""A crashing poll is caught and backs off instead of hot-looping."""
+	monkeypatch.setattr(cp.settings, 'PROCESSOR_IDLE_BACKOFF_SECONDS', 3)
+	sleeps = _run_loop(monkeypatch, [RuntimeError])
+	assert sleeps == [3]

--- a/processor/tests/test_processor.py
+++ b/processor/tests/test_processor.py
@@ -65,9 +65,9 @@ def test_background_process_no_tasks():
 	# Run the background process with empty queue
 	background_process()
 
-	# Verify it completes without error
-	# (The function should return None when no tasks are found)
-	assert background_process() is None
+	# Verify it reports that no work was done when the queue is empty, so the
+	# continuous worker knows to back off instead of hot-looping.
+	assert background_process() is False
 
 
 def test_process_task_success_path_with_refresh(monkeypatch):

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -129,6 +129,11 @@ class Settings(BaseSettings):
 	PROCESSOR_USERNAME: str = 'processor@deadtrees.earth'
 	PROCESSOR_PASSWORD: str = 'processor'
 	PROCESSOR_WORKER_ID: str = ''
+	# Seconds the continuous processor waits before re-polling the queue *only*
+	# when the last poll found no processable task. When there is a backlog the
+	# worker claims the next task immediately (zero wait), so this backoff never
+	# applies mid-drain.
+	PROCESSOR_IDLE_BACKOFF_SECONDS: int = 10
 	SSH_PRIVATE_KEY_PATH: str = '/app/ssh_key'
 	SSH_PRIVATE_KEY_PASSPHRASE: str = ''
 	ODM_AUTO_BOUNDARY: bool = False


### PR DESCRIPTION
## Problem

The processor runs **one task per cron-launched container** (`command: python -m processor.src.processor` → `background_process()` → `break # exit for cron`), then exits and waits for the next cron minute.

With task completion uniformly distributed within the minute, each task pays ~30s average wait for the next trigger. For a ~3 min job that's a ~3.5 min cycle → **≈205 min/day (~3.5h) of pure idle waiting** under continuous load. On top of that, every single task re-pays container startup, `login()`, and startup cleanup (`cleanup_orphaned_resources` / `cleanup_old_temp_directories`).

## Change

Switch to the already-present-but-unwired continuous worker, fixed so it drains the queue back-to-back:

- **`processor/src/processor.py`** — `background_process()` now returns `bool`: `True` when it claimed and processed a healthy task, `False` when nothing was processable (empty queue / head not uploaded). `break # exit for cron` → `return True`; bail-outs → `return False`.
- **`processor/src/continuous_processor.py`** — loops straight into the next claim while work exists (**zero wait**); sleeps `PROCESSOR_IDLE_BACKOFF_SECONDS` only when idle/failed. Startup login+cleanup runs once.
- **`shared/settings.py`** — new `PROCESSOR_IDLE_BACKOFF_SECONDS: int = 10` (env-overridable).
- **`docker-compose.processor.yaml`** — `command` → `continuous_processor`; `restart: on-failure:5` → `unless-stopped` (persistent worker survives crashes/reboots; a poison task is failed-not-retried by stale-active detection, so no infinite spin).
- **`docs/playbooks/create-release.md`** — new deploy model: drop the per-minute `docker compose up` cron entry; `auto_deploy_processor.sh` uses `up -d --build` so a new image recreates the container via the existing graceful-shutdown + re-queue path.

## Effect

Under any backlog the ~30s/task wait disappears and container/login/cleanup overhead is amortized across tasks. Worst-case idle latency drops from ≤60s to ≤10s. Deploys still re-queue in-flight work cleanly via `_handle_graceful_shutdown` (`stop_grace_period: 30s`).

## Tests

- Fixed `test_background_process_no_tasks` (asserted old `None` return → now `is False`).
- Added `processor/tests/test_continuous_processor.py`: drain-without-sleep, idle backoff, mixed sequence, exception-as-idle.

Processor tests only run in the container image (geo deps). Loop control flow was validated locally against fakes: `[T,T,T]→[]`, `[F]→[10]`, `[T,F,T]→[10]`, `[RuntimeError]→[10]`.

## ⚠️ Operational follow-up (not in this PR)

The production `processing-server` crontab still has `* * * * * ... docker compose up`. After merge, remove that line and update `auto_deploy_processor.sh` to `up -d --build`, per the doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The processor now runs as a continuous background worker, automatically draining queued work and backing off only when idle.
  * Added a configurable idle backoff interval for the processor.

* **Bug Fixes**
  * Improved handling when no work is available so the worker pauses instead of looping too quickly.
  * Updated shutdown/restart behavior to better support in-flight work during redeploys.

* **Documentation**
  * Updated the release workflow guide to match the new processor deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->