### PR TITLE
fix(processor): raise Docker client read timeout to 600s

### DIFF
--- a/processor/src/process_odm.py
+++ b/processor/src/process_odm.py
@@ -537,7 +537,9 @@ def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_i
 		token: Authentication token for logging
 		dataset_id: Dataset ID for logging
 	"""
-	client = docker.from_env()
+	# Generous read timeout: creating/starting the ODM container can block past the
+	# 60s docker default when the host disk is saturated after extracting the raw-image zip.
+	client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT_SECONDS)
 	volume_name = f'odm_processing_{dataset_id}'
 	retain_on_failure = retain_failed_artifacts_enabled_for_dataset(dataset_id)
 	resource_labels = dt_resource_labels(dataset_id=dataset_id, stage='odm', keep_eligible=retain_on_failure)

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -31,7 +31,7 @@ logger = UnifiedLogger(__name__)
 def _kill_dangling_dataset_resources(dataset_id: int):
 	"""Kill any running containers and remove volumes left over from an interrupted job."""
 	try:
-		client = docker.from_env()
+		client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT_SECONDS)
 		label_filter = f'dt_dataset_id={dataset_id}'
 
 		containers = client.containers.list(all=True, filters={'label': label_filter})

--- a/processor/src/utils/shared_volume.py
+++ b/processor/src/utils/shared_volume.py
@@ -13,6 +13,17 @@ import time
 from pathlib import Path
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
+from shared.settings import settings
+
+
+def _docker_client() -> docker.DockerClient:
+	"""Docker client with a generous read timeout.
+
+	The default 60s socket read timeout is too low for daemon control-plane calls
+	(containers.create/start, put_archive) when the host disk is busy flushing a
+	freshly-extracted multi-GB raw-image zip. See DOCKER_CLIENT_TIMEOUT_SECONDS.
+	"""
+	return docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT_SECONDS)
 
 
 class _GeneratorStream(io.RawIOBase):
@@ -58,7 +69,7 @@ def copy_files_to_shared_volume(
 		dataset_id: Dataset ID for logging and project naming
 		token: Authentication token for logging
 	"""
-	client = docker.from_env()
+	client = _docker_client()
 	project_name = f'dataset_{dataset_id}'
 
 	logger.info(
@@ -165,7 +176,7 @@ def copy_results_from_shared_volume(volume_name: str, output_dir: Path, project_
 		dataset_id: Dataset ID for logging
 		token: Authentication token for logging
 	"""
-	client = docker.from_env()
+	client = _docker_client()
 
 	logger.info(
 		f'Copying ODM results from shared volume {volume_name} to {output_dir} using Docker API',
@@ -284,7 +295,7 @@ def cleanup_volume_and_references(
 	1) Removing any containers that reference it
 	2) Removing the volume with retry/backoff
 	"""
-	client = docker.from_env()
+	client = _docker_client()
 
 	# Remove referencing containers first
 	containers = _containers_referencing_volume(client, volume_name)

--- a/processor/src/utils/startup_cleanup.py
+++ b/processor/src/utils/startup_cleanup.py
@@ -11,6 +11,7 @@ import time
 from datetime import datetime, timezone
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
+from shared.settings import settings
 from processor.src.utils.debug_artifacts import retention_ttl_hours
 
 
@@ -29,7 +30,7 @@ def cleanup_orphaned_resources(token: str):
 	Args:
 		token: Authentication token for database operations
 	"""
-	client = docker.from_env()
+	client = docker.from_env(timeout=settings.DOCKER_CLIENT_TIMEOUT_SECONDS)
 	ttl_hours = retention_ttl_hours()
 
 	logger.info('=== STARTUP CLEANUP ===', LogContext(category=LogCategory.PROCESS, token=token))

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -46,6 +46,15 @@ class Settings(BaseSettings):
 	TCD_CONTAINER_IMAGE: str = 'deadtrees-tcd:latest'
 	TCD_CONTAINER_TIMEOUT_SECONDS: int = 14400
 
+	# docker.from_env() defaults to a 60s read timeout on the daemon socket, which applies
+	# to control-plane calls (containers.create/start, put_archive, wait). When the host disk
+	# is saturated flushing a freshly-extracted multi-GB raw-image zip, the daemon can take
+	# well over 60s just to service a create/start, surfacing as spurious
+	# "UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)"
+	# failures in the ODM copy-to-volume step. Give the daemon far more headroom; this is not
+	# a timeout on the ODM run itself (that is bounded separately by container.wait).
+	DOCKER_CLIENT_TIMEOUT_SECONDS: int = 600
+
 	# Base paths and directories
 	BASE_DIR: str = str(BASE)
 	# Default to repo-local assets in dev/test; container deployments can still override via env.


### PR DESCRIPTION
## Problem

Datasets in last night's upload batch failed ODM processing with:

```
UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
```

This is **not** a transient error and **not** dataset-specific. The failure is in `copy_files_to_shared_volume`, at the very first Docker API call — `containers.create()`/`.start()` of the `alpine` transfer helper (the `Created temporary container …` log never appears on failures, and the gap is exactly ~60.2s every time).

The `60` is the Docker SDK's default **read timeout** on the daemon socket (`DEFAULT_TIMEOUT_SECONDS = 60`), which bounds *every* control-plane call. Right before the copy step, the pipeline pulls + unzips a 9–11 GB raw-image zip into `/data`; the kernel is still flushing those dirty pages, and `dockerd` has to fsync container/overlay metadata to start the helper. Under that disk saturation the daemon returns no response bytes for >60s → the SDK read-times-out.

### Evidence it's control-plane latency, not the data

Helper create+start time across the batch ranged **0.4s → 60s for identically-sized (~8–10 GB) datasets**. The clincher: dataset **10629 timed out at 60s on one attempt and created the helper in 0.4s on a quieter reschedule** (then succeeded). The three that failed (10620 / 10629#1 / 10630) are the largest and happened to hit create/start while the disk was busiest.

## Fix

Add a configurable `DOCKER_CLIENT_TIMEOUT_SECONDS` (default **600s**) and pass it to the processor's `docker.from_env()` clients:

- `process_odm.py` — ODM container run
- `utils/shared_volume.py` — copy-to / copy-from / cleanup (via a small `_docker_client()` helper)
- `utils/startup_cleanup.py` — startup orphan cleanup
- `processor.py` — dangling-resource cleanup

This gives the daemon headroom to answer control-plane calls under disk load. It does **not** extend the ODM run timeout, which is bounded separately by `container.wait()`. Overridable per host via the `DOCKER_CLIENT_TIMEOUT_SECONDS` env var.

## Notes / follow-ups (out of scope)

- `treecover_segmentation_oam_tcd/predict_treecover.py` also uses bare `docker.from_env()`; left untouched here since it has its own container-timeout handling.
- Root cause is IO saturation from the raw-zip extract; a further mitigation would be to `sync`/drain after extract before creating the helper, or reduce per-host concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker timeout handling across processor workflows to make long-running container and cleanup operations more reliable.
  * Reduced the chance of failures during shared-volume file copy and cleanup tasks when the Docker daemon responds slowly.
  * Added a default timeout setting to support more stable startup and resource cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->