### PR TITLE
fix(processor): reproject COG fallback to EPSG:3857 instead of relabeling

### DIFF
--- a/processor/src/cog/cog.py
+++ b/processor/src/cog/cog.py
@@ -11,7 +11,6 @@ def _build_cog_translate_command(
 	cog_target_path: str,
 	num_bands: int,
 	alpha_band_index: int | None = None,
-	force_epsg_3857: bool = False,
 ):
 	"""Build gdal_translate command with a safe strategy per band-count."""
 	if num_bands < 1:
@@ -97,9 +96,6 @@ def _build_cog_translate_command(
 	if add_alpha:
 		cmd_translate.extend(['-co', 'ALPHA=YES'])
 
-	if force_epsg_3857:
-		cmd_translate.extend(['-a_srs', 'EPSG:3857'])
-
 	return cmd_translate
 
 
@@ -115,6 +111,63 @@ def _run_gdal_translate(command: list[str], token: str | None = None, attempt: s
 		logger.error(
 			(
 				f'gdal_translate failed ({attempt}) exit_code={e.returncode}\n'
+				f'command: {" ".join(command)}\n'
+				f'stdout:\n{e.stdout or ""}\n'
+				f'stderr:\n{e.stderr or ""}'
+			),
+			extra={'token': token},
+		)
+		raise
+
+
+def _reproject_to_epsg3857(src_path: str, dst_path: str, token: str | None = None) -> None:
+	"""Reproject a raster into EPSG:3857 with gdalwarp.
+
+	This is the fallback used when the primary COG translate (which relies on the
+	COG driver's GoogleMapsCompatible reprojection) fails. It performs a REAL
+	reprojection of the pixel grid.
+
+	It must never be replaced by ``gdal_translate -a_srs EPSG:3857``: ``-a_srs``
+	only overrides the CRS *label* without touching the pixel coordinates, so a
+	source in UTM (or any other projected CRS) keeps its metre easting/northing
+	while being tagged as Web Mercator. The result lands thousands of kilometres
+	from the true location (see the 2026-02 batch of mis-georeferenced COGs).
+
+	If the source has no usable CRS, gdalwarp fails here — which is the correct
+	behaviour: we would rather fail loudly than publish a mislocated COG.
+	"""
+	command = [
+		'gdalwarp',
+		'-t_srs',
+		'EPSG:3857',
+		'-of',
+		'GTiff',
+		'-co',
+		'BIGTIFF=YES',
+		'-co',
+		'TILED=YES',
+		'-r',
+		'bilinear',
+		'-multi',
+		'--config',
+		'GDAL_NUM_THREADS',
+		'ALL_CPUS',
+		'--config',
+		'GDAL_CACHEMAX',
+		'32768',
+		src_path,
+		dst_path,
+	]
+	try:
+		result = subprocess.run(command, check=True, capture_output=True, text=True)
+		if result.stdout:
+			logger.info(f'gdalwarp stdout (reproject-3857):\n{result.stdout}', extra={'token': token})
+		if result.stderr:
+			logger.info(f'gdalwarp stderr (reproject-3857):\n{result.stderr}', extra={'token': token})
+	except subprocess.CalledProcessError as e:
+		logger.error(
+			(
+				f'gdalwarp reproject to EPSG:3857 failed exit_code={e.returncode}\n'
 				f'command: {" ".join(command)}\n'
 				f'stdout:\n{e.stdout or ""}\n'
 				f'stderr:\n{e.stderr or ""}'
@@ -188,7 +241,8 @@ def calculate_cog(
 		alpha_band_index=alpha_band_index,
 	)
 
-	# Try to process with original CRS first
+	# Try to process with original CRS first. The COG driver reprojects the
+	# source into the GoogleMapsCompatible (EPSG:3857) tiling scheme itself.
 	try:
 		logger.info(
 			f'Running COG processing with original CRS (bands={num_bands})',
@@ -196,19 +250,30 @@ def calculate_cog(
 		)
 		_run_gdal_translate(cmd_translate, token=token, attempt='original-crs')
 	except subprocess.CalledProcessError:
-		logger.info('Retrying COG processing with EPSG:3857', extra={'token': token})
+		# Fallback: explicitly reproject the source into EPSG:3857 with gdalwarp,
+		# then build the COG from the already-reprojected raster.
+		#
+		# NOTE: the fallback MUST reproject, not relabel. A previous version added
+		# `gdal_translate -a_srs EPSG:3857`, which only overwrites the CRS tag and
+		# leaves the projected-metre coordinates untouched, producing COGs that are
+		# tagged Web Mercator but positioned at their raw UTM coordinates (off by
+		# thousands of km). See _reproject_to_epsg3857.
+		logger.info('Primary COG failed; reprojecting source to EPSG:3857 and retrying', extra={'token': token})
+		reprojected_path = str(Path(cog_target_path).with_name(Path(cog_target_path).stem + '_3857_src.tif'))
 		try:
-			cmd_translate_epsg = _build_cog_translate_command(
-				tiff_file_path=tiff_file_path,
+			_reproject_to_epsg3857(tiff_file_path, reprojected_path, token=token)
+			cmd_translate_reprojected = _build_cog_translate_command(
+				tiff_file_path=reprojected_path,
 				cog_target_path=cog_target_path,
 				num_bands=num_bands,
 				alpha_band_index=alpha_band_index,
-				force_epsg_3857=True,
 			)
-			_run_gdal_translate(cmd_translate_epsg, token=token, attempt='epsg-3857-retry')
+			_run_gdal_translate(cmd_translate_reprojected, token=token, attempt='epsg-3857-reproject-retry')
 		except subprocess.CalledProcessError as e:
-			logger.error(f'Error running gdal_translate with EPSG:3857 retry: {e}', extra={'token': token})
+			logger.error(f'Error running COG creation after EPSG:3857 reprojection: {e}', extra={'token': token})
 			raise  # Re-raise the exception to stop execution if both attempts fail
+		finally:
+			Path(reprojected_path).unlink(missing_ok=True)
 
 	return cog_info(cog_target_path)
 

--- a/processor/tests/test_cog_command_strategy.py
+++ b/processor/tests/test_cog_command_strategy.py
@@ -287,7 +287,7 @@ def test_two_band_high_nodata_standardise_then_cog_preserves_internal_mask(tmp_p
 		assert np.array_equal(actual_transparent, expected_transparent)
 
 
-def test_calculate_cog_logs_full_error_and_retries_with_epsg_3857(monkeypatch):
+def test_calculate_cog_logs_full_error_and_retries_by_reprojecting_to_epsg_3857(monkeypatch):
 	_patch_common(monkeypatch, band_count=3)
 	commands: list[list[str]] = []
 	error_messages: list[str] = []
@@ -309,9 +309,17 @@ def test_calculate_cog_logs_full_error_and_retries_with_epsg_3857(monkeypatch):
 
 	cog_module.calculate_cog('input.tif', 'output.tif')
 
-	assert len(commands) == 2
+	# Primary COG translate (fails) -> gdalwarp reproject to 3857 -> COG translate on reprojected source.
+	assert len(commands) == 3
+	# The primary attempt must never relabel the CRS.
 	assert '-a_srs' not in commands[0]
-	assert '-a_srs' in commands[1]
+	# The fallback must REPROJECT (gdalwarp -t_srs), never relabel with -a_srs, otherwise
+	# projected-metre coordinates get mistagged as Web Mercator and land far from the true location.
+	assert commands[1][0] == 'gdalwarp'
+	assert '-t_srs' in commands[1]
 	assert 'EPSG:3857' in commands[1]
+	assert '-a_srs' not in commands[1]
+	# The final COG is built from the reprojected raster, still without -a_srs.
+	assert '-a_srs' not in commands[2]
 	assert any('boom stderr' in message for message in error_messages)
 	assert any('partial stdout' in message for message in error_messages)


### PR DESCRIPTION
## Problem

Dataset 6653's original ortho is correctly georeferenced (EPSG:32718, UTM 18S → Peru), but its COG displays in the North Sea near Norway.

**Root cause:** In `processor/src/cog/cog.py`, `calculate_cog()` retries with `gdal_translate -a_srs EPSG:3857` when the primary COG translate fails. `-a_srs` only overwrites the CRS **label** — it does not reproject. For any projected-metre source (UTM / Gauss-Krüger / national grids), the raw easting/northing are kept but tagged as Web Mercator, so the image lands thousands of km from its true location.

Reproduced bit-for-bit against the pinned GDAL 3.10.3: the relabel path yields `Origin 536549.720047794…, 9087502.746539248…` / `Pixel 0.074645535434566` — identical to production `6653_cog.tif` (`4°49′E, 62°N`) instead of the correct `74°40′W, 8°15′S`.

## Fix

- Remove the `-a_srs EPSG:3857` relabel footgun (`force_epsg_3857` param deleted).
- Add `_reproject_to_epsg3857()` — the fallback now does a real `gdalwarp -t_srs EPSG:3857` reprojection, then builds the COG from the reprojected raster (temp cleaned up in `finally`).
- If the source has no usable CRS, gdalwarp fails loudly rather than emitting a mislocated COG.
- Update the strategy unit test to assert the fallback reprojects and never uses `-a_srs`.

## Verification

- Unit tests: 7/7 pass (run inside the pinned GDAL 3.10.3 image).
- Behavioral: simulating a primary failure on 6653's ortho, the new fallback yields correct Peru coordinates (`-8312010, -922136`) in real Web Mercator.

## Blast radius (separate follow-up)

An audit of production `cog_info`/`ortho_info` metadata (no COG downloads needed) found **34 of 9006 COGs** created via the old relabel path — all with projected non-3857 ortho CRSs, mostly a Feb 2026 batch:

```
6027, 6028, 6599, 6602, 6652, 6653, 6779, 6795, 6809, 6815, 6840, 6843, 6852, 6862,
6900, 6908, 6924, 6929, 6936, 6944, 6961, 6988, 7638, 7852, 7869, 7879, 7899, 8389,
8438, 8923, 9859, 10074, 10075, 10275
```

Notably, **17 of these were manually audited as `is_georeferenced = False`** — the mislocated COG (what the platform displays) is almost certainly why, since the underlying TIFs are correctly georeferenced. These COGs need regenerating (and those rows re-auditing) — not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)