### PR TITLE
feat(processor): let a worker blacklist task steps it won't run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhY
 PROCESSOR_PASSWORD=processor
 # Optional override; use a stable unique value per processor host.
 PROCESSOR_WORKER_ID=
+# Comma-separated task types this worker refuses to run (e.g. odm_processing).
+# Queue entries whose task_types include any of these are skipped so another
+# (capable) worker picks them up. Leave empty to run every task type.
+PROCESSOR_TASK_BLACKLIST=
 # Per-host resource caps for the production processor container
 # (docker-compose.processor.yaml). On machines smaller than the defaults, lower
 # PROCESSOR_CPU_LIMIT to <= the host's CPU core count. Defaults: 30 CPUs / 96G.

--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -55,6 +55,8 @@ services:
       PROCESSOR_USERNAME: processor@deadtrees.earth
       PROCESSOR_PASSWORD: ${PROCESSOR_PASSWORD}
       PROCESSOR_WORKER_ID: ${PROCESSOR_WORKER_ID:-}
+      # Comma-separated task types this worker refuses to run (e.g. odm_processing).
+      PROCESSOR_TASK_BLACKLIST: ${PROCESSOR_TASK_BLACKLIST:-}
       SSH_PRIVATE_KEY_PASSPHRASE: ${SSH_PRIVATE_KEY_PASSPHRASE}
       SSH_PRIVATE_KEY_PATH: /root/.ssh/processing-to-storage
       DEV_MODE: "false"

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -208,8 +208,28 @@ def are_requested_stages_complete(status_data: dict, task_types: list) -> bool:
 	return bool(requested) and all(status_data.get(done_flag, False) for done_flag in requested)
 
 
+def get_task_blacklist() -> list[str]:
+	"""Return the validated set of task types this worker refuses to run.
+
+	Unknown entries in PROCESSOR_TASK_BLACKLIST are dropped with a warning so a
+	typo can't silently blacklist nothing (or everything).
+	"""
+	blacklist = []
+	for value in settings.processor_task_blacklist:
+		task_type = TaskTypeEnum.from_string(value)
+		if task_type is None:
+			logger.warning(f'Ignoring unknown task type in PROCESSOR_TASK_BLACKLIST: {value!r}')
+			continue
+		blacklist.append(task_type.value)
+	return blacklist
+
+
 def get_next_task(token: str) -> QueueTask:
 	"""Get the next task (QueueTask class) in the queue from supabase.
+
+	Queue entries whose `task_types` include any type in this worker's
+	blacklist (PROCESSOR_TASK_BLACKLIST) are skipped, so the highest-priority
+	task this worker is capable of running is returned instead.
 
 	Args:
 	    token (str): Client access token for supabase
@@ -217,8 +237,13 @@ def get_next_task(token: str) -> QueueTask:
 	Returns:
 	    QueueTask: The next task in the queue as a QueueTask class instance
 	"""
+	blacklist = get_task_blacklist()
 	with use_client(token) as client:
-		response = client.table(settings.queue_position_table).select('*').limit(1).execute()
+		query = client.table(settings.queue_position_table).select('*')
+		if blacklist:
+			# Skip rows whose task_types array overlaps the blacklist.
+			query = query.not_.overlaps('task_types', blacklist)
+		response = query.limit(1).execute()
 	if not response.data or len(response.data) == 0:
 		return None
 	return QueueTask(**response.data[0])

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -138,6 +138,10 @@ class Settings(BaseSettings):
 	PROCESSOR_USERNAME: str = 'processor@deadtrees.earth'
 	PROCESSOR_PASSWORD: str = 'processor'
 	PROCESSOR_WORKER_ID: str = ''
+	# Comma-separated task types this worker refuses to run (e.g. 'odm_processing').
+	# A queue entry whose task_types include any blacklisted type is skipped so a
+	# capable worker picks it up instead. See `processor_task_blacklist`.
+	PROCESSOR_TASK_BLACKLIST: str = ''
 	SSH_PRIVATE_KEY_PATH: str = '/app/ssh_key'
 	SSH_PRIVATE_KEY_PASSPHRASE: str = ''
 	ODM_AUTO_BOUNDARY: bool = False
@@ -344,6 +348,11 @@ class Settings(BaseSettings):
 	@property
 	def tile_embeddings_table(self) -> str:
 		return self._tables['tile_embeddings']
+
+	@property
+	def processor_task_blacklist(self) -> list[str]:
+		"""Task type values this worker must not run, parsed from PROCESSOR_TASK_BLACKLIST."""
+		return [t.strip() for t in self.PROCESSOR_TASK_BLACKLIST.split(',') if t.strip()]
 
 
 settings = Settings()


### PR DESCRIPTION
## What & why

Adds per-worker task-step blacklisting so a processor can refuse to run certain task types (e.g. `odm_processing` on a machine without the horsepower/config for ODM). Instead of grabbing the globally next queue entry and running whatever it contains, a worker now skips entries whose `task_types` include a blacklisted step and picks the highest-priority task it is actually capable of running.

## How

- **`PROCESSOR_TASK_BLACKLIST`** — new comma-separated env var (e.g. `odm_processing,geotiff`). Set it in each processor host's **`.env`** file; `docker-compose.processor.yaml` passes it through. Empty = run everything (current behavior, unchanged default).
- `settings.processor_task_blacklist` parses it into a list.
- `get_next_task()` applies a PostgREST `not.overlaps` filter on the `v2_queue_positions` view — the view is already ordered `priority DESC, created_at ASC`, so filter + `limit(1)` returns the top task this worker can run.
- `get_task_blacklist()` validates entries against `TaskTypeEnum` and drops unknown values with a warning, so a typo can't silently blacklist nothing/everything.
- Crash recovery (`get_active_task`) is **left untouched** — a worker still cleans up its own in-flight/crashed rows regardless of blacklist.

## Behavior note

An entry is skipped if it contains **any** blacklisted step — e.g. a bundle of `odm_processing` + `geotiff` + `cog` is skipped entirely and waits for an ODM-capable worker (no partial execution). This is correct given the fixed pipeline order and geotiff/ortho stage dependencies.

## Testing

- Settings parse `'odm_processing, geotiff , bogus_task'` → validated blacklist `['odm_processing', 'geotiff']` (unknown dropped).
- Filter serializes to `task_types=not.ov.{odm_processing,geotiff}`.
- Modified files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)