### PR TITLE
feat(frontend): add PRIWA observers and mobile layer sheet

### DIFF
--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   Button,
+  Drawer,
   FloatButton,
   Popover,
   Progress,
@@ -28,6 +29,7 @@ import type { PointerEvent } from "react";
 
 import { createStandardMapControls } from "../../utils/basemaps";
 import parseBBox from "../../utils/parseBBox";
+import { useIsMobile } from "../../hooks/useIsMobile";
 import { useUserLocationLayer } from "../../hooks/useUserLocationLayer";
 import { createLglDop20Layer } from "./createLglDop20Layer";
 import { createPriwaTopographicLayer } from "./createPriwaTopographicLayer";
@@ -167,6 +169,7 @@ export default function PriwaFieldMap({
   const [focusedPointId, setFocusedPointId] = useState<string | null>(null);
   const [isLayerPanelOpen, setLayerPanelOpen] = useState(false);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
+  const isMobile = useIsMobile();
   const { candidateCount, matchedMosaics, mosaicIdByPointId } =
     usePriwaMosaicMatches(points, mosaics);
   const visibleMosaics = useMemo(
@@ -700,24 +703,23 @@ export default function PriwaFieldMap({
     message.success("Offline-Basiskartenbereich entfernt");
   }, [clearOfflineBasemapArea]);
 
-  const layerPanel = (
-    <PriwaLayerPanel
-      baseLayer={baseLayer}
-      candidateMosaicCount={candidateCount}
-      matchedMosaics={matchedMosaics}
-      enabledMosaicIds={enabledMosaicIds}
-      selectedMosaicId={selectedMosaicId}
-      hoveredMosaicId={hoveredMosaicId}
-      isLoading={isMatchingMosaics}
-      isOpen={isLayerPanelOpen}
-      errorMessage={cogErrorMessage}
-      onBaseLayerChange={setBaseLayer}
-      onSelectMosaic={setSelectedMosaicId}
-      onSetMosaicVisibility={setMosaicVisibility}
-      onZoomToMosaic={zoomToMosaicFootprint}
-      onOpenPointInTable={openPointInTable}
-    />
-  );
+  const layerPanelProps = {
+    baseLayer,
+    candidateMosaicCount: candidateCount,
+    matchedMosaics,
+    enabledMosaicIds,
+    selectedMosaicId,
+    hoveredMosaicId,
+    isLoading: isMatchingMosaics,
+    isOpen: isLayerPanelOpen,
+    errorMessage: cogErrorMessage,
+    onBaseLayerChange: setBaseLayer,
+    onSelectMosaic: setSelectedMosaicId,
+    onSetMosaicVisibility: setMosaicVisibility,
+    onZoomToMosaic: zoomToMosaicFootprint,
+    onOpenPointInTable: openPointInTable,
+  };
+  const layerPanel = <PriwaLayerPanel {...layerPanelProps} />;
 
   const offlineMapPanel = (
     <div className="w-64 space-y-3">
@@ -829,21 +831,34 @@ export default function PriwaFieldMap({
                 aria-label="Aktuelle Position aktivieren"
               />
             </Tooltip>
-            <Popover
-              trigger="click"
-              placement="rightTop"
-              content={layerPanel}
-              open={isLayerPanelOpen}
-              onOpenChange={setLayerPanelOpen}
-            >
+            {isMobile ? (
               <Button
                 className="pointer-events-auto shadow-md"
                 shape="circle"
                 size="large"
                 icon={<MapLayersIcon />}
+                type={isLayerPanelOpen ? "primary" : "default"}
+                aria-pressed={isLayerPanelOpen}
                 aria-label="Layer auswählen"
+                onClick={() => setLayerPanelOpen(true)}
               />
-            </Popover>
+            ) : (
+              <Popover
+                trigger="click"
+                placement="rightTop"
+                content={layerPanel}
+                open={isLayerPanelOpen}
+                onOpenChange={setLayerPanelOpen}
+              >
+                <Button
+                  className="pointer-events-auto shadow-md"
+                  shape="circle"
+                  size="large"
+                  icon={<MapLayersIcon />}
+                  aria-label="Layer auswählen"
+                />
+              </Popover>
+            )}
             <Popover
               trigger="click"
               placement="rightTop"
@@ -892,6 +907,28 @@ export default function PriwaFieldMap({
             />
           )}
         </>
+      )}
+
+      {!isPlacingPoint && isMobile && (
+        <Drawer
+          title="Layer"
+          placement="bottom"
+          height="82dvh"
+          open={isLayerPanelOpen}
+          onClose={() => setLayerPanelOpen(false)}
+          rootClassName="priwa-layer-sheet-root"
+          className="md:hidden"
+          styles={{
+            header: { padding: "12px 16px" },
+            body: {
+              padding:
+                "12px 16px calc(env(safe-area-inset-bottom, 0px) + 16px)",
+              overflowY: "auto",
+            },
+          }}
+        >
+          <PriwaLayerPanel {...layerPanelProps} variant="sheet" />
+        </Drawer>
       )}
 
       {isPointListOpen && !isPlacingPoint && (

--- a/frontend/src/components/PriwaField/PriwaLayerPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaLayerPanel.tsx
@@ -9,6 +9,7 @@ import type { IPriwaMosaic } from "./usePriwaMosaics";
 export type PriwaBaseLayer = "aerial" | "topographic";
 
 interface PriwaLayerPanelProps {
+  variant?: "popover" | "sheet";
   baseLayer: PriwaBaseLayer;
   candidateMosaicCount: number;
   matchedMosaics: IPriwaMatchedMosaic[];
@@ -37,6 +38,7 @@ const daysApartLabel = ({ minDaysApart, maxDaysApart }: IPriwaMatchedMosaic) =>
     : `${minDaysApart}–${maxDaysApart} Tage Abstand`;
 
 export default function PriwaLayerPanel({
+  variant = "popover",
   baseLayer,
   candidateMosaicCount,
   matchedMosaics,
@@ -52,6 +54,7 @@ export default function PriwaLayerPanel({
   onZoomToMosaic,
   onOpenPointInTable,
 }: PriwaLayerPanelProps) {
+  const isSheet = variant === "sheet";
   const mosaicListRef = useRef<HTMLDivElement | null>(null);
   const visibleCount = matchedMosaics.filter(({ mosaic }) =>
     enabledMosaicIds.has(mosaic.id),
@@ -69,9 +72,15 @@ export default function PriwaLayerPanel({
   }, [isOpen, selectedMosaicId]);
 
   return (
-    <div className="w-[21rem] max-w-[calc(100vw-3rem)] space-y-3">
+    <div
+      className={
+        isSheet
+          ? "w-full space-y-3"
+          : "w-[21rem] max-w-[calc(100vw-3rem)] space-y-3"
+      }
+    >
       <div>
-        <Typography.Text strong>Layer</Typography.Text>
+        {!isSheet && <Typography.Text strong>Layer</Typography.Text>}
         <div className="text-xs text-gray-500">
           PRIWA Punkte bleiben immer sichtbar.
         </div>
@@ -112,7 +121,11 @@ export default function PriwaLayerPanel({
         {matchedMosaics.length > 0 && (
           <div
             ref={mosaicListRef}
-            className="mt-2 max-h-80 space-y-2 overflow-y-auto pr-1"
+            className={
+              isSheet
+                ? "mt-2 space-y-2"
+                : "mt-2 max-h-80 space-y-2 overflow-y-auto pr-1"
+            }
           >
             {matchedMosaics.map((matchedMosaic) => {
               const { mosaic, points } = matchedMosaic;

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -46,6 +46,8 @@ const observerOptions: Array<{ label: string; value: PriwaObserverName }> = [
   { label: "Lukas Ruf", value: "Lukas Ruf" },
   { label: "Markus Mayer", value: "Markus Mayer" },
   { label: "Stefan Treyer", value: "Stefan Treyer" },
+  { label: "Tobias Merz", value: "Tobias Merz" },
+  { label: "Fabian Bohnert", value: "Fabian Bohnert" },
   { label: "Andere", value: "andere" },
 ];
 
@@ -345,7 +347,9 @@ export default function PriwaPointDrawer({
         gps: willUseEstimatedGps ? "nein" : "ja",
         isEstimatedLocation: savedCoordinateSource !== "qr",
         rawQrValue:
-          savedCoordinateSource === "qr" ? rawQrValue.trim() || undefined : undefined,
+          savedCoordinateSource === "qr"
+            ? rawQrValue.trim() || undefined
+            : undefined,
       };
 
       if (editingPoint) {

--- a/frontend/src/components/PriwaField/types.ts
+++ b/frontend/src/components/PriwaField/types.ts
@@ -14,6 +14,8 @@ export type PriwaObserverName =
   | "Lukas Ruf"
   | "Markus Mayer"
   | "Stefan Treyer"
+  | "Tobias Merz"
+  | "Fabian Bohnert"
   | "andere";
 export type PriwaFund = "ja" | "ja_kein_buchdrucker" | "nein" | "unsicher";
 export type PriwaBaumart =

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -136,6 +136,16 @@
   max-height: 100dvh;
 }
 
+.priwa-layer-sheet-root .ant-drawer-content {
+  border-radius: 16px 16px 0 0;
+  overflow: hidden;
+}
+
+.priwa-layer-sheet-root .ant-drawer-body {
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 .logo-scroll {
   overflow: hidden;
   width: 100%;


### PR DESCRIPTION
## What changed
- add Tobias Merz and Fabian Bohnert to the Käferbaum observer dropdown and its typed domain values
- open the PRIWA layer controls as an 82dvh bottom sheet on mobile
- preserve the existing desktop popover and share the same layer state/content across both layouts
- let long mobile flight lists use one safe-area-aware scroll surface

## Why
Field users need the additional observers, and the desktop-sized layer popover overflowed narrow phone viewports and obscured the map controls.

## Validation
- 167 frontend tests
- frontend ESLint
- production frontend build
- repository ast-grep guardrail
- browser QA at 390×844: bottom-anchored scrollable sheet, rounded corners, no console errors
- desktop regression QA: popover remains and no bottom-sheet dialog renders

## Risk / limitation
Low frontend-only risk. The responsive switch follows the existing `md` breakpoint; no database migration or production data write is involved.