### PR TITLE
feat(priwa): add mosaic layers and table export

### DIFF
--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -25,7 +25,7 @@ import TileLayerWebGL from "ol/layer/WebGLTile.js";
 import { unByKey } from "ol/Observable";
 import { fromLonLat, toLonLat } from "ol/proj";
 import View from "ol/View";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PointerEvent } from "react";
 
 import { createStandardMapControls } from "../../utils/basemaps";
@@ -36,7 +36,7 @@ import {
   createPriwaOfflineAreaFeature,
   createPriwaOfflineAreaLayer,
 } from "./createPriwaOfflineAreaLayer";
-import { createPriwaCogLayer } from "./createPriwaCogLayer";
+import { createPriwaCogLayers } from "./createPriwaCogLayer";
 import {
   createPriwaPointFeature,
   createPriwaPointLayer,
@@ -47,6 +47,7 @@ import PriwaPointDrawer from "./PriwaPointDrawer";
 import PriwaPointListPanel from "./PriwaPointListPanel";
 import PriwaOfflineStatus from "./PriwaOfflineStatus";
 import { usePriwaOfflineBasemap } from "./usePriwaOfflineBasemap";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
 import type { IPriwaSyncSummary } from "./priwaOfflineSync";
 import type {
   IPriwaCoordinate,
@@ -56,6 +57,43 @@ import type {
 
 const FIELD_CENTER: [number, number] = [8.18013, 48.45596];
 type PriwaBaseLayer = "aerial" | "topographic";
+
+const formatPriwaMosaicDate = (value: string | null | undefined) => {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (match) {
+    return `${match[3]}.${match[2]}.${match[1]}`;
+  }
+
+  return value;
+};
+
+const mosaicDateRank = (value: string | null | undefined) => {
+  if (!value) return Number.NEGATIVE_INFINITY;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+};
+
+const mosaicIdRank = (id: string) => {
+  const numericId = Number(id);
+  return Number.isFinite(numericId) ? numericId : Number.NEGATIVE_INFINITY;
+};
+
+const comparePriwaMosaics = (left: IPriwaMosaic, right: IPriwaMosaic) => {
+  const captureDifference =
+    mosaicDateRank(right.captureDate) - mosaicDateRank(left.captureDate);
+  if (captureDifference !== 0) return captureDifference;
+
+  const uploadDifference =
+    mosaicDateRank(right.createdAt) - mosaicDateRank(left.createdAt);
+  if (uploadDifference !== 0) return uploadDifference;
+
+  const idDifference = mosaicIdRank(right.id) - mosaicIdRank(left.id);
+  if (idDifference !== 0) return idDifference;
+
+  return right.id.localeCompare(left.id);
+};
 
 function MapLayersIcon() {
   return (
@@ -85,8 +123,9 @@ interface PriwaFieldMapProps {
   isLoadingPoints?: boolean;
   isSavingPoint?: boolean;
   projectName: string;
-  cogPath?: string | null;
+  mosaics?: IPriwaMosaic[];
   isCogLoading?: boolean;
+  cogErrorMessage?: string | null;
   errorMessage?: string | null;
   syncSummary?: IPriwaSyncSummary;
   onAddPoint: (point: IPriwaPoint) => Promise<void>;
@@ -101,8 +140,9 @@ export default function PriwaFieldMap({
   isLoadingPoints = false,
   isSavingPoint = false,
   projectName,
-  cogPath,
+  mosaics = [],
   isCogLoading = false,
+  cogErrorMessage = null,
   errorMessage = null,
   syncSummary,
   onAddPoint,
@@ -129,9 +169,12 @@ export default function PriwaFieldMap({
   const topographicLayerRef = useRef<ReturnType<
     typeof createPriwaTopographicLayer
   > | null>(null);
-  const cogLayerRef = useRef<TileLayerWebGL | null>(null);
+  const cogLayersRef = useRef<TileLayerWebGL[]>([]);
+  const knownMosaicIdsRef = useRef<Set<string>>(new Set());
   const [isDrawerOpen, setDrawerOpen] = useState(false);
-  const [isCogVisible, setCogVisible] = useState(true);
+  const [enabledMosaicIds, setEnabledMosaicIds] = useState<Set<string>>(
+    new Set(),
+  );
   const [isPlacingPoint, setPlacingPoint] = useState(false);
   const [selectedCoordinate, setSelectedCoordinate] =
     useState<IPriwaCoordinate | null>(null);
@@ -141,6 +184,17 @@ export default function PriwaFieldMap({
   const [formSessionId, setFormSessionId] = useState(0);
   const [isPointListOpen, setPointListOpen] = useState(false);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
+  const visibleMosaics = useMemo(
+    () =>
+      [...mosaics]
+        .filter((mosaic) => mosaic.cogUrl.trim().length > 0)
+        .sort(comparePriwaMosaics),
+    [mosaics],
+  );
+  const enabledMosaics = useMemo(
+    () => visibleMosaics.filter((mosaic) => enabledMosaicIds.has(mosaic.id)),
+    [enabledMosaicIds, visibleMosaics],
+  );
   const userLocation = useUserLocationLayer(mapRef);
   const {
     layer: userLocationLayer,
@@ -245,7 +299,7 @@ export default function PriwaFieldMap({
       topographicLayerRef.current = null;
       pointLayerRef.current = null;
       previewLayerRef.current = null;
-      cogLayerRef.current = null;
+      cogLayersRef.current = [];
     };
   }, [openPointForEditing, stopUserLocation, userLocationLayer]);
 
@@ -253,6 +307,23 @@ export default function PriwaFieldMap({
     aerialLayerRef.current?.setVisible(baseLayer === "aerial");
     topographicLayerRef.current?.setVisible(baseLayer === "topographic");
   }, [baseLayer]);
+
+  useEffect(() => {
+    const nextKnownIds = new Set(visibleMosaics.map((mosaic) => mosaic.id));
+    const previousKnownIds = knownMosaicIdsRef.current;
+
+    setEnabledMosaicIds((currentIds) => {
+      const nextEnabledIds = new Set<string>();
+      visibleMosaics.forEach((mosaic) => {
+        if (!previousKnownIds.has(mosaic.id) || currentIds.has(mosaic.id)) {
+          nextEnabledIds.add(mosaic.id);
+        }
+      });
+      return nextEnabledIds;
+    });
+
+    knownMosaicIdsRef.current = nextKnownIds;
+  }, [visibleMosaics]);
 
   useEffect(() => {
     const source = pointLayerRef.current?.getSource();
@@ -280,17 +351,22 @@ export default function PriwaFieldMap({
     const map = mapRef.current;
     if (!map) return;
 
-    if (cogLayerRef.current) {
-      map.removeLayer(cogLayerRef.current);
-      cogLayerRef.current = null;
+    if (cogLayersRef.current.length > 0) {
+      cogLayersRef.current.forEach((layer) => {
+        map.removeLayer(layer);
+      });
+      cogLayersRef.current = [];
     }
 
-    if (!cogPath || !isCogVisible) return;
+    if (enabledMosaics.length === 0) return;
 
-    const cogLayer = createPriwaCogLayer(cogPath);
-    cogLayerRef.current = cogLayer;
-    map.getLayers().insertAt(2, cogLayer);
-  }, [cogPath, isCogVisible]);
+    const cogLayers = createPriwaCogLayers(enabledMosaics);
+    cogLayersRef.current = cogLayers;
+    cogLayers.forEach((layer, index) => {
+      layer.setZIndex(20 + (enabledMosaics.length - index) / 100);
+      map.getLayers().insertAt(2 + index, layer);
+    });
+  }, [enabledMosaics]);
 
   const handlePreviewCoordinate = useCallback(
     (coordinate: IPriwaCoordinate | null) => {
@@ -387,6 +463,23 @@ export default function PriwaFieldMap({
   const pointListToggleLabel = isPointListOpen
     ? "Punktliste schließen"
     : "Punktliste öffnen";
+  const mosaicCount = visibleMosaics.length;
+  const enabledMosaicCount = enabledMosaics.length;
+
+  const setMosaicVisibility = useCallback(
+    (mosaicId: string, checked: boolean) => {
+      setEnabledMosaicIds((currentIds) => {
+        const nextIds = new Set(currentIds);
+        if (checked) {
+          nextIds.add(mosaicId);
+        } else {
+          nextIds.delete(mosaicId);
+        }
+        return nextIds;
+      });
+    },
+    [],
+  );
 
   const handleAddPoint = useCallback(
     async (point: IPriwaPoint) => {
@@ -443,7 +536,7 @@ export default function PriwaFieldMap({
   }, [clearOfflineBasemapArea]);
 
   const layerPanel = (
-    <div className="w-56 space-y-3">
+    <div className="w-[21rem] max-w-[calc(100vw-3rem)] space-y-3">
       <div>
         <Typography.Text strong>Layer</Typography.Text>
         <div className="text-xs text-gray-500">
@@ -465,22 +558,81 @@ export default function PriwaFieldMap({
           onChange={setBaseLayer}
         />
       </div>
-      <div className="flex items-center justify-between gap-4">
-        <div>
-          <div className="text-sm font-medium text-gray-900">Drohnenlayer</div>
-          <div className="text-xs text-gray-500">
-            {isCogLoading
-              ? "Lade Drohnenlayer..."
-              : cogPath
-                ? "Optionaler Overlay"
-                : "Folgt in einem eigenen Schritt"}
-          </div>
+      <div>
+        <div className="text-sm font-medium text-gray-900">Drohnenlayer</div>
+        <div className="text-xs text-gray-500">
+          {isCogLoading
+            ? "Lade Drohnenlayer..."
+            : mosaicCount > 0
+              ? `${enabledMosaicCount} von ${mosaicCount} Befliegung${
+                  mosaicCount === 1 ? "" : "en"
+                } sichtbar`
+              : "Keine Drohnenlayer hinterlegt"}
         </div>
-        <Switch
-          checked={!!cogPath && isCogVisible}
-          disabled={!cogPath}
-          onChange={setCogVisible}
-        />
+        {cogErrorMessage && (
+          <div className="mt-1 text-xs text-red-600">{cogErrorMessage}</div>
+        )}
+        {mosaicCount > 0 && (
+          <div className="mt-2 max-h-80 space-y-2 overflow-y-auto pr-1">
+            {visibleMosaics.map((mosaic) => {
+              const isVisible = enabledMosaicIds.has(mosaic.id);
+              const captureDate = formatPriwaMosaicDate(mosaic.captureDate);
+              const uploadDate = formatPriwaMosaicDate(mosaic.createdAt);
+              const authors =
+                mosaic.authors.length > 0
+                  ? mosaic.authors.join(", ")
+                  : "Keine Autorenangabe";
+
+              return (
+                <div
+                  key={mosaic.id}
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-950">
+                        {mosaic.label}
+                      </div>
+                      <div className="mt-0.5 text-xs text-slate-500">
+                        Aufnahme: {captureDate ?? "ohne Datum"} · Upload:{" "}
+                        {uploadDate ?? "ohne Datum"}
+                      </div>
+                    </div>
+                    <Switch
+                      size="small"
+                      checked={isVisible}
+                      aria-label={`${mosaic.label} anzeigen`}
+                      onChange={(checked) =>
+                        setMosaicVisibility(mosaic.id, checked)
+                      }
+                    />
+                  </div>
+                  <details className="mt-1 text-xs text-slate-500">
+                    <summary className="cursor-pointer select-none">
+                      Details
+                    </summary>
+                    <dl className="mt-1 grid grid-cols-[5.5rem_minmax(0,1fr)] gap-x-2 gap-y-1">
+                      <dt className="text-slate-400">Autoren</dt>
+                      <dd className="min-w-0 break-words">{authors}</dd>
+                      <dt className="text-slate-400">Dataset ID</dt>
+                      <dd className="min-w-0 break-all">{mosaic.id}</dd>
+                      {mosaic.additionalInformation && (
+                        <>
+                          <dt className="text-slate-400">Info</dt>
+                          <dd className="min-w-0 break-words">
+                            {mosaic.additionalInformation}
+                          </dd>
+                        </>
+                      )}
+                      <dt className="text-slate-400">COG</dt>
+                      <dd className="min-w-0 break-all">{mosaic.cogUrl}</dd>
+                    </dl>
+                  </details>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,13 +1,16 @@
 import {
   AimOutlined,
   CheckCircleFilled,
+  DownloadOutlined,
   EditOutlined,
   EnvironmentOutlined,
   WarningFilled,
 } from "@ant-design/icons";
-import { Button, Empty, Segmented, Tag } from "antd";
+import { Button, Empty, Segmented, Table, Tag } from "antd";
+import type { TableProps } from "antd";
 import { useMemo, useState } from "react";
 
+import { downloadPriwaPointsCsv } from "./priwaPointCsv";
 import {
   getPriwaFundLabel,
   getPriwaPointSourceLabel,
@@ -47,6 +50,136 @@ export default function PriwaPointListPanel({
   const pendingSyncCount = points.filter(
     (point) => point.syncStatus && point.syncStatus !== "synced",
   ).length;
+  const columns = useMemo<TableProps<IPriwaPoint>["columns"]>(
+    () => [
+      {
+        title: "Status",
+        key: "status",
+        width: 92,
+        render: (_, point) => {
+          const isQa = isPriwaPointQaCandidate(point);
+          return (
+            <div className="flex items-center gap-1.5">
+              {isQa ? (
+                <WarningFilled className="text-amber-500" />
+              ) : (
+                <CheckCircleFilled className="text-emerald-600" />
+              )}
+              <Tag
+                className="m-0"
+                color={point.coordinateSource === "qr" ? "green" : "gold"}
+              >
+                {getPriwaPointSourceLabel(point)}
+              </Tag>
+            </div>
+          );
+        },
+      },
+      {
+        title: "Baumnr",
+        dataIndex: "baumnr",
+        width: 110,
+        render: (_, point) => getPriwaPointTitle(point),
+      },
+      {
+        title: "Datum",
+        dataIndex: "datum",
+        width: 118,
+      },
+      {
+        title: "Baumart",
+        dataIndex: "baumart",
+        width: 150,
+      },
+      {
+        title: "Fund",
+        dataIndex: "fund",
+        width: 150,
+        render: (_, point) => getPriwaFundLabel(point),
+      },
+      {
+        title: "Bohrmehl",
+        dataIndex: "bm",
+        width: 105,
+      },
+      {
+        title: "Bohrloch",
+        dataIndex: "bohrloch",
+        width: 150,
+      },
+      {
+        title: "Harz",
+        dataIndex: "harz",
+        width: 190,
+      },
+      {
+        title: "Grüne Nadeln",
+        dataIndex: "grueneNadelnAmBoden",
+        width: 130,
+      },
+      {
+        title: "Nadelverfärbung",
+        dataIndex: "nadel",
+        width: 160,
+      },
+      {
+        title: "Rindenverlust",
+        dataIndex: "rinde",
+        width: 125,
+      },
+      {
+        title: "Nadelverlust",
+        dataIndex: "kv",
+        width: 125,
+      },
+      {
+        title: "Name",
+        dataIndex: "name",
+        width: 150,
+      },
+      {
+        title: "Koordinaten",
+        key: "coordinates",
+        width: 190,
+        render: (_, point) => `${point.lat.toFixed(5)}, ${point.lon.toFixed(5)}`,
+      },
+      {
+        title: "Kommentar",
+        dataIndex: "kom",
+        width: 220,
+        ellipsis: true,
+      },
+      {
+        title: "",
+        key: "actions",
+        fixed: "right",
+        width: 88,
+        render: (_, point) => (
+          <div className="flex items-center gap-1">
+            <Button
+              aria-label="Punkt auf Karte zeigen"
+              icon={<AimOutlined />}
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onZoomToPoint(point);
+              }}
+            />
+            <Button
+              aria-label="Punkt bearbeiten"
+              icon={<EditOutlined />}
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onEditPoint(point);
+              }}
+            />
+          </div>
+        ),
+      },
+    ],
+    [onEditPoint, onZoomToPoint],
+  );
   const emptyDescription =
     isLoading
       ? "Lade Punkte..."
@@ -55,18 +188,30 @@ export default function PriwaPointListPanel({
         : "Keine Punkte";
 
   return (
-    <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[50dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-auto md:top-24 md:w-[390px] md:max-h-[calc(100dvh-8rem)]">
+    <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[64dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-4 md:top-24 md:max-h-[calc(100dvh-8rem)]">
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-slate-950">Käferbaum QA</div>
+          <div className="text-sm font-semibold text-slate-950">
+            Käferbäume
+          </div>
           <div className="truncate text-xs text-slate-500">
             {projectName}
             {pendingSyncCount > 0 ? ` · ${pendingSyncCount} lokal` : ""}
           </div>
         </div>
-        <Button size="small" onClick={onClose}>
-          Schließen
-        </Button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button
+            size="small"
+            icon={<DownloadOutlined />}
+            disabled={points.length === 0}
+            onClick={() => downloadPriwaPointsCsv(points, projectName)}
+          >
+            CSV
+          </Button>
+          <Button size="small" onClick={onClose}>
+            Schließen
+          </Button>
+        </div>
       </header>
 
       <div className="grid grid-cols-3 border-b border-slate-200 text-center text-xs">
@@ -106,72 +251,18 @@ export default function PriwaPointListPanel({
             />
           </div>
         ) : (
-          <div className="divide-y divide-slate-100">
-            {visiblePoints.map((point) => {
-              const isQa = isPriwaPointQaCandidate(point);
-              return (
-                <article
-                  key={point.id}
-                  className="grid grid-cols-[1fr_auto] gap-2 px-3 py-2.5"
-                >
-                  <button
-                    type="button"
-                    className="min-w-0 text-left"
-                    onClick={() => onZoomToPoint(point)}
-                  >
-                    <div className="flex min-w-0 items-center gap-1.5">
-                      {isQa ? (
-                        <WarningFilled className="shrink-0 text-amber-500" />
-                      ) : (
-                        <CheckCircleFilled className="shrink-0 text-emerald-600" />
-                      )}
-                      <span className="truncate text-sm font-semibold text-slate-950">
-                        {getPriwaPointTitle(point)}
-                      </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                      <Tag
-                        className="m-0"
-                        color={point.coordinateSource === "qr" ? "green" : "gold"}
-                      >
-                        {getPriwaPointSourceLabel(point)}
-                      </Tag>
-                      <Tag className="m-0">{getPriwaFundLabel(point)}</Tag>
-                      {point.syncStatus && point.syncStatus !== "synced" && (
-                        <Tag
-                          className="m-0"
-                          color={point.syncStatus === "failed" ? "red" : "blue"}
-                        >
-                          {point.syncStatus === "failed" ? "Fehler" : "Lokal"}
-                        </Tag>
-                      )}
-                      <span className="text-xs text-slate-500">{point.baumart}</span>
-                      <span className="text-xs text-slate-400">·</span>
-                      <span className="text-xs text-slate-500">{point.name}</span>
-                    </div>
-                    <div className="mt-1 truncate text-xs text-slate-500">
-                      {point.lat.toFixed(5)}, {point.lon.toFixed(5)} ·{" "}
-                      {point.datum}
-                    </div>
-                  </button>
-                  <div className="flex items-start gap-1">
-                    <Button
-                      aria-label="Punkt auf Karte zeigen"
-                      icon={<AimOutlined />}
-                      size="small"
-                      onClick={() => onZoomToPoint(point)}
-                    />
-                    <Button
-                      aria-label="Punkt bearbeiten"
-                      icon={<EditOutlined />}
-                      size="small"
-                      onClick={() => onEditPoint(point)}
-                    />
-                  </div>
-                </article>
-              );
+          <Table<IPriwaPoint>
+            size="small"
+            rowKey="id"
+            columns={columns}
+            dataSource={visiblePoints}
+            pagination={false}
+            scroll={{ x: "max-content" }}
+            rowClassName="cursor-pointer"
+            onRow={(point) => ({
+              onClick: () => onZoomToPoint(point),
             })}
-          </div>
+          />
         )}
       </div>
 

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPriwaCogLayers,
+  resolvePriwaCogUrl,
+} from "./createPriwaCogLayer";
+
+describe("resolvePriwaCogUrl", () => {
+  it("keeps absolute COG URLs unchanged", () => {
+    expect(resolvePriwaCogUrl("https://example.com/flight.tif")).toBe(
+      "https://example.com/flight.tif",
+    );
+  });
+
+  it("resolves storage-relative COG paths through the configured COG base URL", () => {
+    expect(resolvePriwaCogUrl("priwa/project-1/flight.tif")).toContain(
+      "/cogs/v1/priwa/project-1/flight.tif",
+    );
+  });
+
+  it("creates one map layer per PRIWA mosaic", () => {
+    expect(
+      createPriwaCogLayers([
+        { cogUrl: "priwa/project-1/flight-a.tif" },
+        { cogUrl: "priwa/project-1/flight-b.tif" },
+      ]),
+    ).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.ts
@@ -4,12 +4,24 @@ import { GeoTIFF } from "ol/source";
 import { Settings } from "../../config";
 import { COG_SOURCE_OPTIONS } from "../../utils/cogSourceOptions";
 
-export const createPriwaCogLayer = (cogPath: string) =>
+export interface IPriwaCogLayerSource {
+  cogUrl: string;
+}
+
+export const resolvePriwaCogUrl = (cogUrl: string) => {
+  try {
+    return new URL(cogUrl).toString();
+  } catch {
+    return Settings.COG_BASE_URL + cogUrl.replace(/^\/+/, "");
+  }
+};
+
+export const createPriwaCogLayer = (cog: IPriwaCogLayerSource) =>
   new TileLayerWebGL({
     source: new GeoTIFF({
       sources: [
         {
-          url: Settings.COG_BASE_URL + cogPath,
+          url: resolvePriwaCogUrl(cog.cogUrl),
           nodata: 0,
           bands: [1, 2, 3],
         },
@@ -23,3 +35,6 @@ export const createPriwaCogLayer = (cogPath: string) =>
     cacheSize: 4096,
     preload: 0,
   });
+
+export const createPriwaCogLayers = (cogs: IPriwaCogLayerSource[]) =>
+  cogs.map((cog) => createPriwaCogLayer(cog));

--- a/frontend/src/components/PriwaField/priwaPointCsv.test.ts
+++ b/frontend/src/components/PriwaField/priwaPointCsv.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { priwaPointsToCsv } from "./priwaPointCsv";
+import type { IPriwaPoint } from "./types";
+
+const basePoint: IPriwaPoint = {
+  id: "point-1",
+  baumnr: "B-17",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "ja",
+  bohrloch: "nein",
+  harz: "nein",
+  grueneNadelnAmBoden: "ja",
+  nadel: "fahlgrün/gelblich",
+  rinde: "bis25%",
+  kv: "0%",
+  name: "Sigi Huber",
+  datum: "2026-07-07",
+  kom: 'Nahe "Rückeweg"',
+  capturedAt: "2026-07-07T08:30:00.000Z",
+  coordinateSource: "qr",
+  gps: "ja",
+  isEstimatedLocation: false,
+  lat: 48.12345,
+  lon: 8.54321,
+};
+
+describe("priwaPointsToCsv", () => {
+  it("exports PRIWA points with all field columns and escaped text", () => {
+    expect(priwaPointsToCsv([basePoint]).split("\n")).toEqual([
+      '"id","baumnr","fund","baumart","bohrmehl","bohrloch","harz","gruene_nadeln_am_boden","nadelverfaerbung","rindenverlust","nadelverlust","name","datum","latitude","longitude","coordinate_source","is_estimated_location","captured_at","kommentar","sync_status"',
+      '"point-1","B-17","ja","Fichte","ja","nein","nein","ja","fahlgrün/gelblich","bis25%","0%","Sigi Huber","2026-07-07","48.12345","8.54321","qr","false","2026-07-07T08:30:00.000Z","Nahe ""Rückeweg""","synced"',
+    ]);
+  });
+});

--- a/frontend/src/components/PriwaField/priwaPointCsv.ts
+++ b/frontend/src/components/PriwaField/priwaPointCsv.ts
@@ -1,0 +1,82 @@
+import type { IPriwaPoint } from "./types";
+
+const csvHeaders = [
+  "id",
+  "baumnr",
+  "fund",
+  "baumart",
+  "bohrmehl",
+  "bohrloch",
+  "harz",
+  "gruene_nadeln_am_boden",
+  "nadelverfaerbung",
+  "rindenverlust",
+  "nadelverlust",
+  "name",
+  "datum",
+  "latitude",
+  "longitude",
+  "coordinate_source",
+  "is_estimated_location",
+  "captured_at",
+  "kommentar",
+  "sync_status",
+];
+
+const escapeCsvCell = (value: string | number | boolean | null | undefined) => {
+  const normalized = value === null || value === undefined ? "" : String(value);
+  return `"${normalized.replace(/"/g, '""')}"`;
+};
+
+export const priwaPointsToCsv = (points: IPriwaPoint[]) => {
+  const rows = points.map((point) => [
+    point.id,
+    point.baumnr,
+    point.fund,
+    point.baumart,
+    point.bm,
+    point.bohrloch,
+    point.harz,
+    point.grueneNadelnAmBoden,
+    point.nadel,
+    point.rinde,
+    point.kv,
+    point.name,
+    point.datum,
+    point.lat,
+    point.lon,
+    point.coordinateSource,
+    point.isEstimatedLocation ?? false,
+    point.capturedAt,
+    point.kom,
+    point.syncStatus ?? "synced",
+  ]);
+
+  return [
+    csvHeaders.map(escapeCsvCell).join(","),
+    ...rows.map((row) => row.map(escapeCsvCell).join(",")),
+  ].join("\n");
+};
+
+export const downloadPriwaPointsCsv = (
+  points: IPriwaPoint[],
+  projectName: string,
+) => {
+  const csv = priwaPointsToCsv(points);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  const date = new Date().toISOString().slice(0, 10);
+  const safeProjectName = projectName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  anchor.href = url;
+  anchor.download = `priwa-kaeferbaeume-${safeProjectName || "projekt"}-${date}.csv`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};

--- a/frontend/src/components/PriwaField/usePriwaMosaics.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaMosaics.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const supabaseMock = vi.hoisted(() => {
+  const rpc = vi.fn();
+  const from = vi.fn();
+  const datasetQuery = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    not: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  return {
+    datasetQuery,
+    from,
+    rpc,
+  };
+});
+
+vi.mock("../../hooks/useSupabase", () => ({
+  supabase: {
+    from: supabaseMock.from,
+    rpc: supabaseMock.rpc,
+  },
+}));
+
+describe("fetchPriwaMosaics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabaseMock.from.mockReturnValue(supabaseMock.datasetQuery);
+    supabaseMock.datasetQuery.select.mockReturnValue(supabaseMock.datasetQuery);
+    supabaseMock.datasetQuery.eq.mockReturnValue(supabaseMock.datasetQuery);
+    supabaseMock.datasetQuery.not.mockReturnValue(supabaseMock.datasetQuery);
+    supabaseMock.datasetQuery.order.mockReturnValue(supabaseMock.datasetQuery);
+    supabaseMock.datasetQuery.limit.mockResolvedValue({ data: [], error: null });
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          id: "dataset-1",
+          project_id: "project-1",
+          label: "Flug 2026-06-24",
+          cog_url: "uploads/project-1/flights/2026-06-24.tif",
+          capture_date: "2026-06-24",
+          created_at: "2026-06-25T08:30:00.000Z",
+          authors: ["PRIWA Wald"],
+          additional_information: "Sommerbefliegung",
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it("fetches latest public COG mosaics uploaded by PRIWA project members", async () => {
+    const { fetchPriwaMosaics } = await import("./usePriwaMosaics");
+
+    await expect(fetchPriwaMosaics("project-1")).resolves.toEqual([
+      {
+        id: "dataset-1",
+        projectId: "project-1",
+        label: "Flug 2026-06-24",
+        cogUrl: "uploads/project-1/flights/2026-06-24.tif",
+        captureDate: "2026-06-24",
+        createdAt: "2026-06-25T08:30:00.000Z",
+        authors: ["PRIWA Wald"],
+        additionalInformation: "Sommerbefliegung",
+      },
+    ]);
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "priwa_project_latest_flight_mosaics",
+      {
+        p_project_id: "project-1",
+        p_limit: 50,
+      },
+    );
+  });
+
+  it("falls back to public PRIWA-like drone COG datasets while the RPC is not deployed", async () => {
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: "PGRST202",
+        message:
+          "Could not find the function public.priwa_project_latest_flight_mosaics",
+      },
+    });
+    supabaseMock.datasetQuery.limit.mockResolvedValueOnce({
+      data: [
+        {
+          id: 41,
+          file_name: "latest-priwa-flight.tif",
+          cog_path: "uploads/latest-priwa-flight-cog.tif",
+          aquisition_year: 2026,
+          aquisition_month: 6,
+          aquisition_day: 21,
+          created_at: "2026-06-22T12:12:44.567Z",
+          authors: ["PRIMA-Wald"],
+          additional_information: "Fallback mosaic",
+        },
+        {
+          id: 42,
+          file_name: "other-flight.tif",
+          cog_path: "uploads/other-flight-cog.tif",
+          aquisition_year: 2026,
+          aquisition_month: 6,
+          aquisition_day: 20,
+          created_at: "2026-06-22T11:00:00.000Z",
+          authors: ["Different uploader"],
+          additional_information: null,
+        },
+      ],
+      error: null,
+    });
+    const { fetchPriwaMosaics } = await import("./usePriwaMosaics");
+
+    await expect(fetchPriwaMosaics("project-1")).resolves.toEqual([
+      {
+        id: "41",
+        projectId: "project-1",
+        label: "latest-priwa-flight.tif",
+        cogUrl: "uploads/latest-priwa-flight-cog.tif",
+        captureDate: "2026-06-21",
+        createdAt: "2026-06-22T12:12:44.567Z",
+        authors: ["PRIMA-Wald"],
+        additionalInformation: "Fallback mosaic",
+      },
+    ]);
+
+    expect(supabaseMock.from).toHaveBeenCalledWith(
+      "v2_full_dataset_view_public",
+    );
+    expect(supabaseMock.datasetQuery.eq).toHaveBeenCalledWith(
+      "platform",
+      "drone",
+    );
+    expect(supabaseMock.datasetQuery.eq).toHaveBeenCalledWith(
+      "is_cog_done",
+      true,
+    );
+    expect(supabaseMock.datasetQuery.not).toHaveBeenCalledWith(
+      "cog_path",
+      "is",
+      null,
+    );
+  });
+});

--- a/frontend/src/components/PriwaField/usePriwaMosaics.ts
+++ b/frontend/src/components/PriwaField/usePriwaMosaics.ts
@@ -1,0 +1,154 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { Settings } from "../../config";
+import { supabase } from "../../hooks/useSupabase";
+
+export interface IPriwaMosaic {
+  id: string;
+  projectId: string;
+  label: string;
+  cogUrl: string;
+  captureDate: string | null;
+  createdAt: string;
+  authors: string[];
+  additionalInformation: string | null;
+}
+
+interface IPriwaMosaicRow {
+  id: string;
+  project_id: string;
+  label: string;
+  cog_url: string;
+  capture_date: string | null;
+  created_at: string;
+  authors: string[] | null;
+  additional_information: string | null;
+}
+
+interface IPriwaDatasetMosaicRow {
+  id: number;
+  file_name: string | null;
+  cog_path: string | null;
+  aquisition_year: number | null;
+  aquisition_month: number | null;
+  aquisition_day: number | null;
+  created_at: string;
+  authors: string[] | null;
+  additional_information: string | null;
+}
+
+const PRIWA_MOSAIC_LIMIT = 50;
+const PRIWA_PREVIEW_AUTHOR_MARKERS = new Set([
+  "prima",
+  "prima-wald",
+  "priwa",
+  "unique land use",
+  "unique land use gmbh",
+]);
+
+const isMissingPriwaMosaicRpc = (error: unknown) => {
+  const candidate = error as { code?: string; message?: string } | null;
+  return (
+    candidate?.code === "PGRST202" ||
+    candidate?.message?.includes("priwa_project_latest_flight_mosaics") === true
+  );
+};
+
+const hasPriwaPreviewAuthor = (authors: string[] | null) =>
+  (authors ?? []).some((author) =>
+    PRIWA_PREVIEW_AUTHOR_MARKERS.has(author.trim().toLowerCase()),
+  );
+
+const dateFromAcquisitionParts = (row: IPriwaDatasetMosaicRow) => {
+  if (!row.aquisition_year || !row.aquisition_month || !row.aquisition_day) {
+    return null;
+  }
+
+  const date = new Date(
+    Date.UTC(row.aquisition_year, row.aquisition_month - 1, row.aquisition_day),
+  );
+  if (
+    date.getUTCFullYear() !== row.aquisition_year ||
+    date.getUTCMonth() !== row.aquisition_month - 1 ||
+    date.getUTCDate() !== row.aquisition_day
+  ) {
+    return null;
+  }
+
+  return date.toISOString().slice(0, 10);
+};
+
+const fetchPreviewFallbackMosaics = async (
+  projectId: string,
+): Promise<IPriwaMosaic[]> => {
+  const { data, error } = await supabase
+    .from(Settings.DATA_TABLE_PUBLIC)
+    .select(
+      "id, file_name, cog_path, aquisition_year, aquisition_month, aquisition_day, created_at, authors, additional_information",
+    )
+    .eq("platform", "drone")
+    .eq("is_cog_done", true)
+    .not("cog_path", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(300);
+
+  if (error) throw error;
+
+  return ((data ?? []) as IPriwaDatasetMosaicRow[])
+    .filter((row) => row.cog_path && hasPriwaPreviewAuthor(row.authors))
+    .slice(0, PRIWA_MOSAIC_LIMIT)
+    .map((row) => ({
+      id: String(row.id),
+      projectId,
+      label: row.file_name || `Dataset ${row.id}`,
+      cogUrl: row.cog_path as string,
+      captureDate: dateFromAcquisitionParts(row),
+      createdAt: row.created_at,
+      authors: row.authors ?? [],
+      additionalInformation: row.additional_information,
+    }));
+};
+
+export const priwaMosaicsQueryKey = (
+  projectId: string | null | undefined,
+) => ["priwa-project-mosaics", projectId];
+
+export const fetchPriwaMosaics = async (
+  projectId: string,
+): Promise<IPriwaMosaic[]> => {
+  const { data, error } = await supabase
+    .rpc("priwa_project_latest_flight_mosaics", {
+      p_project_id: projectId,
+      p_limit: PRIWA_MOSAIC_LIMIT,
+    });
+
+  if (error) {
+    if (isMissingPriwaMosaicRpc(error)) {
+      return fetchPreviewFallbackMosaics(projectId);
+    }
+
+    throw error;
+  }
+
+  return ((data ?? []) as IPriwaMosaicRow[]).map((row) => ({
+    id: row.id,
+    projectId: row.project_id,
+    label: row.label,
+    cogUrl: row.cog_url,
+    captureDate: row.capture_date,
+    createdAt: row.created_at,
+    authors: row.authors ?? [],
+    additionalInformation: row.additional_information,
+  }));
+};
+
+export function usePriwaMosaics(projectId: string | null | undefined) {
+  return useQuery({
+    queryKey: priwaMosaicsQueryKey(projectId),
+    enabled: !!projectId,
+    queryFn: () => fetchPriwaMosaics(projectId as string),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -1,6 +1,7 @@
 import PriwaFieldMap from "../components/PriwaField/PriwaFieldMap";
 import { usePriwaOfflineStatus } from "../components/PriwaField/usePriwaOfflineStatus";
 import { usePriwaOfflineKaeferbaeume } from "../components/PriwaField/usePriwaOfflineKaeferbaeume";
+import { usePriwaMosaics } from "../components/PriwaField/usePriwaMosaics";
 import { usePriwaProjectMemberships } from "../hooks/usePriwaProjectMemberships";
 import { Alert, Button, Result, Spin } from "antd";
 
@@ -24,6 +25,12 @@ export default function PriwaField() {
     syncSummary,
     syncNow,
   } = usePriwaOfflineKaeferbaeume(activeMembership?.projectId);
+  const {
+    data: mosaics = [],
+    error: mosaicsError,
+    isLoading: isLoadingMosaics,
+    isRefetching: isRefetchingMosaics,
+  } = usePriwaMosaics(activeMembership?.projectId);
 
   if (!isOnline && isLoadingMemberships) {
     return (
@@ -90,7 +97,11 @@ export default function PriwaField() {
       projectName={activeMembership.projectName}
       isLoadingPoints={isLoadingPoints || isRefetching}
       isSavingPoint={isSaving}
-      cogPath={null}
+      mosaics={mosaics}
+      isCogLoading={isLoadingMosaics || isRefetchingMosaics}
+      cogErrorMessage={
+        mosaicsError instanceof Error ? mosaicsError.message : null
+      }
       errorMessage={pointsError instanceof Error ? pointsError.message : null}
       onAddPoint={createPoint}
       onUpdatePoint={updatePoint}

--- a/supabase/migrations/20260707120000_add_priwa_project_mosaics.sql
+++ b/supabase/migrations/20260707120000_add_priwa_project_mosaics.sql
@@ -1,0 +1,82 @@
+create or replace function public.priwa_project_latest_flight_mosaics(
+    p_project_id uuid,
+    p_limit integer default 50
+)
+returns table (
+    id text,
+    project_id uuid,
+    label text,
+    cog_url text,
+    capture_date date,
+    created_at timestamp with time zone,
+    authors text[],
+    additional_information text
+)
+language sql
+stable
+-- Required to test uploader project membership; execution is still limited to
+-- authenticated callers below and rows are restricted to public COG datasets.
+security definer
+set search_path = public
+as $$
+    select
+        dataset.id::text as id,
+        p_project_id as project_id,
+        coalesce(nullif(dataset.file_name, ''), 'Dataset ' || dataset.id::text) as label,
+        dataset.cog_path as cog_url,
+        case
+            when dataset.aquisition_year between 1981 and 2098
+                and dataset.aquisition_month between 1 and 12
+                and dataset.aquisition_day between 1 and 31
+                and dataset.aquisition_day <= extract(
+                    day from (
+                        date_trunc(
+                            'month',
+                            make_date(
+                                dataset.aquisition_year::integer,
+                                dataset.aquisition_month::integer,
+                                1
+                            )
+                        ) + interval '1 month - 1 day'
+                    )
+                )
+            then make_date(
+                dataset.aquisition_year::integer,
+                dataset.aquisition_month::integer,
+                dataset.aquisition_day::integer
+            )
+            else null
+        end as capture_date,
+        dataset.created_at,
+        dataset.authors,
+        dataset.additional_information
+    from public.v2_full_dataset_view_public dataset
+    where exists (
+            select 1
+            from public.priwa_project_memberships requester_membership
+            where requester_membership.project_id = p_project_id
+              and requester_membership.user_id = (select auth.uid())
+        )
+      and exists (
+            select 1
+            from public.priwa_project_memberships uploader_membership
+            where uploader_membership.project_id = p_project_id
+              and uploader_membership.user_id = dataset.user_id
+        )
+      and dataset.platform::text = 'drone'
+      and dataset.is_cog_done is true
+      and dataset.cog_path is not null
+    order by
+        capture_date desc nulls last,
+        dataset.created_at desc,
+        dataset.id desc
+    limit least(greatest(coalesce(p_limit, 50), 1), 100);
+$$;
+
+comment on function public.priwa_project_latest_flight_mosaics(uuid, integer)
+is 'Returns latest public COG drone datasets uploaded by members of a PRIWA project for authenticated members of that same project.';
+
+revoke all on function public.priwa_project_latest_flight_mosaics(uuid, integer) from public;
+revoke all on function public.priwa_project_latest_flight_mosaics(uuid, integer) from anon;
+grant execute on function public.priwa_project_latest_flight_mosaics(uuid, integer) to authenticated;
+grant execute on function public.priwa_project_latest_flight_mosaics(uuid, integer) to service_role;


### PR DESCRIPTION
## Summary

- Add a PRIWA project mosaic RPC that returns completed public drone COGs uploaded by members of the same PRIWA project, including capture date, upload date, authors, additional info, dataset ID, and COG path.
- Load those mosaics into the PRIWA field map, enabled by default, newest capture date on top.
- Replace the single drone-layer switch with a per-flight layer manager in the existing layer panel, including metadata and visibility toggles.
- Replace the compact point list with a wider table view and add CSV export for all PRIWA Käferbäume.

## Why

PRIWA Wald users need uploaded COG flights visible directly on the field map, but overlapping imagery also needs enough metadata and visibility control to understand which dataset is being inspected.

## Validation

- `npm --prefix frontend test -- --run src/components/PriwaField`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- `git diff --check`
- DB reset/seed applied the PRIWA fixture and amended migration locally; the recovery-email helper failed because the local API service was not running after the full QA Docker bootstrap was interrupted by a slow base-image pull.
- Built-in browser smoke on local Supabase + Vite: signed in as seeded PRIWA QA user, opened `/priwa-field`, verified `2 von 2 Befliegungen sichtbar`, capture/upload dates, dataset IDs, details, both switches enabled by default, and per-flight toggle changing the count to `1 von 2`.

## Risk

- QA fixture COG paths do not have real TIFF objects in the narrowed local browser setup, so OpenLayers logs expected COG fetch errors there. Production behavior depends on returned COG paths being reachable through the configured COG base URL.
