### PR TITLE
fix(processor): compress the EPSG:3857 warp intermediate

### DIFF
--- a/processor/src/cog/cog.py
+++ b/processor/src/cog/cog.py
@@ -135,6 +135,13 @@ def _reproject_to_epsg3857(src_path: str, dst_path: str, token: str | None = Non
 
 	If the source has no usable CRS, gdalwarp fails here — which is the correct
 	behaviour: we would rather fail loudly than publish a mislocated COG.
+
+	The intermediate is written with lossless DEFLATE compression: it is a
+	transient file that is deleted right after the COG is built, and an
+	uncompressed GTiff of a production-size mosaic can expand to tens of GB and
+	exhaust the processor temp volume before the retry reaches gdal_translate.
+	DEFLATE keeps it bounded without adding a lossy generation ahead of the COG's
+	own JPEG step.
 	"""
 	command = [
 		'gdalwarp',
@@ -142,6 +149,10 @@ def _reproject_to_epsg3857(src_path: str, dst_path: str, token: str | None = Non
 		'EPSG:3857',
 		'-of',
 		'GTiff',
+		'-co',
+		'COMPRESS=DEFLATE',
+		'-co',
+		'PREDICTOR=2',
 		'-co',
 		'BIGTIFF=YES',
 		'-co',


### PR DESCRIPTION
## Context

Follow-up to #480 (already merged), addressing the Codex review comment on `processor/src/cog/cog.py`.

## Problem

The COG fallback added in #480 (`_reproject_to_epsg3857`) materializes a full GeoTIFF from `gdalwarp` before building the COG, but its only GTiff creation options were `BIGTIFF` and `TILED`. GDAL's GTiff default is `COMPRESS=NONE`, so for a production-size mosaic the transient reprojected raster can expand to tens of GB in `settings.processing_path` and exhaust the processor temp volume before the retry reaches `gdal_translate`.

## Fix

Write the warp intermediate with lossless **`COMPRESS=DEFLATE` + `PREDICTOR=2`**. The file is deleted right after the COG is built, and being lossless it adds no quality generation ahead of the COG's own JPEG step.

## Verification

On dataset 6653's ortho (the one that surfaced the original bug):

- Intermediate size: **162 MB → 61 MB** (~2.6×) under the pinned GDAL 3.10.3.
- Resulting COG stays correctly georeferenced (Upper-Left `-8312010, -922136` = `74°40′W, 8°15′S`, Peru).
- Unit tests: 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)