### PR TITLE
Add Product Download email button to /deadtrees map panel

### DIFF
--- a/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
+++ b/frontend/src/components/DeadwoodMap/LayerControlPanel.tsx
@@ -14,6 +14,7 @@ import {
   FlagOutlined,
   LoginOutlined,
   InfoCircleOutlined,
+  MailOutlined,
 } from "@ant-design/icons";
 import { mapColors } from "../../theme/mapColors";
 import { palette } from "../../theme/palette";
@@ -99,6 +100,12 @@ const LayerControlPanel = ({
   const actionButtonSize = "small";
   const controlButtonClass = "";
   const shouldShowLegend = showLegend;
+
+  const productDownloadMailto = `mailto:info@deadtrees.earth?subject=${encodeURIComponent(
+    "Product Download Request",
+  )}&body=${encodeURIComponent(
+    "Hi deadtrees.earth team,\n\nI would like to download the satellite product. To process my request, please let us know:\n\nPlanned use of the product:\n(Please describe how you plan to use the product.)\n\nName and affiliation:\n\nThank you!\n",
+  )}`;
 
   return (
     <div
@@ -236,6 +243,27 @@ const LayerControlPanel = ({
           </div>
         </div>
       )}
+
+      {/* Product Download Section */}
+      <Divider className="my-2.5" />
+      <div className="mb-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500">
+        Product Download
+      </div>
+      <Tooltip title="The satellite product is publicly available. Email us and let us know how you plan to use it to download the product.">
+        <Button
+          size={actionButtonSize}
+          icon={<MailOutlined />}
+          href={productDownloadMailto}
+          block
+          className={controlButtonClass}
+          style={{
+            borderColor: palette.primary[500],
+            color: palette.primary[500],
+          }}
+        >
+          Download Product
+        </Button>
+      </Tooltip>
 
       {/* Polygon Stats Section */}
       {onPolygonStatsClick && (


### PR DESCRIPTION
## What

Adds a **Product Download** section to the layer control panel on the `/deadtrees` satellite map page, with a **Download Product** button.

The button is a `mailto:` link to `info@deadtrees.earth` with a prefilled subject and body that asks the requester for:
- their planned use of the product
- their name and affiliation

The button's hover tooltip clarifies that the satellite product is publicly available.

## Why

Users viewing the satellite (Sentinel) product had no way to obtain it. This gives a lightweight request flow while capturing how the data will be used.

## Screenshot / test

Visible in the right-side control panel at `/deadtrees` (below "Model Info"). Verified locally via `test live` (frontend `localhost:5173`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)