### PR TITLE
fix(frontend): speed up account view map navigation

### DIFF
--- a/.github/scripts/firebase-hosting-deploy.sh
+++ b/.github/scripts/firebase-hosting-deploy.sh
@@ -137,6 +137,41 @@ is_hosting_version_already_active() {
 	grep -Fq 'current active version' "$log_file" && grep -Fq '/channels/' "$log_file"
 }
 
+emit_preview_url() {
+	if [[ "$mode" != "preview" ]]; then
+		return 0
+	fi
+
+	local channel_response preview_url
+	channel_response="$(
+		curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 3 \
+			--silent --show-error \
+			--header "Authorization: Bearer $FIREBASE_TOKEN" \
+			"https://firebasehosting.googleapis.com/v1beta1/projects/${project_id}/sites/${project_id}/channels/${channel_id}"
+	)"
+	preview_url="$(node -e '
+const fs = require("fs");
+const body = JSON.parse(fs.readFileSync(0, "utf8"));
+if (!body.url) {
+  console.error("Firebase channel response did not include url");
+  process.exit(1);
+}
+process.stdout.write(body.url);
+' <<<"$channel_response")"
+
+	echo "Firebase preview URL: $preview_url"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		echo "preview_url=$preview_url" >>"$GITHUB_OUTPUT"
+	fi
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		{
+			echo "### Firebase Hosting preview"
+			echo
+			echo "[Open preview]($preview_url)"
+		} >>"$GITHUB_STEP_SUMMARY"
+	fi
+}
+
 for attempt in $(seq 1 "$max_attempts"); do
 	log_file="$runner_temp/firebase-hosting-${mode}-${attempt}.log"
 	echo "Firebase Hosting ${mode} deploy attempt ${attempt}/${max_attempts}"
@@ -147,11 +182,13 @@ for attempt in $(seq 1 "$max_attempts"); do
 	set -e
 
 	if [[ "$rc" -eq 0 ]]; then
+		emit_preview_url
 		exit 0
 	fi
 
 	if is_hosting_version_already_active "$log_file"; then
 		echo "Firebase reports this Hosting version is already active on the target channel; treating as a successful deploy."
+		emit_preview_url
 		exit 0
 	fi
 

--- a/.github/scripts/firebase-hosting-deploy.sh
+++ b/.github/scripts/firebase-hosting-deploy.sh
@@ -132,9 +132,9 @@ is_transient_firebase_auth_error() {
 		"$log_file"
 }
 
-is_live_already_active() {
+is_hosting_version_already_active() {
 	local log_file="$1"
-	grep -Fq 'current active version' "$log_file" && grep -Fq '/channels/live' "$log_file"
+	grep -Fq 'current active version' "$log_file" && grep -Fq '/channels/' "$log_file"
 }
 
 for attempt in $(seq 1 "$max_attempts"); do
@@ -150,8 +150,8 @@ for attempt in $(seq 1 "$max_attempts"); do
 		exit 0
 	fi
 
-	if [[ "$mode" == "live" ]] && is_live_already_active "$log_file"; then
-		echo "Firebase reports this Hosting version is already active on live; treating as a successful deploy."
+	if is_hosting_version_already_active "$log_file"; then
+		echo "Firebase reports this Hosting version is already active on the target channel; treating as a successful deploy."
 		exit 0
 	fi
 

--- a/.github/workflows/frontend-hosting-pull-request.yml
+++ b/.github/workflows/frontend-hosting-pull-request.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   checks: write
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -69,7 +70,7 @@ jobs:
         id: firebase-channel
         run: |
           raw="pr${{ github.event.pull_request.number }}-${{ github.head_ref }}"
-          channel="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]+/_/g; s/^[_-]+|[_-]+$//g' | cut -c1-30)"
+          channel="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+|-+$//g' | cut -c1-30)"
           if [ -z "$channel" ]; then
             channel="pr${{ github.event.pull_request.number }}"
           fi
@@ -85,6 +86,46 @@ jobs:
           FIREBASE_TOOLS_VERSION: 15.22.2
           FIREBASE_CHANNEL_ID: ${{ steps.firebase-channel.outputs.channel }}
         run: ../.github/scripts/firebase-hosting-deploy.sh preview
+      - name: Comment Firebase preview URL
+        if: ${{ steps.firebase-preview.outputs.preview_url != '' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = "<!-- deadtrees-frontend-preview -->";
+            const previewUrl = "${{ steps.firebase-preview.outputs.preview_url }}";
+            const body = [
+              marker,
+              "### Frontend preview",
+              "",
+              `[Open Firebase preview](${previewUrl})`,
+              "",
+              "Channel: `${{ steps.firebase-channel.outputs.channel }}`",
+              "Commit: `${{ github.event.pull_request.head.sha }}`",
+            ].join("\n");
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
       - name: Warn when Firebase preview deploy fails
         if: ${{ steps.firebase-preview.outcome == 'failure' }}
         run: |

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -30,6 +30,7 @@ import AuditBadge from "./AuditBadge";
 import { useQueryClient } from "@tanstack/react-query";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useCanUploadPrivate } from "../hooks/useUserPrivileges";
+import { openDatasetDetail } from "../utils/datasetDetailNavigation";
 
 interface Dataset {
   id: number;
@@ -82,7 +83,7 @@ const DataTable: React.FC<DataTableProps> = ({
 }) => {
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const { data: userData, isLoading: isLoadingData } = useUserDatasets();
-  const { user } = useAuth();
+  const { status, user } = useAuth();
   const [datasetsInPublication, setDatasetsInPublication] = useState<number[]>([]);
 
   // State for edit modal
@@ -338,15 +339,14 @@ const DataTable: React.FC<DataTableProps> = ({
         label: "View Map",
         icon: <EnvironmentOutlined />,
         disabled: !canView,
-        onClick: async () => {
-          try {
-            await queryClient.invalidateQueries({ queryKey: ["public-datasets"] });
-            await queryClient.refetchQueries({ queryKey: ["public-datasets"] });
-          } catch (e) {
-            // no-op; navigation still proceeds
-          }
-          nav(`/dataset/${record.id}`);
-        },
+        onClick: () =>
+          openDatasetDetail({
+            queryClient,
+            navigate: nav,
+            dataset: record,
+            authStatus: status,
+            userId: user?.id,
+          }),
       },
       {
         key: "edit",

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -343,7 +343,7 @@ const DataTable: React.FC<DataTableProps> = ({
           openDatasetDetail({
             queryClient,
             navigate: nav,
-            dataset: record,
+            datasetId: record.id,
             authStatus: status,
             userId: user?.id,
           }),

--- a/frontend/src/hooks/useDatasets.ts
+++ b/frontend/src/hooks/useDatasets.ts
@@ -4,6 +4,7 @@ import { supabase } from "./useSupabase";
 import { Settings } from "../config";
 import { IDataset, IDatasetArchiveItem } from "../types/dataset";
 import { fixTextEncoding } from "../utils/textUtils";
+import { getPublicDatasetByIdQueryKey } from "../utils/datasetDetailNavigation";
 
 interface DatasetQueryOptions {
   enabled?: boolean;
@@ -68,7 +69,7 @@ export function usePublicDatasetById(datasetId: number | undefined) {
   const { status, user } = useAuth();
 
 	return useQuery({
-		queryKey: ["public-dataset-by-id", datasetId, status, user?.id ?? "anonymous"],
+		queryKey: getPublicDatasetByIdQueryKey(datasetId, status, user?.id),
 		enabled: !!datasetId && status !== "checking",
 		queryFn: async () => {
 			if (!datasetId) return null;

--- a/frontend/src/utils/datasetDetailNavigation.test.ts
+++ b/frontend/src/utils/datasetDetailNavigation.test.ts
@@ -7,26 +7,30 @@ import {
 } from "./datasetDetailNavigation";
 
 describe("openDatasetDetail", () => {
-  it("primes the dataset detail cache and navigates immediately", () => {
-    const queryClient = new QueryClient();
+  it("marks existing detail data stale without caching a partial row and navigates immediately", () => {
+    const invalidateQueries = vi.fn(() => new Promise(() => {}));
+    const setQueryData = vi.fn();
+    const queryClient = {
+      invalidateQueries,
+      setQueryData,
+    } as unknown as QueryClient;
     const navigate = vi.fn();
-    const dataset = {
-      id: 10610,
-      file_name: "LB-Hofberg-20260630",
-      is_cog_done: true,
-    };
 
     openDatasetDetail({
       queryClient,
       navigate,
-      dataset,
+      datasetId: 10610,
       authStatus: "authenticated",
       userId: "user-123",
     });
 
     const queryKey = getPublicDatasetByIdQueryKey(10610, "authenticated", "user-123");
-    expect(queryClient.getQueryData(queryKey)).toBe(dataset);
-    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    expect(setQueryData).not.toHaveBeenCalled();
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey,
+      exact: true,
+      refetchType: "none",
+    });
     expect(navigate).toHaveBeenCalledWith("/dataset/10610");
   });
 });

--- a/frontend/src/utils/datasetDetailNavigation.test.ts
+++ b/frontend/src/utils/datasetDetailNavigation.test.ts
@@ -1,0 +1,32 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getPublicDatasetByIdQueryKey,
+  openDatasetDetail,
+} from "./datasetDetailNavigation";
+
+describe("openDatasetDetail", () => {
+  it("primes the dataset detail cache and navigates immediately", () => {
+    const queryClient = new QueryClient();
+    const navigate = vi.fn();
+    const dataset = {
+      id: 10610,
+      file_name: "LB-Hofberg-20260630",
+      is_cog_done: true,
+    };
+
+    openDatasetDetail({
+      queryClient,
+      navigate,
+      dataset,
+      authStatus: "authenticated",
+      userId: "user-123",
+    });
+
+    const queryKey = getPublicDatasetByIdQueryKey(10610, "authenticated", "user-123");
+    expect(queryClient.getQueryData(queryKey)).toBe(dataset);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    expect(navigate).toHaveBeenCalledWith("/dataset/10610");
+  });
+});

--- a/frontend/src/utils/datasetDetailNavigation.ts
+++ b/frontend/src/utils/datasetDetailNavigation.ts
@@ -3,8 +3,6 @@ import type { NavigateFunction } from "react-router-dom";
 
 import type { AuthStatus } from "../hooks/useAuthProvider";
 
-export type DatasetDetailCacheRecord = { id: number };
-
 export function getPublicDatasetByIdQueryKey(
   datasetId: number | undefined,
   authStatus: AuthStatus,
@@ -16,24 +14,23 @@ export function getPublicDatasetByIdQueryKey(
 export function openDatasetDetail({
   queryClient,
   navigate,
-  dataset,
+  datasetId,
   authStatus,
   userId,
 }: {
   queryClient: QueryClient;
   navigate: NavigateFunction;
-  dataset: DatasetDetailCacheRecord;
+  datasetId: number;
   authStatus: AuthStatus;
   userId?: string | null;
 }) {
-  const queryKey = getPublicDatasetByIdQueryKey(dataset.id, authStatus, userId);
+  const queryKey = getPublicDatasetByIdQueryKey(datasetId, authStatus, userId);
 
-  queryClient.setQueryData(queryKey, dataset);
   void queryClient.invalidateQueries({
     queryKey,
     exact: true,
     refetchType: "none",
   });
 
-  navigate(`/dataset/${dataset.id}`);
+  navigate(`/dataset/${datasetId}`);
 }

--- a/frontend/src/utils/datasetDetailNavigation.ts
+++ b/frontend/src/utils/datasetDetailNavigation.ts
@@ -1,0 +1,39 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { NavigateFunction } from "react-router-dom";
+
+import type { AuthStatus } from "../hooks/useAuthProvider";
+
+export type DatasetDetailCacheRecord = { id: number };
+
+export function getPublicDatasetByIdQueryKey(
+  datasetId: number | undefined,
+  authStatus: AuthStatus,
+  userId?: string | null,
+) {
+  return ["public-dataset-by-id", datasetId, authStatus, userId ?? "anonymous"] as const;
+}
+
+export function openDatasetDetail({
+  queryClient,
+  navigate,
+  dataset,
+  authStatus,
+  userId,
+}: {
+  queryClient: QueryClient;
+  navigate: NavigateFunction;
+  dataset: DatasetDetailCacheRecord;
+  authStatus: AuthStatus;
+  userId?: string | null;
+}) {
+  const queryKey = getPublicDatasetByIdQueryKey(dataset.id, authStatus, userId);
+
+  queryClient.setQueryData(queryKey, dataset);
+  void queryClient.invalidateQueries({
+    queryKey,
+    exact: true,
+    refetchType: "none",
+  });
+
+  navigate(`/dataset/${dataset.id}`);
+}


### PR DESCRIPTION
## Summary
- Remove the blocking full public dataset refetch from the account table's View Map action.
- Keep navigation immediate while avoiding writes of partial account-table rows into the dataset detail query cache.
- Add a unit test covering immediate navigation and the no-partial-cache behavior.

## Why
The View Map action on My Account waited for a full `public-datasets` invalidation/refetch before route navigation, making the click feel unresponsive and confusing in recordings.

## Review follow-up
Addressed review feedback that the account table row shape is not guaranteed to match the full `IDataset` shape consumed by the detail route. The helper now passes only the dataset id, marks any existing matching detail query stale without refetching, and lets the detail route perform its normal single-row fetch.

## Validation
- `npm --prefix frontend test -- datasetDetailNavigation`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- Browser plugin check against local Vite module before review follow-up: navigation was recorded at 0ms even when `invalidateQueries()` never resolved.

## Risk
Low. The account click no longer blocks on a broad archive refresh, and the detail page still owns the canonical dataset fetch instead of rendering from a partial account-table row.
