### PR TITLE
perf(audit): compute phenology probability in Postgres instead of the browser

### DIFF
--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -21,7 +21,6 @@ import {
 	Drawer,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { useQuery } from "@tanstack/react-query";
 import {
 	SearchOutlined,
 	FilterOutlined,
@@ -42,7 +41,6 @@ import { usePendingCorrections } from "../hooks/usePendingCorrections";
 import { palette } from "../theme/palette";
 import { getBiomeEmoji, getBiomeTagColor, truncateBiomeLabel } from "../utils/biomeDisplay";
 import { useDatasetLogs, useProcessingOverview, ProcessingOverviewRow, ProcessingStatus } from "../hooks/useProcessingOverview";
-import { getAcquisitionPeriod } from "../utils/phenologyUtils";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { isDatasetReadyForAudit } from "../utils/processingSteps";
@@ -119,25 +117,6 @@ const compareNullableNumbers = (a: number | null | undefined, b: number | null |
 	if (aNum === null) return 1; // nulls last
 	if (bNum === null) return -1;
 	return aNum - bNum;
-};
-
-const getPhenologyProbability = (dataset: IDataset, curve: number[] | null | undefined): number | null => {
-	if (!curve || curve.length === 0) return null;
-
-	const year = parseInt(dataset.aquisition_year, 10);
-	if (isNaN(year)) return null;
-
-	const parsedMonth = parseInt(dataset.aquisition_month, 10);
-	const parsedDay = parseInt(dataset.aquisition_day, 10);
-	const month = !isNaN(parsedMonth) && parsedMonth >= 1 && parsedMonth <= 12 ? parsedMonth : undefined;
-	const day = !isNaN(parsedDay) && parsedDay >= 1 && parsedDay <= 31 ? parsedDay : undefined;
-
-	const period = getAcquisitionPeriod(year, month, day);
-	const index = Math.max(0, Math.min(curve.length - 1, period.centerDay - 1));
-	const value = curve[index];
-	if (typeof value !== "number" || Number.isNaN(value)) return null;
-
-	return Math.max(0, Math.min(1, value / 255));
 };
 
 const getAcquisitionMonthIndex = (dataset: IDataset): number | null => {
@@ -491,58 +470,18 @@ function DatasetAuditInner() {
 		referenceDatasetIds,
 	]);
 
-	const pendingDatasetIds = useMemo(() => {
-		if (activeTab !== "pending") return [];
-		return filteredDatasets.map((dataset) => dataset.id);
-	}, [activeTab, filteredDatasets]);
-
-	const { data: pendingPhenologyProbabilityMap = new Map<number, number | null>(), isLoading: isPendingPhenologyLoading } = useQuery({
-		queryKey: ["audit-pending-phenology-probabilities", pendingDatasetIds],
-		enabled: activeTab === "pending" && pendingDatasetIds.length > 0,
-		queryFn: async () => {
-			const datasetById = new Map(filteredDatasets.map((dataset) => [dataset.id, dataset]));
-			const probabilities = new Map<number, number | null>();
-			pendingDatasetIds.forEach((id) => probabilities.set(id, null));
-
-			const chunkSize = 500;
-			for (let i = 0; i < pendingDatasetIds.length; i += chunkSize) {
-				const chunk = pendingDatasetIds.slice(i, i + chunkSize);
-				const { data, error } = await supabase
-					.from("v2_metadata")
-					.select("dataset_id, metadata")
-					.in("dataset_id", chunk);
-
-				if (error) throw error;
-
-				for (const row of data || []) {
-					const datasetId = (row as { dataset_id?: number }).dataset_id;
-					if (typeof datasetId !== "number") continue;
-
-					const curve = (row as { metadata?: { phenology?: { phenology_curve?: number[] } } }).metadata?.phenology?.phenology_curve;
-					const dataset = datasetById.get(datasetId);
-					if (!dataset) continue;
-
-					probabilities.set(datasetId, getPhenologyProbability(dataset, curve));
-				}
-			}
-
-			return probabilities;
-		},
-		staleTime: 5 * 60 * 1000,
-	});
-
+	// Phenology probability is computed server-side and arrives on each dataset
+	// (v2_full_dataset_view.phenology_probability), so no extra fetch is needed.
 	const sortedFilteredDatasets = useMemo(() => {
 		if (activeTab !== "pending") return filteredDatasets;
 
 		return [...filteredDatasets].sort((a, b) => {
-			const aProb = pendingPhenologyProbabilityMap.get(a.id);
-			const bProb = pendingPhenologyProbabilityMap.get(b.id);
-			const aValue = typeof aProb === "number" ? aProb : -1;
-			const bValue = typeof bProb === "number" ? bProb : -1;
+			const aValue = typeof a.phenology_probability === "number" ? a.phenology_probability : -1;
+			const bValue = typeof b.phenology_probability === "number" ? b.phenology_probability : -1;
 			if (bValue !== aValue) return bValue - aValue;
 			return b.id - a.id;
 		});
-	}, [activeTab, filteredDatasets, pendingPhenologyProbabilityMap]);
+	}, [activeTab, filteredDatasets]);
 
 	// Update navigation context with filtered dataset IDs (sorted by ID descending to match table order)
 	const filteredIds = useMemo(() => {
@@ -807,7 +746,7 @@ function DatasetAuditInner() {
 		title: "Phenology Prob.",
 		key: "phenology_probability",
 		render: (_: unknown, record: IDataset) => {
-			const probability = pendingPhenologyProbabilityMap.get(record.id);
+			const probability = record.phenology_probability;
 			if (typeof probability !== "number") {
 				return <Tag color="default">—</Tag>;
 			}
@@ -817,10 +756,8 @@ function DatasetAuditInner() {
 			return <Tag color={color}>{pct}%</Tag>;
 		},
 		sorter: (a: IDataset, b: IDataset) => {
-			const aProb = pendingPhenologyProbabilityMap.get(a.id);
-			const bProb = pendingPhenologyProbabilityMap.get(b.id);
-			const aValue = typeof aProb === "number" ? aProb : -1;
-			const bValue = typeof bProb === "number" ? bProb : -1;
+			const aValue = typeof a.phenology_probability === "number" ? a.phenology_probability : -1;
+			const bValue = typeof b.phenology_probability === "number" ? b.phenology_probability : -1;
 			return aValue - bValue;
 		},
 		width: 130,
@@ -1552,7 +1489,7 @@ function DatasetAuditInner() {
 						dataSource={sortedFilteredDatasets}
 						columns={columns}
 						rowKey="id"
-						loading={isDatasetLoading || isAuditsLoading || isFlaggedLoading || isCorrectionsLoading || isPendingPhenologyLoading}
+						loading={isDatasetLoading || isAuditsLoading || isFlaggedLoading || isCorrectionsLoading}
 						pagination={{
 							pageSize: 20,
 							showSizeChanger: true,

--- a/frontend/src/types/dataset.ts
+++ b/frontend/src/types/dataset.ts
@@ -92,6 +92,10 @@ export interface IDataset {
   has_ml_tiles: boolean | null;
   ml_tiles_completed_at?: string | null;
 
+  // Phenology match probability at the acquisition date, in [0, 1].
+  // Computed server-side in v2_full_dataset_view (see phenology_probability_at).
+  phenology_probability?: number | null;
+
   // Audit status fields (from database view)
   final_assessment: "ready" | "fixable_issues" | "no_issues" | "exclude_completely" | null;
   deadwood_quality: "great" | "sentinel_ok" | "bad" | null;

--- a/supabase/migrations/20260707200000_add_phenology_probability_to_dataset_view.sql
+++ b/supabase/migrations/20260707200000_add_phenology_probability_to_dataset_view.sql
@@ -21,17 +21,20 @@ CREATE OR REPLACE FUNCTION public.phenology_probability_at(
 LANGUAGE sql
 IMMUTABLE
 AS $$
+  -- Ordered CASE branches: Postgres does not guarantee OR short-circuits, so the
+  -- type check must gate jsonb_array_length, and the year check must gate make_date.
   SELECT CASE
-    WHEN curve IS NULL
-      OR jsonb_typeof(curve) <> 'array'
-      OR jsonb_array_length(curve) = 0
-      OR y IS NULL OR y < 1 OR y > 9999
-      THEN NULL::real
+    WHEN curve IS NULL THEN NULL::real
+    WHEN jsonb_typeof(curve) <> 'array' THEN NULL::real
+    WHEN jsonb_array_length(curve) = 0 THEN NULL::real
+    WHEN y IS NULL OR y < 1 OR y > 9999 THEN NULL::real
     ELSE GREATEST(0::real, LEAST(1::real,
       NULLIF(curve ->> LEAST(GREATEST(center_day - 1, 0), jsonb_array_length(curve) - 1), '')::real / 255.0))
   END
   FROM (
     SELECT CASE
+      -- Invalid year: no valid day-of-year (outer CASE returns NULL for these).
+      WHEN y IS NULL OR y < 1 OR y > 9999 THEN 183
       -- Full date known: exact day-of-year (day capped to the month length).
       WHEN m BETWEEN 1 AND 12 AND d BETWEEN 1 AND 31
         THEN EXTRACT(DOY FROM make_date(y::int, m::int, 1))::int + LEAST(d::int, dim) - 1
@@ -43,7 +46,7 @@ AS $$
     END AS center_day
     FROM (
       SELECT CASE
-        WHEN m BETWEEN 1 AND 12
+        WHEN y BETWEEN 1 AND 9999 AND m BETWEEN 1 AND 12
           THEN EXTRACT(DAY FROM (make_date(y::int, m::int, 1) + interval '1 month - 1 day'))::int
         ELSE 30
       END AS dim
@@ -59,7 +62,13 @@ GRANT EXECUTE ON FUNCTION public.phenology_probability_at(jsonb, smallint, small
 -- so dependents and grants are preserved. `v2_full_dataset_view_public` selects
 -- explicit base columns and does NOT reference the new column, so the public map
 -- path is unaffected and pays none of the compute cost.
-CREATE OR REPLACE VIEW public.v2_full_dataset_view AS
+--
+-- security_invoker=true MUST be restated: this view is RLS-sensitive (readable by
+-- anon/authenticated over RLS-protected base tables) and a prior migration set it.
+-- CREATE OR REPLACE resets view options, so omitting it would silently revert the
+-- view to a security-definer view and bypass RLS.
+CREATE OR REPLACE VIEW public.v2_full_dataset_view
+WITH (security_invoker = true) AS
  WITH ds AS (
          SELECT v2_datasets.id,
             v2_datasets.user_id,

--- a/supabase/migrations/20260707200000_add_phenology_probability_to_dataset_view.sql
+++ b/supabase/migrations/20260707200000_add_phenology_probability_to_dataset_view.sql
@@ -1,0 +1,210 @@
+-- Move the "phenology probability" computation from the browser into Postgres.
+--
+-- Previously the audit page downloaded the full `metadata` JSONB for up to 500
+-- datasets just to read one value out of the 366-element `phenology_curve` per
+-- dataset (a multi-MB response behind a 3.6k-char URL that intermittently 502'd
+-- at the nginx->kong hop). This computes the same value server-side and exposes
+-- it as `v2_full_dataset_view.phenology_probability`, so it rides along with the
+-- dataset list the audit page already fetches (`select *`) — no extra request.
+--
+-- The logic mirrors the former client-side getPhenologyProbability():
+--   centerDay = day-of-year of the acquisition date
+--               (mid-month if the day is unknown, day 183 if only the year is),
+--   probability = clamp(curve[centerDay - 1] / 255, 0, 1).
+
+CREATE OR REPLACE FUNCTION public.phenology_probability_at(
+  curve jsonb,
+  y smallint,
+  m smallint,
+  d smallint
+) RETURNS real
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN curve IS NULL
+      OR jsonb_typeof(curve) <> 'array'
+      OR jsonb_array_length(curve) = 0
+      OR y IS NULL OR y < 1 OR y > 9999
+      THEN NULL::real
+    ELSE GREATEST(0::real, LEAST(1::real,
+      NULLIF(curve ->> LEAST(GREATEST(center_day - 1, 0), jsonb_array_length(curve) - 1), '')::real / 255.0))
+  END
+  FROM (
+    SELECT CASE
+      -- Full date known: exact day-of-year (day capped to the month length).
+      WHEN m BETWEEN 1 AND 12 AND d BETWEEN 1 AND 31
+        THEN EXTRACT(DOY FROM make_date(y::int, m::int, 1))::int + LEAST(d::int, dim) - 1
+      -- Month known, day unknown: middle of the month.
+      WHEN m BETWEEN 1 AND 12
+        THEN (2 * EXTRACT(DOY FROM make_date(y::int, m::int, 1))::int + dim - 1) / 2
+      -- Only the year is known: approximate middle of the year.
+      ELSE 183
+    END AS center_day
+    FROM (
+      SELECT CASE
+        WHEN m BETWEEN 1 AND 12
+          THEN EXTRACT(DAY FROM (make_date(y::int, m::int, 1) + interval '1 month - 1 day'))::int
+        ELSE 30
+      END AS dim
+    ) days_in_month
+  ) center
+$$;
+
+GRANT EXECUTE ON FUNCTION public.phenology_probability_at(jsonb, smallint, smallint, smallint)
+  TO anon, authenticated, service_role;
+
+-- Re-create the view with the new column appended at the end. CREATE OR REPLACE
+-- keeps all existing columns/order intact and only adds `phenology_probability`,
+-- so dependents and grants are preserved. `v2_full_dataset_view_public` selects
+-- explicit base columns and does NOT reference the new column, so the public map
+-- path is unaffected and pays none of the compute cost.
+CREATE OR REPLACE VIEW public.v2_full_dataset_view AS
+ WITH ds AS (
+         SELECT v2_datasets.id,
+            v2_datasets.user_id,
+            v2_datasets.created_at,
+            v2_datasets.file_name,
+            v2_datasets.license,
+            v2_datasets.platform,
+            v2_datasets.project_id,
+            v2_datasets.authors,
+            v2_datasets.aquisition_year,
+            v2_datasets.aquisition_month,
+            v2_datasets.aquisition_day,
+            v2_datasets.additional_information,
+            v2_datasets.data_access,
+            v2_datasets.citation_doi,
+            v2_datasets.archived
+           FROM v2_datasets
+          WHERE (v2_datasets.data_access <> 'private'::access OR auth.uid() = v2_datasets.user_id OR can_view_all_private_data()) AND (v2_datasets.archived = false OR auth.uid() = v2_datasets.user_id)
+        ), ortho AS (
+         SELECT v2_orthos.dataset_id,
+            v2_orthos.ortho_file_name,
+            v2_orthos.ortho_file_size,
+            v2_orthos.bbox,
+            v2_orthos.sha256,
+            v2_orthos.ortho_upload_runtime
+           FROM v2_orthos
+        ), status AS (
+         SELECT v2_statuses.dataset_id,
+            v2_statuses.current_status,
+            v2_statuses.is_upload_done,
+            v2_statuses.is_ortho_done,
+            v2_statuses.is_cog_done,
+            v2_statuses.is_thumbnail_done,
+            v2_statuses.is_deadwood_done,
+            v2_statuses.is_forest_cover_done,
+            v2_statuses.is_metadata_done,
+            v2_statuses.is_odm_done,
+            (EXISTS ( SELECT 1
+                   FROM dataset_audit da
+                  WHERE da.dataset_id = v2_statuses.dataset_id)) AS is_audited,
+            v2_statuses.has_error,
+            v2_statuses.error_message,
+            v2_statuses.has_ml_tiles,
+            v2_statuses.ml_tiles_completed_at,
+            v2_statuses.is_combined_model_done,
+            v2_statuses.is_aoi_done,
+            v2_statuses.is_aoi_required
+           FROM v2_statuses
+        ), extra AS (
+         SELECT ds_1.id AS dataset_id,
+            cog.cog_file_name,
+            cog.cog_path,
+            cog.cog_file_size,
+            thumb.thumbnail_file_name,
+            thumb.thumbnail_path,
+            meta.metadata ->> 'gadm'::text AS admin_metadata,
+            meta.metadata ->> 'biome'::text AS biome_metadata,
+            public.phenology_probability_at(meta.metadata -> 'phenology'::text -> 'phenology_curve'::text, ds_1.aquisition_year, ds_1.aquisition_month, ds_1.aquisition_day) AS phenology_probability
+           FROM v2_datasets ds_1
+             LEFT JOIN v2_cogs cog ON cog.dataset_id = ds_1.id
+             LEFT JOIN v2_thumbnails thumb ON thumb.dataset_id = ds_1.id
+             LEFT JOIN v2_metadata meta ON meta.dataset_id = ds_1.id
+          WHERE (ds_1.data_access <> 'private'::access OR auth.uid() = ds_1.user_id OR can_view_all_private_data()) AND (ds_1.archived = false OR auth.uid() = ds_1.user_id)
+        ), label_info AS (
+         SELECT dataset.id AS dataset_id,
+            (EXISTS ( SELECT 1
+                   FROM v2_labels
+                  WHERE v2_labels.dataset_id = dataset.id AND v2_labels.label_source = 'visual_interpretation'::"LabelSource" AND v2_labels.label_data = 'deadwood'::"LabelData")) AS has_labels,
+            (EXISTS ( SELECT 1
+                   FROM v2_labels
+                  WHERE v2_labels.dataset_id = dataset.id AND v2_labels.label_source = 'model_prediction'::"LabelSource" AND v2_labels.label_data = 'deadwood'::"LabelData")) AS has_deadwood_prediction
+           FROM v2_datasets dataset
+          WHERE (dataset.data_access <> 'private'::access OR auth.uid() = dataset.user_id OR can_view_all_private_data()) AND (dataset.archived = false OR auth.uid() = dataset.user_id)
+        ), freidata_doi AS (
+         SELECT jt.dataset_id,
+            dp.doi AS freidata_doi
+           FROM jt_data_publication_datasets jt
+             JOIN data_publication dp ON dp.id = jt.publication_id
+          WHERE dp.doi IS NOT NULL
+        ), correction_stats AS (
+         SELECT gc.dataset_id,
+            count(*) FILTER (WHERE gc.review_status = 'pending'::text) AS pending_corrections_count,
+            count(*) FILTER (WHERE gc.review_status = 'approved'::text) AS approved_corrections_count,
+            count(*) FILTER (WHERE gc.review_status = 'rejected'::text) AS rejected_corrections_count,
+            count(*) AS total_corrections_count
+           FROM v2_geometry_corrections gc
+          GROUP BY gc.dataset_id
+        )
+ SELECT ds.id,
+    ds.user_id,
+    ds.created_at,
+    ds.file_name,
+    ds.license,
+    ds.platform,
+    ds.project_id,
+    ds.authors,
+    ds.aquisition_year,
+    ds.aquisition_month,
+    ds.aquisition_day,
+    ds.additional_information,
+    ds.data_access,
+    ds.citation_doi,
+    ds.archived,
+    ortho.ortho_file_name,
+    ortho.ortho_file_size,
+    ortho.bbox,
+    ortho.sha256,
+    status.current_status,
+    status.is_upload_done,
+    status.is_ortho_done,
+    status.is_cog_done,
+    status.is_thumbnail_done,
+    status.is_deadwood_done,
+    status.is_forest_cover_done,
+    status.is_metadata_done,
+    status.is_odm_done,
+    status.is_audited,
+    status.has_error,
+    status.error_message,
+    extra.cog_file_name,
+    extra.cog_path,
+    extra.cog_file_size,
+    extra.thumbnail_file_name,
+    extra.thumbnail_path,
+    extra.admin_metadata::jsonb ->> 'admin_level_1'::text AS admin_level_1,
+    extra.admin_metadata::jsonb ->> 'admin_level_2'::text AS admin_level_2,
+    extra.admin_metadata::jsonb ->> 'admin_level_3'::text AS admin_level_3,
+    extra.biome_metadata::jsonb ->> 'biome_name'::text AS biome_name,
+    label_info.has_labels,
+    label_info.has_deadwood_prediction,
+    freidata_doi.freidata_doi,
+    status.has_ml_tiles,
+    status.ml_tiles_completed_at,
+    COALESCE(correction_stats.pending_corrections_count, 0::bigint) AS pending_corrections_count,
+    COALESCE(correction_stats.approved_corrections_count, 0::bigint) AS approved_corrections_count,
+    COALESCE(correction_stats.rejected_corrections_count, 0::bigint) AS rejected_corrections_count,
+    COALESCE(correction_stats.total_corrections_count, 0::bigint) AS total_corrections_count,
+    status.is_combined_model_done,
+    status.is_aoi_done,
+    status.is_aoi_required,
+    extra.phenology_probability
+   FROM ds
+     LEFT JOIN ortho ON ortho.dataset_id = ds.id
+     LEFT JOIN status ON status.dataset_id = ds.id
+     LEFT JOIN extra ON extra.dataset_id = ds.id
+     LEFT JOIN label_info ON label_info.dataset_id = ds.id
+     LEFT JOIN freidata_doi ON freidata_doi.dataset_id = ds.id
+     LEFT JOIN correction_stats ON correction_stats.dataset_id = ds.id;


### PR DESCRIPTION
## Problem

The audit page's **pending** tab sorts by a phenology match probability. To compute it, the browser fetched the full `metadata` JSONB for up to **500 datasets in one request** just to read a single value out of each 366-element `phenology_curve`.

That request — a multi-MB response behind a 3,662-char URL — **intermittently returns `502` at the nginx→kong hop** (worse under low traffic, where idle keepalive connections go stale). And because the table's loading spinner was gated on this query (`isPendingPhenologyLoading`), a slow/failed fetch **froze the whole grid**: the real audit data was ready in ~4s, but the table kept spinning while the query retried with exponential backoff (observed 45s+ of "loading").

## Fix

Move the computation into Postgres so the value rides along with the dataset list the page already loads (`select *` on `v2_full_dataset_view`) — no extra request, no giant URL, no 502.

- **`phenology_probability_at(curve, y, m, d)`** — an `IMMUTABLE` SQL function reproducing the former client logic: day-of-year → `curve[centerDay-1] / 255`, with the mid-month / mid-year fallbacks.
- **`v2_full_dataset_view.phenology_probability`** — new trailing column computed via the `v2_metadata` join already in the view (`CREATE OR REPLACE`, additive, dependents preserved). `v2_full_dataset_view_public` selects explicit columns and does **not** reference it, so the public/homepage path is unchanged and pays no compute cost.
- **Frontend** now reads `dataset.phenology_probability`, deleting the separate `v2_metadata` fetch, the client-side compute helper, and the loading-gate that froze the table.

## Verification

- Server-side computation matches the old client values exactly (spot-checked datasets 5/6/8/10 → `0.6784 / 0.0706 / 0.9961 / 0.0078`).
- Runs for all ~9k datasets in **~120ms**.
- `tsc --noEmit` passes; no dangling references.

After merge, confirm via:
\`\`\`sql
SELECT id, round(phenology_probability::numeric,4) FROM v2_full_dataset_view WHERE id IN (5,6,8,10) ORDER BY id;
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)