### PR TITLE
feat(frontend): link PRIWA flights to beetle trees

### DIFF
--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -4,8 +4,6 @@ import {
   FloatButton,
   Popover,
   Progress,
-  Segmented,
-  Switch,
   Tooltip,
   Typography,
   message,
@@ -49,9 +47,11 @@ import {
   createPriwaPreviewLayer,
 } from "./createPriwaPointLayer";
 import PriwaPointDrawer from "./PriwaPointDrawer";
+import PriwaLayerPanel, { type PriwaBaseLayer } from "./PriwaLayerPanel";
 import PriwaPointListPanel from "./PriwaPointListPanel";
 import PriwaOfflineStatus from "./PriwaOfflineStatus";
 import { usePriwaOfflineBasemap } from "./usePriwaOfflineBasemap";
+import { usePriwaMosaicMatches } from "./usePriwaMosaicMatches";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
 import type { IPriwaSyncSummary } from "./priwaOfflineSync";
 import type {
@@ -61,44 +61,6 @@ import type {
 } from "./types";
 
 const FIELD_CENTER: [number, number] = [8.18013, 48.45596];
-type PriwaBaseLayer = "aerial" | "topographic";
-
-const formatPriwaMosaicDate = (value: string | null | undefined) => {
-  if (!value) return null;
-
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
-  if (match) {
-    return `${match[3]}.${match[2]}.${match[1]}`;
-  }
-
-  return value;
-};
-
-const mosaicDateRank = (value: string | null | undefined) => {
-  if (!value) return Number.NEGATIVE_INFINITY;
-  const timestamp = Date.parse(value);
-  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
-};
-
-const mosaicIdRank = (id: string) => {
-  const numericId = Number(id);
-  return Number.isFinite(numericId) ? numericId : Number.NEGATIVE_INFINITY;
-};
-
-const comparePriwaMosaics = (left: IPriwaMosaic, right: IPriwaMosaic) => {
-  const captureDifference =
-    mosaicDateRank(right.captureDate) - mosaicDateRank(left.captureDate);
-  if (captureDifference !== 0) return captureDifference;
-
-  const uploadDifference =
-    mosaicDateRank(right.createdAt) - mosaicDateRank(left.createdAt);
-  if (uploadDifference !== 0) return uploadDifference;
-
-  const idDifference = mosaicIdRank(right.id) - mosaicIdRank(left.id);
-  if (idDifference !== 0) return idDifference;
-
-  return right.id.localeCompare(left.id);
-};
 
 function MapLayersIcon() {
   return (
@@ -180,7 +142,12 @@ export default function PriwaFieldMap({
   const cogLayersRef = useRef<TileLayerWebGL[]>([]);
   const knownMosaicIdsRef = useRef<Set<string>>(new Set());
   const hoveredMosaicIdRef = useRef<string | null>(null);
-  const toggleMosaicVisibilityRef = useRef<(mosaicId: string) => void>(() => {
+  const selectMosaicFromFootprintRef = useRef<(mosaicId: string) => void>(
+    () => {
+      return;
+    },
+  );
+  const openPointForEditingRef = useRef<(point: IPriwaPoint) => void>(() => {
     return;
   });
   const [isDrawerOpen, setDrawerOpen] = useState(false);
@@ -197,14 +164,14 @@ export default function PriwaFieldMap({
   const [editingPoint, setEditingPoint] = useState<IPriwaPoint | null>(null);
   const [formSessionId, setFormSessionId] = useState(0);
   const [isPointListOpen, setPointListOpen] = useState(false);
+  const [focusedPointId, setFocusedPointId] = useState<string | null>(null);
   const [isLayerPanelOpen, setLayerPanelOpen] = useState(false);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
+  const { candidateCount, matchedMosaics, mosaicIdByPointId } =
+    usePriwaMosaicMatches(points, mosaics);
   const visibleMosaics = useMemo(
-    () =>
-      [...mosaics]
-        .filter((mosaic) => mosaic.cogUrl.trim().length > 0)
-        .sort(comparePriwaMosaics),
-    [mosaics],
+    () => matchedMosaics.map(({ mosaic }) => mosaic),
+    [matchedMosaics],
   );
   const enabledMosaics = useMemo(
     () => visibleMosaics.filter((mosaic) => enabledMosaicIds.has(mosaic.id)),
@@ -263,37 +230,41 @@ export default function PriwaFieldMap({
     }
   }, [hoveredMosaicId, visibleMosaics]);
 
-  const toggleMosaicVisibilityFromFootprint = useCallback(
-    (mosaicId: string) => {
-      setEnabledMosaicIds((currentIds) => {
-        const nextIds = new Set(currentIds);
-        if (nextIds.has(mosaicId)) {
-          nextIds.delete(mosaicId);
-        } else {
-          nextIds.add(mosaicId);
-        }
+  const selectMosaicFromFootprint = useCallback((mosaicId: string) => {
+    setSelectedMosaicId(mosaicId);
+    setLayerPanelOpen(true);
+  }, []);
 
-        return nextIds;
-      });
+  useEffect(() => {
+    selectMosaicFromFootprintRef.current = selectMosaicFromFootprint;
+  }, [selectMosaicFromFootprint]);
+
+  const selectMatchedMosaicForPoint = useCallback(
+    (point: IPriwaPoint) => {
+      const mosaicId = mosaicIdByPointId[point.id];
+      if (!mosaicId) return;
 
       setSelectedMosaicId(mosaicId);
-      setLayerPanelOpen(true);
     },
-    [],
+    [mosaicIdByPointId],
+  );
+
+  const openPointForEditing = useCallback(
+    (point: IPriwaPoint) => {
+      selectMatchedMosaicForPoint(point);
+      setPointListOpen(false);
+      setFormSessionId((currentSessionId) => currentSessionId + 1);
+      setEditingPoint(point);
+      setSelectedCoordinate({ lat: point.lat, lon: point.lon });
+      setSelectedCoordinateSource(point.coordinateSource);
+      setDrawerOpen(true);
+    },
+    [selectMatchedMosaicForPoint],
   );
 
   useEffect(() => {
-    toggleMosaicVisibilityRef.current = toggleMosaicVisibilityFromFootprint;
-  }, [toggleMosaicVisibilityFromFootprint]);
-
-  const openPointForEditing = useCallback((point: IPriwaPoint) => {
-    setPointListOpen(false);
-    setFormSessionId((currentSessionId) => currentSessionId + 1);
-    setEditingPoint(point);
-    setSelectedCoordinate({ lat: point.lat, lon: point.lon });
-    setSelectedCoordinateSource(point.coordinateSource);
-    setDrawerOpen(true);
-  }, []);
+    openPointForEditingRef.current = openPointForEditing;
+  }, [openPointForEditing]);
 
   useEffect(() => {
     isPlacingPointRef.current = isPlacingPoint;
@@ -353,6 +324,23 @@ export default function PriwaFieldMap({
     const clickKey = map.on("singleclick", (event) => {
       if (isPlacingPointRef.current) return;
 
+      const pointFeature = map.forEachFeatureAtPixel(
+        event.pixel,
+        (feature) => {
+          const point = feature.get("point") as IPriwaPoint | undefined;
+          return point ?? null;
+        },
+        {
+          hitTolerance: 18,
+          layerFilter: (layer) => layer === pointLayerRef.current,
+        },
+      );
+
+      if (pointFeature) {
+        openPointForEditingRef.current(pointFeature);
+        return;
+      }
+
       const mosaicId = map.forEachFeatureAtPixel(
         event.pixel,
         (feature) => {
@@ -366,23 +354,7 @@ export default function PriwaFieldMap({
       );
 
       if (mosaicId) {
-        toggleMosaicVisibilityRef.current(mosaicId);
-        return;
-      }
-
-      const pointFeature = map.forEachFeatureAtPixel(
-        event.pixel,
-        (feature) => {
-          const point = feature.get("point") as IPriwaPoint | undefined;
-          return point ?? null;
-        },
-        {
-          hitTolerance: 18,
-        },
-      );
-
-      if (pointFeature) {
-        openPointForEditing(pointFeature);
+        selectMosaicFromFootprintRef.current(mosaicId);
       }
     });
 
@@ -440,7 +412,7 @@ export default function PriwaFieldMap({
       previewLayerRef.current = null;
       cogLayersRef.current = [];
     };
-  }, [openPointForEditing, stopUserLocation, userLocationLayer]);
+  }, [stopUserLocation, userLocationLayer]);
 
   useEffect(() => {
     aerialLayerRef.current?.setVisible(baseLayer === "aerial");
@@ -545,6 +517,20 @@ export default function PriwaFieldMap({
     });
   }, []);
 
+  const focusPointOnMap = useCallback(
+    (point: IPriwaPoint) => {
+      selectMatchedMosaicForPoint(point);
+      zoomToCoordinate(point);
+    },
+    [selectMatchedMosaicForPoint, zoomToCoordinate],
+  );
+
+  const openPointInTable = useCallback((point: IPriwaPoint) => {
+    setFocusedPointId(point.id);
+    setLayerPanelOpen(false);
+    setPointListOpen(true);
+  }, []);
+
   const zoomToMosaicFootprint = useCallback((mosaic: IPriwaMosaic) => {
     if (!mosaic.bbox) {
       message.warning(
@@ -643,8 +629,7 @@ export default function PriwaFieldMap({
   const pointListToggleLabel = isPointListOpen
     ? "Punktliste schließen"
     : "Punktliste öffnen";
-  const mosaicCount = visibleMosaics.length;
-  const enabledMosaicCount = enabledMosaics.length;
+  const isMatchingMosaics = isCogLoading || isLoadingPoints;
 
   const setMosaicVisibility = useCallback(
     (mosaicId: string, checked: boolean) => {
@@ -716,140 +701,22 @@ export default function PriwaFieldMap({
   }, [clearOfflineBasemapArea]);
 
   const layerPanel = (
-    <div className="w-[21rem] max-w-[calc(100vw-3rem)] space-y-3">
-      <div>
-        <Typography.Text strong>Layer</Typography.Text>
-        <div className="text-xs text-gray-500">
-          PRIWA Punkte bleiben immer sichtbar.
-        </div>
-      </div>
-      <div>
-        <div className="mb-1 text-sm font-medium text-gray-900">
-          Kartenbasis
-        </div>
-        <Segmented<PriwaBaseLayer>
-          block
-          size="small"
-          value={baseLayer}
-          options={[
-            { label: "Luftbild", value: "aerial" },
-            { label: "Karte", value: "topographic" },
-          ]}
-          onChange={setBaseLayer}
-        />
-      </div>
-      <div>
-        <div className="text-sm font-medium text-gray-900">Drohnenlayer</div>
-        <div className="text-xs text-gray-500">
-          {isCogLoading
-            ? "Lade Drohnenlayer..."
-            : mosaicCount > 0
-              ? `${enabledMosaicCount} von ${mosaicCount} Befliegung${
-                  mosaicCount === 1 ? "" : "en"
-                } sichtbar`
-              : "Keine Drohnenlayer hinterlegt"}
-        </div>
-        {cogErrorMessage && (
-          <div className="mt-1 text-xs text-red-600">{cogErrorMessage}</div>
-        )}
-        {mosaicCount > 0 && (
-          <div className="mt-2 max-h-80 space-y-2 overflow-y-auto pr-1">
-            {visibleMosaics.map((mosaic) => {
-              const isVisible = enabledMosaicIds.has(mosaic.id);
-              const isSelected = mosaic.id === selectedMosaicId;
-              const isHovered = mosaic.id === hoveredMosaicId;
-              const captureDate = formatPriwaMosaicDate(mosaic.captureDate);
-              const uploadDate = formatPriwaMosaicDate(mosaic.createdAt);
-              const authors =
-                mosaic.authors.length > 0
-                  ? mosaic.authors.join(", ")
-                  : "Keine Autorenangabe";
-
-              return (
-                <div
-                  key={mosaic.id}
-                  className={`rounded-md border bg-white px-2 py-2 ${
-                    isSelected
-                      ? "border-orange-500 ring-2 ring-orange-200"
-                      : isHovered
-                        ? "border-sky-500 ring-2 ring-sky-200"
-                        : "border-slate-200"
-                  }`}
-                  onClick={() => setSelectedMosaicId(mosaic.id)}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="flex min-w-0 items-center gap-1.5">
-                        <div className="truncate text-sm font-medium text-slate-950">
-                          {mosaic.label}
-                        </div>
-                        {isHovered && (
-                          <span className="shrink-0 rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[0.65rem] font-medium uppercase leading-none text-sky-700">
-                            Karte
-                          </span>
-                        )}
-                      </div>
-                      <div className="mt-0.5 text-xs text-slate-500">
-                        Aufnahme: {captureDate ?? "ohne Datum"} · Upload:{" "}
-                        {uploadDate ?? "ohne Datum"}
-                      </div>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      <Tooltip title="Kartengrenze anzeigen">
-                        <Button
-                          size="small"
-                          icon={<AimOutlined />}
-                          aria-label={`${mosaic.label} auf Karte zeigen`}
-                          disabled={!mosaic.bbox}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            zoomToMosaicFootprint(mosaic);
-                          }}
-                        />
-                      </Tooltip>
-                      <Switch
-                        size="small"
-                        checked={isVisible}
-                        aria-label={`${mosaic.label} anzeigen`}
-                        onClick={(_, event) => event.stopPropagation()}
-                        onChange={(checked) =>
-                          setMosaicVisibility(mosaic.id, checked)
-                        }
-                      />
-                    </div>
-                  </div>
-                  <details className="mt-1 text-xs text-slate-500">
-                    <summary className="cursor-pointer select-none">
-                      Details
-                    </summary>
-                    <dl className="mt-1 grid grid-cols-[5.5rem_minmax(0,1fr)] gap-x-2 gap-y-1">
-                      <dt className="text-slate-400">Autoren</dt>
-                      <dd className="min-w-0 break-words">{authors}</dd>
-                      <dt className="text-slate-400">Dataset ID</dt>
-                      <dd className="min-w-0 break-all">{mosaic.id}</dd>
-                      <dt className="text-slate-400">Kartengrenze</dt>
-                      <dd className="min-w-0 break-words">
-                        {mosaic.bbox ? "verfügbar" : "nicht verfügbar"}
-                      </dd>
-                      {mosaic.additionalInformation && (
-                        <>
-                          <dt className="text-slate-400">Info</dt>
-                          <dd className="min-w-0 break-words">
-                            {mosaic.additionalInformation}
-                          </dd>
-                        </>
-                      )}
-                      <dt className="text-slate-400">COG</dt>
-                      <dd className="min-w-0 break-all">{mosaic.cogUrl}</dd>
-                    </dl>
-                  </details>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    </div>
+    <PriwaLayerPanel
+      baseLayer={baseLayer}
+      candidateMosaicCount={candidateCount}
+      matchedMosaics={matchedMosaics}
+      enabledMosaicIds={enabledMosaicIds}
+      selectedMosaicId={selectedMosaicId}
+      hoveredMosaicId={hoveredMosaicId}
+      isLoading={isMatchingMosaics}
+      isOpen={isLayerPanelOpen}
+      errorMessage={cogErrorMessage}
+      onBaseLayerChange={setBaseLayer}
+      onSelectMosaic={setSelectedMosaicId}
+      onSetMosaicVisibility={setMosaicVisibility}
+      onZoomToMosaic={zoomToMosaicFootprint}
+      onOpenPointInTable={openPointInTable}
+    />
   );
 
   const offlineMapPanel = (
@@ -999,9 +866,10 @@ export default function PriwaFieldMap({
                 size="large"
                 icon={<UnorderedListOutlined />}
                 aria-pressed={isPointListOpen}
-                onClick={() =>
-                  setPointListOpen((currentIsOpen) => !currentIsOpen)
-                }
+                onClick={() => {
+                  setFocusedPointId(null);
+                  setPointListOpen((currentIsOpen) => !currentIsOpen);
+                }}
                 aria-label={pointListToggleLabel}
               />
             </Tooltip>
@@ -1031,9 +899,13 @@ export default function PriwaFieldMap({
           points={points}
           projectName={projectName}
           isLoading={isLoadingPoints}
-          onClose={() => setPointListOpen(false)}
+          focusedPointId={focusedPointId}
+          onClose={() => {
+            setFocusedPointId(null);
+            setPointListOpen(false);
+          }}
           onEditPoint={openPointForEditing}
-          onZoomToPoint={zoomToCoordinate}
+          onZoomToPoint={focusPointOnMap}
         />
       )}
 

--- a/frontend/src/components/PriwaField/PriwaLayerPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaLayerPanel.tsx
@@ -1,0 +1,248 @@
+import { AimOutlined, TableOutlined } from "@ant-design/icons";
+import { Button, Segmented, Switch, Tooltip, Typography } from "antd";
+import { useEffect, useRef } from "react";
+
+import type { IPriwaMatchedMosaic } from "./usePriwaMosaicMatches";
+import type { IPriwaPoint } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+
+export type PriwaBaseLayer = "aerial" | "topographic";
+
+interface PriwaLayerPanelProps {
+  baseLayer: PriwaBaseLayer;
+  candidateMosaicCount: number;
+  matchedMosaics: IPriwaMatchedMosaic[];
+  enabledMosaicIds: ReadonlySet<string>;
+  selectedMosaicId: string | null;
+  hoveredMosaicId: string | null;
+  isLoading: boolean;
+  isOpen: boolean;
+  errorMessage: string | null;
+  onBaseLayerChange: (baseLayer: PriwaBaseLayer) => void;
+  onSelectMosaic: (mosaicId: string) => void;
+  onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
+  onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
+  onOpenPointInTable: (point: IPriwaPoint) => void;
+}
+
+const formatPriwaDate = (value: string | null | undefined) => {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  return match ? `${match[3]}.${match[2]}.${match[1]}` : value;
+};
+
+const daysApartLabel = ({ minDaysApart, maxDaysApart }: IPriwaMatchedMosaic) =>
+  minDaysApart === maxDaysApart
+    ? `${minDaysApart} ${minDaysApart === 1 ? "Tag" : "Tage"} Abstand`
+    : `${minDaysApart}–${maxDaysApart} Tage Abstand`;
+
+export default function PriwaLayerPanel({
+  baseLayer,
+  candidateMosaicCount,
+  matchedMosaics,
+  enabledMosaicIds,
+  selectedMosaicId,
+  hoveredMosaicId,
+  isLoading,
+  isOpen,
+  errorMessage,
+  onBaseLayerChange,
+  onSelectMosaic,
+  onSetMosaicVisibility,
+  onZoomToMosaic,
+  onOpenPointInTable,
+}: PriwaLayerPanelProps) {
+  const mosaicListRef = useRef<HTMLDivElement | null>(null);
+  const visibleCount = matchedMosaics.filter(({ mosaic }) =>
+    enabledMosaicIds.has(mosaic.id),
+  ).length;
+
+  useEffect(() => {
+    if (!isOpen || !selectedMosaicId) return;
+    const frame = window.requestAnimationFrame(() => {
+      const selectedCard = mosaicListRef.current?.querySelector<HTMLElement>(
+        `[data-mosaic-id="${CSS.escape(selectedMosaicId)}"]`,
+      );
+      selectedCard?.scrollIntoView({ block: "nearest" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen, selectedMosaicId]);
+
+  return (
+    <div className="w-[21rem] max-w-[calc(100vw-3rem)] space-y-3">
+      <div>
+        <Typography.Text strong>Layer</Typography.Text>
+        <div className="text-xs text-gray-500">
+          PRIWA Punkte bleiben immer sichtbar.
+        </div>
+      </div>
+      <div>
+        <div className="mb-1 text-sm font-medium text-gray-900">
+          Kartenbasis
+        </div>
+        <Segmented<PriwaBaseLayer>
+          block
+          size="small"
+          value={baseLayer}
+          options={[
+            { label: "Luftbild", value: "aerial" },
+            { label: "Karte", value: "topographic" },
+          ]}
+          onChange={onBaseLayerChange}
+        />
+      </div>
+      <div>
+        <div className="text-sm font-medium text-gray-900">
+          Umfeldbefliegungen
+        </div>
+        <div className="text-xs text-gray-500">
+          {isLoading
+            ? "Ordne Befliegungen den Bäumen zu..."
+            : matchedMosaics.length > 0
+              ? `${visibleCount} von ${matchedMosaics.length} Befliegung${
+                  matchedMosaics.length === 1 ? "" : "en"
+                } sichtbar`
+              : candidateMosaicCount > 0
+                ? "Keine räumlich und zeitlich passende Befliegung"
+                : "Keine Drohnenlayer hinterlegt"}
+        </div>
+        {errorMessage && (
+          <div className="mt-1 text-xs text-red-600">{errorMessage}</div>
+        )}
+        {matchedMosaics.length > 0 && (
+          <div
+            ref={mosaicListRef}
+            className="mt-2 max-h-80 space-y-2 overflow-y-auto pr-1"
+          >
+            {matchedMosaics.map((matchedMosaic) => {
+              const { mosaic, points } = matchedMosaic;
+              const isVisible = enabledMosaicIds.has(mosaic.id);
+              const isSelected = mosaic.id === selectedMosaicId;
+              const isHovered = mosaic.id === hoveredMosaicId;
+              const authors = mosaic.authors.length
+                ? mosaic.authors.join(", ")
+                : "Keine Autorenangabe";
+
+              return (
+                <div
+                  key={mosaic.id}
+                  data-mosaic-id={mosaic.id}
+                  aria-current={isSelected ? "true" : undefined}
+                  className={`rounded-md border bg-white px-2 py-2 ${
+                    isSelected
+                      ? "border-orange-500 ring-2 ring-orange-200"
+                      : isHovered
+                        ? "border-sky-500 ring-2 ring-sky-200"
+                        : "border-slate-200"
+                  }`}
+                  onClick={() => onSelectMosaic(mosaic.id)}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <div className="truncate text-sm font-medium text-slate-950">
+                          {mosaic.label}
+                        </div>
+                        {isHovered && (
+                          <span className="shrink-0 rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[0.65rem] font-medium uppercase leading-none text-sky-700">
+                            Karte
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-0.5 text-xs text-slate-500">
+                        Aufnahme:{" "}
+                        {formatPriwaDate(mosaic.captureDate) ?? "ohne Datum"} ·
+                        Upload:{" "}
+                        {formatPriwaDate(mosaic.createdAt) ?? "ohne Datum"}
+                      </div>
+                      <div className="mt-0.5 text-xs font-medium text-emerald-700">
+                        {points.length} Baum{points.length === 1 ? "" : "e"} ·{" "}
+                        {daysApartLabel(matchedMosaic)}
+                      </div>
+                      <div className="mt-1.5 rounded border border-emerald-100 bg-emerald-50/70 px-2 py-1.5">
+                        <div className="text-[0.7rem] font-semibold uppercase tracking-wide text-emerald-800">
+                          Zugeordnete Käferbäume
+                        </div>
+                        <ul className="mt-1 space-y-0.5">
+                          {points.map(({ point }) => (
+                            <li key={point.id}>
+                              <button
+                                type="button"
+                                className="group flex w-full items-center gap-2 rounded px-1 py-1 text-left text-xs transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-600"
+                                aria-label={`${point.baumnr ? `Baum ${point.baumnr}` : "Baum ohne Nummer"} in Käferbaumtabelle anzeigen`}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  onOpenPointInTable(point);
+                                }}
+                              >
+                                <span className="min-w-0 flex-1 truncate font-medium text-slate-700 group-hover:text-emerald-800">
+                                  {point.baumnr
+                                    ? `Baum ${point.baumnr}`
+                                    : "Ohne Baumnr"}
+                                </span>
+                                <span className="shrink-0 tabular-nums text-slate-500">
+                                  {formatPriwaDate(point.datum) ?? "ohne Datum"}
+                                </span>
+                                <TableOutlined className="shrink-0 text-emerald-700" />
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <Tooltip title="Kartengrenze anzeigen">
+                        <Button
+                          size="small"
+                          icon={<AimOutlined />}
+                          aria-label={`${mosaic.label} auf Karte zeigen`}
+                          disabled={!mosaic.bbox}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onZoomToMosaic(mosaic);
+                          }}
+                        />
+                      </Tooltip>
+                      <Switch
+                        size="small"
+                        checked={isVisible}
+                        aria-label={`${mosaic.label} anzeigen`}
+                        onClick={(_, event) => event.stopPropagation()}
+                        onChange={(checked) =>
+                          onSetMosaicVisibility(mosaic.id, checked)
+                        }
+                      />
+                    </div>
+                  </div>
+                  <details className="mt-1 text-xs text-slate-500">
+                    <summary className="cursor-pointer select-none">
+                      Details
+                    </summary>
+                    <dl className="mt-1 grid grid-cols-[5.5rem_minmax(0,1fr)] gap-x-2 gap-y-1">
+                      <dt className="text-slate-400">Autoren</dt>
+                      <dd className="min-w-0 break-words">{authors}</dd>
+                      <dt className="text-slate-400">Dataset ID</dt>
+                      <dd className="min-w-0 break-all">{mosaic.id}</dd>
+                      <dt className="text-slate-400">Kartengrenze</dt>
+                      <dd>{mosaic.bbox ? "verfügbar" : "nicht verfügbar"}</dd>
+                      {mosaic.additionalInformation && (
+                        <>
+                          <dt className="text-slate-400">Info</dt>
+                          <dd className="min-w-0 break-words">
+                            {mosaic.additionalInformation}
+                          </dd>
+                        </>
+                      )}
+                      <dt className="text-slate-400">COG</dt>
+                      <dd className="min-w-0 break-all">{mosaic.cogUrl}</dd>
+                    </dl>
+                  </details>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointCompactList.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointCompactList.tsx
@@ -1,0 +1,95 @@
+import {
+  AimOutlined,
+  CheckCircleFilled,
+  EditOutlined,
+  WarningFilled,
+} from "@ant-design/icons";
+import { Button, Tag } from "antd";
+
+import {
+  getPriwaFundLabel,
+  getPriwaPointSourceLabel,
+  getPriwaPointTitle,
+  isPriwaPointQaCandidate,
+} from "./priwaPointQa";
+import type { IPriwaPoint } from "./types";
+
+interface PriwaPointCompactListProps {
+  points: IPriwaPoint[];
+  onEditPoint: (point: IPriwaPoint) => void;
+  onZoomToPoint: (point: IPriwaPoint) => void;
+}
+
+export default function PriwaPointCompactList({
+  points,
+  onEditPoint,
+  onZoomToPoint,
+}: PriwaPointCompactListProps) {
+  return (
+    <div className="divide-y divide-slate-100">
+      {points.map((point) => {
+        const isQa = isPriwaPointQaCandidate(point);
+        return (
+          <article
+            key={point.id}
+            className="grid grid-cols-[1fr_auto] gap-2 px-3 py-2.5"
+          >
+            <button
+              type="button"
+              className="min-w-0 text-left"
+              onClick={() => onZoomToPoint(point)}
+            >
+              <div className="flex min-w-0 items-center gap-1.5">
+                {isQa ? (
+                  <WarningFilled className="shrink-0 text-amber-500" />
+                ) : (
+                  <CheckCircleFilled className="shrink-0 text-emerald-600" />
+                )}
+                <span className="truncate text-sm font-semibold text-slate-950">
+                  {getPriwaPointTitle(point)}
+                </span>
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                <Tag
+                  className="m-0"
+                  color={point.coordinateSource === "qr" ? "green" : "gold"}
+                >
+                  {getPriwaPointSourceLabel(point)}
+                </Tag>
+                <Tag className="m-0">{getPriwaFundLabel(point)}</Tag>
+                {point.syncStatus && point.syncStatus !== "synced" && (
+                  <Tag
+                    className="m-0"
+                    color={point.syncStatus === "failed" ? "red" : "blue"}
+                  >
+                    {point.syncStatus === "failed" ? "Fehler" : "Lokal"}
+                  </Tag>
+                )}
+                <span className="text-xs text-slate-500">{point.baumart}</span>
+                <span className="text-xs text-slate-400">·</span>
+                <span className="text-xs text-slate-500">{point.name}</span>
+              </div>
+              <div className="mt-1 truncate text-xs text-slate-500">
+                {point.lat.toFixed(5)}, {point.lon.toFixed(5)} · {point.datum}
+              </div>
+            </button>
+            <div className="flex items-start gap-1">
+              <Button
+                aria-label="Punkt auf Karte zeigen"
+                icon={<AimOutlined />}
+                size="small"
+                onClick={() => onZoomToPoint(point)}
+              />
+              <Button
+                aria-label="Punkt bearbeiten"
+                icon={<EditOutlined />}
+                size="small"
+                onClick={() => onEditPoint(point)}
+              />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,30 +1,38 @@
-import {
-  AimOutlined,
-  CheckCircleFilled,
-  DownloadOutlined,
-  EditOutlined,
-  EnvironmentOutlined,
-  WarningFilled,
-} from "@ant-design/icons";
-import { Button, Empty, Segmented, Table, Tag } from "antd";
-import type { TableProps } from "antd";
-import { useMemo, useState } from "react";
+import { DownloadOutlined, EnvironmentOutlined } from "@ant-design/icons";
+import { Button, Empty, Segmented } from "antd";
+import { useEffect, useMemo, useRef, useState } from "react";
 
+import PriwaPointCompactList from "./PriwaPointCompactList";
+import PriwaPointTable from "./PriwaPointTable";
 import { downloadPriwaPointsCsv } from "./priwaPointCsv";
-import {
-  getPriwaFundLabel,
-  getPriwaPointSourceLabel,
-  getPriwaPointTitle,
-  isPriwaPointQaCandidate,
-} from "./priwaPointQa";
+import { isPriwaPointQaCandidate } from "./priwaPointQa";
 import type { IPriwaPoint } from "./types";
 
 type PriwaPointFilter = "all" | "qa";
+type PriwaPointView = "list" | "table";
+
+const PRIWA_POINT_VIEW_STORAGE_KEY = "deadtrees-priwa-field:point-view";
+
+const loadInitialPointView = (): PriwaPointView => {
+  if (typeof window === "undefined") return "table";
+
+  try {
+    const storedView = window.localStorage.getItem(
+      PRIWA_POINT_VIEW_STORAGE_KEY,
+    );
+    if (storedView === "list" || storedView === "table") return storedView;
+  } catch {
+    // Local storage may be unavailable in privacy-restricted browsers.
+  }
+
+  return window.matchMedia("(max-width: 767px)").matches ? "list" : "table";
+};
 
 interface PriwaPointListPanelProps {
   points: IPriwaPoint[];
   projectName: string;
   isLoading?: boolean;
+  focusedPointId?: string | null;
   onClose: () => void;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
@@ -34,11 +42,14 @@ export default function PriwaPointListPanel({
   points,
   projectName,
   isLoading = false,
+  focusedPointId = null,
   onClose,
   onEditPoint,
   onZoomToPoint,
 }: PriwaPointListPanelProps) {
   const [filter, setFilter] = useState<PriwaPointFilter>("all");
+  const [view, setView] = useState<PriwaPointView>(loadInitialPointView);
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const qaPoints = useMemo(
     () => points.filter(isPriwaPointQaCandidate),
     [points],
@@ -47,153 +58,55 @@ export default function PriwaPointListPanel({
     (point) => point.coordinateSource === "qr",
   ).length;
   const visiblePoints = filter === "qa" ? qaPoints : points;
+  const focusedPoint = useMemo(
+    () => points.find((point) => point.id === focusedPointId) ?? null,
+    [focusedPointId, points],
+  );
   const pendingSyncCount = points.filter(
     (point) => point.syncStatus && point.syncStatus !== "synced",
   ).length;
-  const columns = useMemo<TableProps<IPriwaPoint>["columns"]>(
-    () => [
-      {
-        title: "Status",
-        key: "status",
-        width: 92,
-        render: (_, point) => {
-          const isQa = isPriwaPointQaCandidate(point);
-          return (
-            <div className="flex items-center gap-1.5">
-              {isQa ? (
-                <WarningFilled className="text-amber-500" />
-              ) : (
-                <CheckCircleFilled className="text-emerald-600" />
-              )}
-              <Tag
-                className="m-0"
-                color={point.coordinateSource === "qr" ? "green" : "gold"}
-              >
-                {getPriwaPointSourceLabel(point)}
-              </Tag>
-            </div>
-          );
-        },
-      },
-      {
-        title: "Baumnr",
-        dataIndex: "baumnr",
-        width: 110,
-        render: (_, point) => getPriwaPointTitle(point),
-      },
-      {
-        title: "Datum",
-        dataIndex: "datum",
-        width: 118,
-      },
-      {
-        title: "Baumart",
-        dataIndex: "baumart",
-        width: 150,
-      },
-      {
-        title: "Fund",
-        dataIndex: "fund",
-        width: 150,
-        render: (_, point) => getPriwaFundLabel(point),
-      },
-      {
-        title: "Bohrmehl",
-        dataIndex: "bm",
-        width: 105,
-      },
-      {
-        title: "Bohrloch",
-        dataIndex: "bohrloch",
-        width: 150,
-      },
-      {
-        title: "Harz",
-        dataIndex: "harz",
-        width: 190,
-      },
-      {
-        title: "Grüne Nadeln",
-        dataIndex: "grueneNadelnAmBoden",
-        width: 130,
-      },
-      {
-        title: "Nadelverfärbung",
-        dataIndex: "nadel",
-        width: 160,
-      },
-      {
-        title: "Rindenverlust",
-        dataIndex: "rinde",
-        width: 125,
-      },
-      {
-        title: "Nadelverlust",
-        dataIndex: "kv",
-        width: 125,
-      },
-      {
-        title: "Name",
-        dataIndex: "name",
-        width: 150,
-      },
-      {
-        title: "Koordinaten",
-        key: "coordinates",
-        width: 190,
-        render: (_, point) => `${point.lat.toFixed(5)}, ${point.lon.toFixed(5)}`,
-      },
-      {
-        title: "Kommentar",
-        dataIndex: "kom",
-        width: 220,
-        ellipsis: true,
-      },
-      {
-        title: "",
-        key: "actions",
-        fixed: "right",
-        width: 88,
-        render: (_, point) => (
-          <div className="flex items-center gap-1">
-            <Button
-              aria-label="Punkt auf Karte zeigen"
-              icon={<AimOutlined />}
-              size="small"
-              onClick={(event) => {
-                event.stopPropagation();
-                onZoomToPoint(point);
-              }}
-            />
-            <Button
-              aria-label="Punkt bearbeiten"
-              icon={<EditOutlined />}
-              size="small"
-              onClick={(event) => {
-                event.stopPropagation();
-                onEditPoint(point);
-              }}
-            />
-          </div>
-        ),
-      },
-    ],
-    [onEditPoint, onZoomToPoint],
-  );
-  const emptyDescription =
-    isLoading
-      ? "Lade Punkte..."
-      : filter === "qa" && points.length > 0
-        ? "Keine QA-Punkte"
-        : "Keine Punkte";
+  const emptyDescription = isLoading
+    ? "Lade Punkte..."
+    : filter === "qa" && points.length > 0
+      ? "Keine QA-Punkte"
+      : "Keine Punkte";
+
+  const changeView = (nextView: PriwaPointView) => {
+    setView(nextView);
+    try {
+      window.localStorage.setItem(PRIWA_POINT_VIEW_STORAGE_KEY, nextView);
+    } catch {
+      // The selected view still applies for the current session.
+    }
+  };
+
+  useEffect(() => {
+    if (!focusedPointId) return;
+
+    setFilter("all");
+    setView("table");
+  }, [focusedPointId]);
+
+  useEffect(() => {
+    if (!focusedPointId || view !== "table" || filter !== "all") return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const focusedRow = Array.from(
+        contentRef.current?.querySelectorAll<HTMLElement>("[data-row-key]") ??
+          [],
+      ).find((row) => row.dataset.rowKey === focusedPointId);
+
+      focusedRow?.scrollIntoView({ block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [filter, focusedPointId, view, visiblePoints]);
 
   return (
     <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[64dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-4 md:top-24 md:max-h-[calc(100dvh-8rem)]">
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-slate-950">
-            Käferbäume
-          </div>
+          <div className="text-sm font-semibold text-slate-950">Käferbäume</div>
           <div className="truncate text-xs text-slate-500">
             {projectName}
             {pendingSyncCount > 0 ? ` · ${pendingSyncCount} lokal` : ""}
@@ -216,33 +129,69 @@ export default function PriwaPointListPanel({
 
       <div className="grid grid-cols-3 border-b border-slate-200 text-center text-xs">
         <div className="px-2 py-2">
-          <div className="text-base font-semibold text-slate-950">{points.length}</div>
+          <div className="text-base font-semibold text-slate-950">
+            {points.length}
+          </div>
           <div className="text-slate-500">Gesamt</div>
         </div>
         <div className="border-x border-slate-200 px-2 py-2">
-          <div className="text-base font-semibold text-emerald-700">{exactCount}</div>
+          <div className="text-base font-semibold text-emerald-700">
+            {exactCount}
+          </div>
           <div className="text-slate-500">Exakt</div>
         </div>
         <div className="px-2 py-2">
-          <div className="text-base font-semibold text-amber-700">{qaPoints.length}</div>
+          <div className="text-base font-semibold text-amber-700">
+            {qaPoints.length}
+          </div>
           <div className="text-slate-500">QA</div>
         </div>
       </div>
 
-      <div className="border-b border-slate-200 px-3 py-2">
-        <Segmented
-          block
-          size="small"
-          value={filter}
-          onChange={(value) => setFilter(value as PriwaPointFilter)}
-          options={[
-            { label: "Alle", value: "all" },
-            { label: "QA prüfen", value: "qa" },
-          ]}
-        />
+      <div className="grid gap-2 border-b border-slate-200 px-3 py-2 md:grid-cols-2">
+        <div>
+          <div className="mb-1 text-xs font-medium text-slate-500">Ansicht</div>
+          <Segmented<PriwaPointView>
+            aria-label="Punktlistenansicht"
+            block
+            size="small"
+            value={view}
+            onChange={changeView}
+            options={[
+              { label: "Liste", value: "list" },
+              { label: "Tabelle", value: "table" },
+            ]}
+          />
+        </div>
+        <div>
+          <div className="mb-1 text-xs font-medium text-slate-500">Filter</div>
+          <Segmented<PriwaPointFilter>
+            aria-label="Punktlistenfilter"
+            block
+            size="small"
+            value={filter}
+            onChange={setFilter}
+            options={[
+              { label: "Alle", value: "all" },
+              { label: "QA prüfen", value: "qa" },
+            ]}
+          />
+        </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      {focusedPoint && (
+        <div className="border-b border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900">
+          Aus Umfeldbefliegung geöffnet:{" "}
+          <strong>
+            {focusedPoint.baumnr
+              ? `Baum ${focusedPoint.baumnr}`
+              : "Baum ohne Nummer"}
+          </strong>{" "}
+          ist in der Tabelle hervorgehoben.
+        </div>
+      )}
+
+      <div ref={contentRef} className="min-h-0 flex-1 overflow-y-auto">
         {visiblePoints.length === 0 ? (
           <div className="px-3 py-8">
             <Empty
@@ -250,18 +199,18 @@ export default function PriwaPointListPanel({
               description={emptyDescription}
             />
           </div>
+        ) : view === "list" ? (
+          <PriwaPointCompactList
+            points={visiblePoints}
+            onEditPoint={onEditPoint}
+            onZoomToPoint={onZoomToPoint}
+          />
         ) : (
-          <Table<IPriwaPoint>
-            size="small"
-            rowKey="id"
-            columns={columns}
-            dataSource={visiblePoints}
-            pagination={false}
-            scroll={{ x: "max-content" }}
-            rowClassName="cursor-pointer"
-            onRow={(point) => ({
-              onClick: () => onZoomToPoint(point),
-            })}
+          <PriwaPointTable
+            points={visiblePoints}
+            focusedPointId={focusedPointId}
+            onEditPoint={onEditPoint}
+            onZoomToPoint={onZoomToPoint}
           />
         )}
       </div>

--- a/frontend/src/components/PriwaField/PriwaPointTable.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointTable.tsx
@@ -1,0 +1,144 @@
+import {
+  AimOutlined,
+  CheckCircleFilled,
+  EditOutlined,
+  WarningFilled,
+} from "@ant-design/icons";
+import { Button, Table, Tag } from "antd";
+import type { TableProps } from "antd";
+import { useMemo } from "react";
+
+import {
+  getPriwaFundLabel,
+  getPriwaPointSourceLabel,
+  getPriwaPointTitle,
+  isPriwaPointQaCandidate,
+} from "./priwaPointQa";
+import type { IPriwaPoint } from "./types";
+
+interface PriwaPointTableProps {
+  points: IPriwaPoint[];
+  focusedPointId?: string | null;
+  onEditPoint: (point: IPriwaPoint) => void;
+  onZoomToPoint: (point: IPriwaPoint) => void;
+}
+
+export default function PriwaPointTable({
+  points,
+  focusedPointId = null,
+  onEditPoint,
+  onZoomToPoint,
+}: PriwaPointTableProps) {
+  const columns = useMemo<TableProps<IPriwaPoint>["columns"]>(
+    () => [
+      {
+        title: "Status",
+        key: "status",
+        width: 92,
+        render: (_, point) => {
+          const isQa = isPriwaPointQaCandidate(point);
+          return (
+            <div className="flex items-center gap-1.5">
+              {isQa ? (
+                <WarningFilled className="text-amber-500" />
+              ) : (
+                <CheckCircleFilled className="text-emerald-600" />
+              )}
+              <Tag
+                className="m-0"
+                color={point.coordinateSource === "qr" ? "green" : "gold"}
+              >
+                {getPriwaPointSourceLabel(point)}
+              </Tag>
+            </div>
+          );
+        },
+      },
+      {
+        title: "Baumnr",
+        dataIndex: "baumnr",
+        width: 110,
+        render: (_, point) => getPriwaPointTitle(point),
+      },
+      { title: "Datum", dataIndex: "datum", width: 118 },
+      { title: "Baumart", dataIndex: "baumart", width: 150 },
+      {
+        title: "Fund",
+        dataIndex: "fund",
+        width: 150,
+        render: (_, point) => getPriwaFundLabel(point),
+      },
+      { title: "Bohrmehl", dataIndex: "bm", width: 105 },
+      { title: "Bohrloch", dataIndex: "bohrloch", width: 150 },
+      { title: "Harz", dataIndex: "harz", width: 190 },
+      {
+        title: "Grüne Nadeln",
+        dataIndex: "grueneNadelnAmBoden",
+        width: 130,
+      },
+      { title: "Nadelverfärbung", dataIndex: "nadel", width: 160 },
+      { title: "Rindenverlust", dataIndex: "rinde", width: 125 },
+      { title: "Nadelverlust", dataIndex: "kv", width: 125 },
+      { title: "Name", dataIndex: "name", width: 150 },
+      {
+        title: "Koordinaten",
+        key: "coordinates",
+        width: 190,
+        render: (_, point) =>
+          `${point.lat.toFixed(5)}, ${point.lon.toFixed(5)}`,
+      },
+      {
+        title: "Kommentar",
+        dataIndex: "kom",
+        width: 220,
+        ellipsis: true,
+      },
+      {
+        title: "",
+        key: "actions",
+        fixed: "right",
+        width: 88,
+        render: (_, point) => (
+          <div className="flex items-center gap-1">
+            <Button
+              aria-label="Punkt auf Karte zeigen"
+              icon={<AimOutlined />}
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onZoomToPoint(point);
+              }}
+            />
+            <Button
+              aria-label="Punkt bearbeiten"
+              icon={<EditOutlined />}
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation();
+                onEditPoint(point);
+              }}
+            />
+          </div>
+        ),
+      },
+    ],
+    [onEditPoint, onZoomToPoint],
+  );
+
+  return (
+    <Table<IPriwaPoint>
+      size="small"
+      rowKey="id"
+      columns={columns}
+      dataSource={points}
+      pagination={false}
+      scroll={{ x: "max-content" }}
+      rowClassName={(point) =>
+        point.id === focusedPointId
+          ? "priwa-point-table-row-focused cursor-pointer"
+          : "cursor-pointer"
+      }
+      onRow={(point) => ({ onClick: () => onZoomToPoint(point) })}
+    />
+  );
+}

--- a/frontend/src/components/PriwaField/priwaMosaicMatching.test.ts
+++ b/frontend/src/components/PriwaField/priwaMosaicMatching.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import type { IPriwaPoint } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+import {
+  PRIWA_MOSAIC_MATCH_MAX_DAYS,
+  matchPriwaPointsToMosaics,
+} from "./priwaMosaicMatching";
+
+const point = (overrides: Partial<IPriwaPoint> = {}): IPriwaPoint => ({
+  id: "point-1",
+  lat: 48.45,
+  lon: 8.15,
+  baumnr: "101",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "ja",
+  bohrloch: "ja",
+  harz: "nein",
+  grueneNadelnAmBoden: "nein",
+  nadel: "grün",
+  rinde: "0%",
+  kv: "0%",
+  name: "andere",
+  datum: "2026-06-15",
+  kom: "",
+  capturedAt: "2026-06-15T08:00:00.000Z",
+  coordinateSource: "qr",
+  gps: "ja",
+  ...overrides,
+});
+
+const mosaic = (overrides: Partial<IPriwaMosaic> = {}): IPriwaMosaic => ({
+  id: "mosaic-1",
+  projectId: "project-1",
+  label: "PRIWA flight",
+  cogUrl: "uploads/priwa-flight-cog.tif",
+  bbox: "BOX(8.10 48.40,8.20 48.50)",
+  captureDate: "2026-06-17",
+  createdAt: "2026-06-18T08:00:00.000Z",
+  authors: ["PRIWA"],
+  additionalInformation: null,
+  ...overrides,
+});
+
+describe("matchPriwaPointsToMosaics", () => {
+  it("matches a point inside the bbox to a nearby acquisition date", () => {
+    expect(matchPriwaPointsToMosaics([point()], [mosaic()])).toEqual([
+      {
+        pointId: "point-1",
+        mosaicId: "mosaic-1",
+        daysApart: 2,
+      },
+    ]);
+  });
+
+  it("includes points on bbox boundaries and excludes points outside", () => {
+    const boundaryPoint = point({ id: "boundary", lon: 8.1, lat: 48.4 });
+    const outsidePoint = point({ id: "outside", lon: 8.099, lat: 48.4 });
+
+    expect(
+      matchPriwaPointsToMosaics([boundaryPoint, outsidePoint], [mosaic()]),
+    ).toEqual([
+      {
+        pointId: "boundary",
+        mosaicId: "mosaic-1",
+        daysApart: 2,
+      },
+    ]);
+  });
+
+  it("includes the 30-day boundary and rejects more distant flights", () => {
+    const withinWindow = mosaic({ id: "within", captureDate: "2026-07-15" });
+    const outsideWindow = mosaic({ id: "outside", captureDate: "2026-07-16" });
+
+    expect(
+      matchPriwaPointsToMosaics(
+        [point()],
+        [outsideWindow, withinWindow],
+        PRIWA_MOSAIC_MATCH_MAX_DAYS,
+      ),
+    ).toEqual([
+      {
+        pointId: "point-1",
+        mosaicId: "within",
+        daysApart: 30,
+      },
+    ]);
+  });
+
+  it("chooses the closest acquisition date when multiple COGs overlap", () => {
+    const fiveDaysBefore = mosaic({
+      id: "before",
+      captureDate: "2026-06-10",
+    });
+    const oneDayAfter = mosaic({ id: "after", captureDate: "2026-06-16" });
+
+    expect(
+      matchPriwaPointsToMosaics([point()], [fiveDaysBefore, oneDayAfter]),
+    ).toEqual([
+      {
+        pointId: "point-1",
+        mosaicId: "after",
+        daysApart: 1,
+      },
+    ]);
+  });
+
+  it("uses newer acquisition and upload dates as deterministic tie-breakers", () => {
+    const olderCapture = mosaic({
+      id: "older-capture",
+      captureDate: "2026-06-14",
+      createdAt: "2026-06-20T00:00:00.000Z",
+    });
+    const newerCaptureOlderUpload = mosaic({
+      id: "newer-capture-old-upload",
+      captureDate: "2026-06-16",
+      createdAt: "2026-06-17T00:00:00.000Z",
+    });
+    const newerCaptureNewerUpload = mosaic({
+      id: "newer-capture-new-upload",
+      captureDate: "2026-06-16",
+      createdAt: "2026-06-18T00:00:00.000Z",
+    });
+
+    expect(
+      matchPriwaPointsToMosaics(
+        [point()],
+        [olderCapture, newerCaptureOlderUpload, newerCaptureNewerUpload],
+      ),
+    ).toEqual([
+      {
+        pointId: "point-1",
+        mosaicId: "newer-capture-new-upload",
+        daysApart: 1,
+      },
+    ]);
+  });
+
+  it("uses natural ID ordering when dates tie", () => {
+    const lowerId = mosaic({ id: "flight-2" });
+    const higherId = mosaic({ id: "flight-10" });
+
+    expect(matchPriwaPointsToMosaics([point()], [lowerId, higherId])).toEqual([
+      {
+        pointId: "point-1",
+        mosaicId: "flight-10",
+        daysApart: 2,
+      },
+    ]);
+  });
+
+  it("can associate several points with the same COG", () => {
+    expect(
+      matchPriwaPointsToMosaics(
+        [point(), point({ id: "point-2", datum: "2026-06-18" })],
+        [mosaic()],
+      ),
+    ).toEqual([
+      { pointId: "point-1", mosaicId: "mosaic-1", daysApart: 2 },
+      { pointId: "point-2", mosaicId: "mosaic-1", daysApart: 1 },
+    ]);
+  });
+
+  it("skips malformed or incomplete spatial and date metadata", () => {
+    expect(
+      matchPriwaPointsToMosaics(
+        [point(), point({ id: "bad-date-point", datum: "not-a-date" })],
+        [
+          mosaic({ id: "no-bbox", bbox: null }),
+          mosaic({ id: "bad-bbox", bbox: "invalid" }),
+          mosaic({ id: "no-date", captureDate: null }),
+          mosaic({ id: "bad-date", captureDate: "2026-02-31" }),
+        ],
+      ),
+    ).toEqual([]);
+  });
+
+  it("compares calendar days without daylight-saving offsets", () => {
+    expect(
+      matchPriwaPointsToMosaics(
+        [point({ datum: "2026-03-28" })],
+        [mosaic({ captureDate: "2026-03-30" })],
+      ),
+    ).toEqual([{ pointId: "point-1", mosaicId: "mosaic-1", daysApart: 2 }]);
+  });
+});

--- a/frontend/src/components/PriwaField/priwaMosaicMatching.ts
+++ b/frontend/src/components/PriwaField/priwaMosaicMatching.ts
@@ -1,0 +1,121 @@
+import parseBBox from "../../utils/parseBBox";
+
+import type { IPriwaPoint } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const PRIWA_MOSAIC_MATCH_MAX_DAYS = 30;
+
+export interface IPriwaPointMosaicMatch {
+  pointId: string;
+  mosaicId: string;
+  daysApart: number;
+}
+
+interface IPriwaMosaicCandidate {
+  mosaic: IPriwaMosaic;
+  captureDay: number;
+  daysApart: number;
+}
+
+const dateOnlyToUtcDay = (value: string | null | undefined) => {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const parsed = new Date(timestamp);
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return Math.floor(timestamp / MILLISECONDS_PER_DAY);
+};
+
+const compareCandidates = (
+  left: IPriwaMosaicCandidate,
+  right: IPriwaMosaicCandidate,
+) => {
+  const dayDifference = left.daysApart - right.daysApart;
+  if (dayDifference !== 0) return dayDifference;
+
+  const captureDifference = right.captureDay - left.captureDay;
+  if (captureDifference !== 0) return captureDifference;
+
+  const uploadDifference =
+    Date.parse(right.mosaic.createdAt) - Date.parse(left.mosaic.createdAt);
+  if (!Number.isNaN(uploadDifference) && uploadDifference !== 0) {
+    return uploadDifference;
+  }
+
+  return right.mosaic.id.localeCompare(left.mosaic.id, undefined, {
+    numeric: true,
+  });
+};
+
+const pointIsInsideMosaic = (point: IPriwaPoint, mosaic: IPriwaMosaic) => {
+  if (
+    !mosaic.bbox ||
+    !Number.isFinite(point.lon) ||
+    !Number.isFinite(point.lat)
+  ) {
+    return false;
+  }
+
+  const bbox = parseBBox(mosaic.bbox);
+  if (!bbox) return false;
+
+  const [minLon, minLat, maxLon, maxLat] = bbox;
+  return (
+    point.lon >= minLon &&
+    point.lon <= maxLon &&
+    point.lat >= minLat &&
+    point.lat <= maxLat
+  );
+};
+
+export const matchPriwaPointsToMosaics = (
+  points: IPriwaPoint[],
+  mosaics: IPriwaMosaic[],
+  maxDaysApart = PRIWA_MOSAIC_MATCH_MAX_DAYS,
+): IPriwaPointMosaicMatch[] => {
+  const normalizedMaxDays = Math.max(0, Math.floor(maxDaysApart));
+
+  return points.flatMap((point) => {
+    const pointDay = dateOnlyToUtcDay(point.datum);
+    if (pointDay === null) return [];
+
+    const candidates = mosaics.flatMap<IPriwaMosaicCandidate>((mosaic) => {
+      if (!pointIsInsideMosaic(point, mosaic)) return [];
+
+      const captureDay = dateOnlyToUtcDay(mosaic.captureDate);
+      if (captureDay === null) return [];
+
+      const daysApart = Math.abs(captureDay - pointDay);
+      if (daysApart > normalizedMaxDays) return [];
+
+      return [{ mosaic, captureDay, daysApart }];
+    });
+
+    const bestCandidate = candidates.sort(compareCandidates)[0];
+    if (!bestCandidate) return [];
+
+    return [
+      {
+        pointId: point.id,
+        mosaicId: bestCandidate.mosaic.id,
+        daysApart: bestCandidate.daysApart,
+      },
+    ];
+  });
+};

--- a/frontend/src/components/PriwaField/usePriwaMosaicMatches.ts
+++ b/frontend/src/components/PriwaField/usePriwaMosaicMatches.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+
+import { matchPriwaPointsToMosaics } from "./priwaMosaicMatching";
+import type { IPriwaPoint } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+
+export interface IPriwaMatchedPoint {
+  point: IPriwaPoint;
+  daysApart: number;
+}
+
+export interface IPriwaMatchedMosaic {
+  mosaic: IPriwaMosaic;
+  points: IPriwaMatchedPoint[];
+  minDaysApart: number;
+  maxDaysApart: number;
+}
+
+const dateRank = (value: string | null | undefined) => {
+  if (!value) return Number.NEGATIVE_INFINITY;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+};
+
+const compareMosaics = (left: IPriwaMosaic, right: IPriwaMosaic) => {
+  const captureDifference =
+    dateRank(right.captureDate) - dateRank(left.captureDate);
+  if (captureDifference !== 0) return captureDifference;
+
+  const uploadDifference = dateRank(right.createdAt) - dateRank(left.createdAt);
+  if (uploadDifference !== 0) return uploadDifference;
+
+  return right.id.localeCompare(left.id, undefined, { numeric: true });
+};
+
+const compareMatchedPoints = (
+  left: IPriwaMatchedPoint,
+  right: IPriwaMatchedPoint,
+) => {
+  const dateDifference =
+    dateRank(right.point.datum) - dateRank(left.point.datum);
+  if (dateDifference !== 0) return dateDifference;
+
+  return left.point.baumnr.localeCompare(right.point.baumnr, "de", {
+    numeric: true,
+  });
+};
+
+export const buildPriwaMosaicMatchIndex = (
+  points: IPriwaPoint[],
+  mosaics: IPriwaMosaic[],
+) => {
+  const candidates = [...mosaics]
+    .filter((mosaic) => mosaic.cogUrl.trim().length > 0)
+    .sort(compareMosaics);
+  const matches = matchPriwaPointsToMosaics(points, candidates);
+  const pointsById = new Map(points.map((point) => [point.id, point]));
+  const matchesByMosaicId = new Map<string, IPriwaMatchedPoint[]>();
+  const mosaicIdByPointId: Record<string, string> = {};
+
+  matches.forEach((match) => {
+    const point = pointsById.get(match.pointId);
+    if (!point) return;
+
+    mosaicIdByPointId[point.id] = match.mosaicId;
+    const mosaicPoints = matchesByMosaicId.get(match.mosaicId) ?? [];
+    mosaicPoints.push({ point, daysApart: match.daysApart });
+    matchesByMosaicId.set(match.mosaicId, mosaicPoints);
+  });
+
+  const matchedMosaics = candidates.flatMap<IPriwaMatchedMosaic>((mosaic) => {
+    const matchedPoints = matchesByMosaicId.get(mosaic.id);
+    if (!matchedPoints?.length) return [];
+
+    matchedPoints.sort(compareMatchedPoints);
+    const dayDistances = matchedPoints.map(({ daysApart }) => daysApart);
+    return [
+      {
+        mosaic,
+        points: matchedPoints,
+        minDaysApart: Math.min(...dayDistances),
+        maxDaysApart: Math.max(...dayDistances),
+      },
+    ];
+  });
+
+  return {
+    candidateCount: candidates.length,
+    matchedMosaics,
+    mosaicIdByPointId,
+  };
+};
+
+export const usePriwaMosaicMatches = (
+  points: IPriwaPoint[],
+  mosaics: IPriwaMosaic[],
+) =>
+  useMemo(() => buildPriwaMosaicMatchIndex(points, mosaics), [mosaics, points]);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -344,6 +344,15 @@
   color: #2d6b3f !important;
 }
 
+.priwa-point-table-row-focused > td,
+.priwa-point-table-row-focused:hover > td {
+  background: #ecfdf5 !important;
+}
+
+.priwa-point-table-row-focused > td:first-child {
+  box-shadow: inset 3px 0 #059669;
+}
+
 .dt-mobile-nav-shell {
   padding-top: calc(env(safe-area-inset-top, 0px) + 0.5rem);
 }


### PR DESCRIPTION
## What changed
- match PRIWA beetle-tree points to the closest COG by bounding box and capture date within 30 days
- show only matched flights, their associated trees and dates in the layer sidebar
- add compact-list/table switching and direct tree navigation into the table
- make map footprint clicks select and explain a layer while keeping visibility under the sidebar switch only
- extract matching and layer UI from the map controller for clearer ownership

## Why
Field users need to understand which Umfeldbefliegung belongs to which Käferbäume and move predictably between map, layer sidebar, and point table.

## Validation
- frontend lint
- 167 Vitest tests, including 9 focused matching tests
- production frontend build
- Codex-only autoreview: no actionable findings
- manual browser QA against the production-connected local frontend

## Risk / limitation
Associations are heuristic: a tree must lie inside the COG bounding box and be within 30 calendar days of the capture date; deterministic date/upload/ID tie-breakers choose one flight.