### PR TITLE
fix(labels): survive DB statement timeouts on large geometry inserts

### DIFF
--- a/shared/labels.py
+++ b/shared/labels.py
@@ -19,9 +19,15 @@ from shared.db import use_client
 from shared.settings import settings
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
-from shared.retry import retry_on_transient_error
+from shared.retry import retry_on_transient_error, is_statement_timeout
 
-MAX_CHUNK_SIZE = 1024 * 1024 * 5  # 5MB per chunk
+# Each chunk is inserted as a single SQL statement, which must finish within the
+# database ``statement_timeout`` (8s for the ``authenticated`` role in production).
+# Insert time scales with both the byte size *and* the number of rows (each row
+# updates the spatial index), so we cap on both. These are first-line limits;
+# ``_insert_records_adaptive`` handles any chunk that still exceeds the budget.
+MAX_CHUNK_SIZE = 1024 * 1024 * 2  # 2MB of WKB per chunk
+MAX_CHUNK_GEOMETRIES = 2000  # rows per chunk
 
 
 def create_label_with_geometries(payload: LabelPayloadData, user_id: str, token: str) -> Label:
@@ -116,7 +122,9 @@ def create_label_with_geometries(payload: LabelPayloadData, user_id: str, token:
 				wkb_geom = wkb.dumps(polygon)
 				geom_size = len(wkb_geom)
 
-				if current_chunk_size + geom_size > MAX_CHUNK_SIZE and current_chunk:
+				exceeds_size = current_chunk_size + geom_size > MAX_CHUNK_SIZE
+				exceeds_count = len(current_chunk) >= MAX_CHUNK_GEOMETRIES
+				if current_chunk and (exceeds_size or exceeds_count):
 					# Upload current chunk
 					upload_geometry_chunk(
 						client, geom_table, GeometryModel, label_id, current_chunk, payload.properties, token
@@ -164,15 +172,53 @@ def upload_geometry_chunk(
 		geometry = GeometryModel(label_id=label_id, geometry=geom.__geo_interface__, properties=properties)
 		geometry_records.append(geometry.model_dump(exclude={'id', 'created_at'}))
 
+	try:
+		_insert_records_adaptive(client, table, geometry_records, label_id, token)
+	except Exception as e:
+		logger.error(f'Error uploading geometry chunk: {str(e)}', extra={'token': token})
+		raise Exception(f'Error uploading geometry chunk: {str(e)}')
+
+
+def _insert_records_adaptive(client, table: str, records: List[dict], label_id: int, token: str) -> None:
+	"""Insert ``records`` as one statement, splitting the batch if the DB cancels it.
+
+	A Postgres ``statement_timeout`` (SQLSTATE 57014) means the batch was too large
+	to insert within the time budget; the whole statement is rolled back atomically
+	(no partial rows), so we can safely halve the batch and retry each half. This
+	recurses down to a single record, which — if it *still* times out — is a genuine
+	problem and is re-raised. Transient network errors are handled per-insert by
+	``retry_on_transient_error`` and are not split.
+	"""
+	try:
+		_insert_records_with_retry(client, table, records, label_id)
+	except Exception as e:
+		if is_statement_timeout(e) and len(records) > 1:
+			mid = len(records) // 2
+			logger.warning(
+				f'Geometry insert hit statement timeout for {len(records)} records; '
+				f'splitting into {mid} + {len(records) - mid} and retrying',
+				extra={'token': token},
+			)
+			_insert_records_adaptive(client, table, records[:mid], label_id, token)
+			_insert_records_adaptive(client, table, records[mid:], label_id, token)
+		else:
+			raise
+
+
+def _insert_records_with_retry(client, table: str, records: List[dict], label_id: int) -> None:
+	"""Insert a single batch, retrying only on transient network failures.
+
+	Idempotency: read a baseline row count so that, if a transient failure drops the
+	connection *after* the insert committed, the retry can detect the rows already
+	landed and skip re-inserting (a PostgREST batch insert is atomic, so the count is
+	either the baseline or baseline + len(records)). If we can't read a baseline, fall
+	back to plain retry.
+	"""
+
 	def _count_existing() -> int:
 		response = client.table(table).select('id', count='exact').eq('label_id', label_id).execute()
 		return response.count or 0
 
-	# Baseline row count so that, if a transient failure drops the connection
-	# *after* the insert committed, the retry can detect the rows already landed
-	# and skip re-inserting (a PostgREST batch insert is atomic, so the count is
-	# either the baseline or baseline + len(records)). If we can't read a
-	# baseline, fall back to plain retry.
 	try:
 		count_before = _count_existing()
 	except Exception:
@@ -181,17 +227,13 @@ def upload_geometry_chunk(
 	def _already_committed() -> bool:
 		if count_before is None:
 			return False
-		return _count_existing() >= count_before + len(geometry_records)
+		return _count_existing() >= count_before + len(records)
 
 	@retry_on_transient_error(verify_succeeded=_already_committed)
 	def _insert() -> None:
-		client.table(table).insert(geometry_records).execute()
+		client.table(table).insert(records).execute()
 
-	try:
-		_insert()
-	except Exception as e:
-		logger.error(f'Error uploading geometry chunk: {str(e)}', extra={'token': token})
-		raise Exception(f'Error uploading geometry chunk: {str(e)}')
+	_insert()
 
 
 def delete_model_prediction_labels(

--- a/shared/retry.py
+++ b/shared/retry.py
@@ -36,6 +36,24 @@ TRANSIENT_ERROR_PATTERNS = (
 	'no existing session',
 )
 
+# A Postgres statement timeout (SQLSTATE 57014) is *deterministic*, not a network
+# blip: the same statement, re-issued unchanged, will exceed the same time budget
+# and be cancelled again. Blindly retrying it (its message contains "timeout", so
+# it would otherwise match TRANSIENT_ERROR_PATTERNS) just burns every attempt to
+# no effect. Callers must instead make the statement smaller (e.g. split the batch),
+# so we deliberately classify it as non-transient.
+STATEMENT_TIMEOUT_PATTERNS = (
+	'57014',
+	'statement timeout',
+	'canceling statement due to statement timeout',
+)
+
+
+def is_statement_timeout(exc: BaseException) -> bool:
+	"""True if the exception is a Postgres statement_timeout cancellation (SQLSTATE 57014)."""
+	message = str(exc).lower()
+	return any(pattern in message for pattern in STATEMENT_TIMEOUT_PATTERNS)
+
 
 def is_transient_error(exc: BaseException) -> bool:
 	"""Heuristic for whether an exception looks like a transient network failure.
@@ -44,7 +62,13 @@ def is_transient_error(exc: BaseException) -> bool:
 	bubble up through several layers (supabase -> httpx -> httpcore) and get
 	re-wrapped as plain ``Exception`` along the way, so the type is unreliable
 	but the underlying message is preserved.
+
+	A Postgres statement timeout is explicitly excluded: it looks like a timeout
+	but is deterministic, so retrying it unchanged never helps (see
+	``STATEMENT_TIMEOUT_PATTERNS``).
 	"""
+	if is_statement_timeout(exc):
+		return False
 	message = str(exc).lower()
 	return any(pattern in message for pattern in TRANSIENT_ERROR_PATTERNS)
 

--- a/shared/retry.py
+++ b/shared/retry.py
@@ -36,21 +36,29 @@ TRANSIENT_ERROR_PATTERNS = (
 	'no existing session',
 )
 
-# A Postgres statement timeout (SQLSTATE 57014) is *deterministic*, not a network
-# blip: the same statement, re-issued unchanged, will exceed the same time budget
-# and be cancelled again. Blindly retrying it (its message contains "timeout", so
-# it would otherwise match TRANSIENT_ERROR_PATTERNS) just burns every attempt to
-# no effect. Callers must instead make the statement smaller (e.g. split the batch),
-# so we deliberately classify it as non-transient.
+# A Postgres statement timeout is *deterministic*, not a network blip: the same
+# statement, re-issued unchanged, will exceed the same time budget and be cancelled
+# again. Blindly retrying it (its message contains "timeout", so it would otherwise
+# match TRANSIENT_ERROR_PATTERNS) just burns every attempt to no effect. Callers must
+# instead make the statement smaller (e.g. split the batch), so we classify it as
+# non-transient.
+#
+# We match on the "statement timeout" *message*, NOT on SQLSTATE 57014 alone: 57014
+# is Postgres's generic query_canceled code, also raised for user/admin cancellations
+# (pg_cancel_backend -> "canceling statement due to user request"). Those must
+# propagate, not be split-and-retried, so only the timeout message qualifies.
 STATEMENT_TIMEOUT_PATTERNS = (
-	'57014',
-	'statement timeout',
 	'canceling statement due to statement timeout',
+	'statement timeout',
 )
 
 
 def is_statement_timeout(exc: BaseException) -> bool:
-	"""True if the exception is a Postgres statement_timeout cancellation (SQLSTATE 57014)."""
+	"""True if the exception is a Postgres statement_timeout cancellation.
+
+	Deliberately keyed on the statement-timeout message rather than SQLSTATE 57014,
+	which also covers non-timeout query cancellations that should not be split/retried.
+	"""
 	message = str(exc).lower()
 	return any(pattern in message for pattern in STATEMENT_TIMEOUT_PATTERNS)
 

--- a/shared/tests/test_labels_retry.py
+++ b/shared/tests/test_labels_retry.py
@@ -61,6 +61,52 @@ class _FakeClient:
 		return self._table
 
 
+_STATEMENT_TIMEOUT = "{'message': 'canceling statement due to statement timeout', 'code': '57014'}"
+
+
+class _GatedTable:
+	"""Insert succeeds only for batches of ``max_ok_batch`` rows or fewer; larger
+	batches raise a Postgres statement timeout, which the uploader must resolve by
+	splitting the batch."""
+
+	def __init__(self, max_ok_batch):
+		self.max_ok_batch = max_ok_batch
+		self.rows = []
+		self.insert_attempts = 0
+		self.timeout_count = 0
+		self.ok_batches = []
+
+	def select(self, *args, **kwargs):
+		return _FakeSelect(self)
+
+	def insert(self, records):
+		return _GatedInsert(self, records)
+
+
+class _GatedInsert:
+	def __init__(self, table, records):
+		self._table = table
+		self._records = list(records)
+
+	def execute(self):
+		t = self._table
+		t.insert_attempts += 1
+		if len(self._records) > t.max_ok_batch:
+			t.timeout_count += 1
+			raise Exception(_STATEMENT_TIMEOUT)
+		t.rows.extend(self._records)
+		t.ok_batches.append(len(self._records))
+		return None
+
+
+class _GatedClient:
+	def __init__(self, max_ok_batch):
+		self._table = _GatedTable(max_ok_batch)
+
+	def table(self, name):
+		return self._table
+
+
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
 	monkeypatch.setattr('shared.retry.time.sleep', lambda d: None)
@@ -70,13 +116,13 @@ def _polygon():
 	return Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
 
 
-def _upload(client):
+def _upload(client, count=1):
 	upload_geometry_chunk(
 		client,
 		table='v2_deadwood_geometries',
 		GeometryModel=DeadwoodGeometry,
 		label_id=1,
-		geometries=[_polygon()],
+		geometries=[_polygon() for _ in range(count)],
 		properties=None,
 		token='token',
 	)
@@ -112,3 +158,42 @@ def test_upload_geometry_chunk_does_not_duplicate_when_commit_response_lost():
 	# skipped re-inserting, so there is exactly one geometry, not two.
 	assert client._table.insert_attempts == 1
 	assert len(client._table.rows) == 1
+
+
+def test_upload_splits_batch_on_statement_timeout():
+	"""A batch that hits statement_timeout is halved recursively until it fits."""
+	client = _GatedClient(max_ok_batch=1)  # only single-row inserts succeed
+
+	_upload(client, count=4)
+
+	t = client._table
+	# All four geometries landed, committed one row at a time.
+	assert len(t.rows) == 4
+	assert t.ok_batches == [1, 1, 1, 1]
+	# The oversized batches — insert(4), then insert(2) for each half — each timed
+	# out exactly once (no wasteful retries of the same too-large statement).
+	assert t.timeout_count == 3
+
+
+def test_upload_splits_only_as_far_as_needed():
+	"""Splitting stops as soon as a sub-batch fits the budget."""
+	client = _GatedClient(max_ok_batch=2)  # batches of 2 succeed
+
+	_upload(client, count=4)
+
+	t = client._table
+	assert len(t.rows) == 4
+	# insert(4) times out once, then the two halves of 2 both commit.
+	assert t.timeout_count == 1
+	assert t.ok_batches == [2, 2]
+
+
+def test_upload_reraises_when_single_record_still_times_out():
+	"""A single geometry that still times out is a real error, not something to split."""
+	client = _GatedClient(max_ok_batch=0)  # even one row times out
+
+	with pytest.raises(Exception, match='Error uploading geometry chunk'):
+		_upload(client, count=2)
+
+	# Nothing committed, and it did not spin forever: 2 -> 1 (still fails) -> raise.
+	assert client._table.rows == []

--- a/shared/tests/test_retry.py
+++ b/shared/tests/test_retry.py
@@ -62,6 +62,21 @@ def test_is_statement_timeout_false_for_network_timeouts(message):
 	assert is_statement_timeout(Exception(message)) is False
 
 
+@pytest.mark.parametrize(
+	'message',
+	[
+		# SQLSTATE 57014 is generic query_canceled, not only statement_timeout: a
+		# user/admin cancellation shares the code but must propagate, not be split.
+		"{'message': 'canceling statement due to user request', 'code': '57014'}",
+		'canceling statement due to user request',
+	],
+)
+def test_is_statement_timeout_false_for_other_query_cancellations(message):
+	assert is_statement_timeout(Exception(message)) is False
+	# ...and such a cancellation is not a network transient either, so it propagates.
+	assert is_transient_error(Exception(message)) is False
+
+
 def test_statement_timeout_is_not_transient():
 	"""A Postgres statement timeout contains 'timeout' but must NOT be retried."""
 	exc = Exception("{'message': 'canceling statement due to statement timeout', 'code': '57014'}")

--- a/shared/tests/test_retry.py
+++ b/shared/tests/test_retry.py
@@ -1,6 +1,6 @@
 import pytest
 
-from shared.retry import is_transient_error, retry_on_transient_error
+from shared.retry import is_statement_timeout, is_transient_error, retry_on_transient_error
 
 
 # ---------------------------------------------------------------------------
@@ -36,6 +36,51 @@ def test_is_transient_error_true_for_network_failures(message):
 )
 def test_is_transient_error_false_for_deterministic_errors(exc):
 	assert is_transient_error(exc) is False
+
+
+@pytest.mark.parametrize(
+	'message',
+	[
+		'canceling statement due to statement timeout',
+		"{'message': 'canceling statement due to statement timeout', 'code': '57014'}",
+		'ERROR: statement timeout',
+	],
+)
+def test_is_statement_timeout_true_for_postgres_cancellation(message):
+	assert is_statement_timeout(Exception(message)) is True
+
+
+@pytest.mark.parametrize(
+	'message',
+	[
+		'The write operation timed out',
+		'read operation timed out',
+		'Server disconnected without sending a response.',
+	],
+)
+def test_is_statement_timeout_false_for_network_timeouts(message):
+	assert is_statement_timeout(Exception(message)) is False
+
+
+def test_statement_timeout_is_not_transient():
+	"""A Postgres statement timeout contains 'timeout' but must NOT be retried."""
+	exc = Exception("{'message': 'canceling statement due to statement timeout', 'code': '57014'}")
+	assert is_transient_error(exc) is False
+
+
+def test_statement_timeout_reraised_immediately_without_retry(no_sleep):
+	calls = []
+
+	@retry_on_transient_error
+	def fn():
+		calls.append(1)
+		raise Exception('canceling statement due to statement timeout')
+
+	with pytest.raises(Exception, match='statement timeout'):
+		fn()
+
+	assert len(calls) == 1
+	assert no_sleep == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Large deadwood/treecover prediction labels were being **lost at the final DB write**. The geometry uploader (`shared/labels.py`) inserts each chunk as a single SQL statement. A chunk large enough to exceed the `authenticated` role's **8s `statement_timeout`** gets cancelled by Postgres (`SQLSTATE 57014 – canceling statement due to statement timeout`).

Because that error message contains the substring `timeout`, `is_transient_error()` misclassified it as a transient network blip, so `retry_on_transient_error` **retried the same oversized statement 4×** — each attempt getting a fresh 8s window and hitting the identical wall — then gave up and discarded the whole (often multi-hour) segmentation.

Real-world hit: **dataset 8389** — combined segmentation failed with `Error uploading geometry chunk: canceling statement due to statement timeout` after inference had already run.

## Root cause

- `statement_timeout` on the `authenticated` role is **8s** (confirmed in prod).
- Chunks were capped only by byte size at **5 MB**, which for dense predictions is far more than can be inserted (with spatial-index maintenance) in 8s.
- A statement timeout is **deterministic**, not transient — retrying it unchanged can never succeed.

## Fix

- **`retry.py`** — classify Postgres statement timeout (`57014`) as **non-transient** so it is no longer retried unchanged. New helper `is_statement_timeout()`.
- **`labels.py`** — on a statement timeout, **adaptively split** the batch in half and retry each half, recursing down to a single record. A single record that *still* times out is a genuine error and is re-raised. Statement timeouts roll back atomically (no partial rows), so splitting cannot duplicate geometries.
- **`labels.py`** — shrink first-line chunk limits (**5 MB → 2 MB**, plus a **2000-row** cap) so the vast majority of inserts finish well under budget and never need to split.

## Tests

- `test_retry.py`: statement timeout is detected by `is_statement_timeout`, is **not** classified transient, and is re-raised immediately without retry (network timeouts stay transient).
- `test_labels_retry.py`: an oversized batch splits recursively until it fits and commits every geometry once; splitting stops as soon as a sub-batch fits; a single record that keeps timing out surfaces as `Error uploading geometry chunk`. Existing transient-retry and commit-then-response-lost idempotency tests unchanged and passing.

`shared/tests` full suite: **67 passed**. `ruff format` clean.

## Not included

This does **not** address the separate RLS (`42501`) failure seen on datasets 6027/6028 — that's an auth-token issue after ~9h inferences, tracked separately; re-running is the immediate remedy there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)