### PR TITLE
ci(dependabot): constrain compatibility updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,10 +79,55 @@ updates:
       - "/deadtrees-cli"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
-      python-patch-minor:
+      compatibility-patches:
+        patterns:
+          - "numpy"
+          - "rasterio"
+          - "open-clip-torch"
+          - "segmentation-models-pytorch"
+          - "transformers"
+        update-types: ["patch"]
+      python-safe-updates:
+        patterns: ["*"]
+        exclude-patterns:
+          - "numpy"
+          - "rasterio"
+          - "torch"
+          - "torchvision"
+          - "open-clip-torch"
+          - "segmentation-models-pytorch"
+          - "transformers"
         update-types: ["patch", "minor"]
+    ignore:
+      # These packages define the geospatial/model compatibility envelope.
+      # Patch releases stay grouped above; feature-line upgrades are explicit
+      # maintenance work with processor/API image and checkpoint validation.
+      - dependency-name: "numpy"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "rasterio"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      # PyTorch and Torchvision are a tested pair. Dependabot groups do not
+      # guarantee that both packages have an update in the same run.
+      - dependency-name: "torch"
+      - dependency-name: "torchvision"
+      - dependency-name: "open-clip-torch"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "segmentation-models-pytorch"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "transformers"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   # Pinned GDAL runtime images
   - package-ecosystem: "docker"
@@ -91,6 +136,14 @@ updates:
       - "/processor"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     groups:
       service-base-images:
         patterns: ["*"]
+    ignore:
+      # A GDAL feature-line change can also change Ubuntu/Python and therefore
+      # the available PyTorch wheels. Allow patch/digest refreshes only.
+      - dependency-name: "osgeo/gdal"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/docs/agents/environment-and-access.md
+++ b/docs/agents/environment-and-access.md
@@ -106,6 +106,16 @@ This keeps new Codex worktrees usable without committing secrets. If a copied
 local file is stale, update the primary checkout's local-only file rather than
 adding secrets to tracked docs.
 
+The setup script fetches `origin` and fails before installing dependencies when
+the worktree does not include current `origin/main`. Use `--base-ref REF` when
+the user explicitly names another base. `--allow-stale-base` is reserved for
+intentional older-base work, and `--skip-git-fetch` is for deliberate offline
+use with a trusted cached ref. To run only this check:
+
+```bash
+bash scripts/setup-worktree.sh --git-preflight-only
+```
+
 Start implementation, QA, and broad test work from current `origin/main` unless
 the user names another base:
 

--- a/docs/agents/testing-strategy.md
+++ b/docs/agents/testing-strategy.md
@@ -178,7 +178,13 @@ explicitly constrained in their service manifest so update PRs exercise the
 relevant CI lane. NumPy is temporarily constrained below 2.5 because Rasterio
 1.5 still uses the ndarray shape-mutation path deprecated in NumPy 2.5; remove
 that upper bound only after the processor geospatial tests run without those
-warnings.
+warnings. Dependabot groups routine Python updates and compatibility-envelope
+patches separately. All PyTorch/Torchvision upgrades are manual so the tested
+pair cannot move independently. NumPy, Rasterio, OpenCLIP,
+segmentation-models-pytorch, and Transformers feature-line upgrades are also
+manual maintenance work. GDAL base images receive automated patch or digest
+refreshes only because feature-line changes can also change the bundled
+Ubuntu/Python runtime and available PyTorch wheels.
 
 Keep authenticated contributor journeys out of the production-read Playwright
 suite. Use the local contributor smoke when a frontend change touches upload,

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -11,6 +11,10 @@ LINK_SHARED=true
 INSTALL_FRONTEND=true
 INSTALL_PYTHON=true
 ENSURE_ASSETS=true
+FETCH_GIT=true
+ALLOW_STALE_BASE=false
+GIT_PREFLIGHT_ONLY=false
+BASE_REF="origin/main"
 
 usage() {
   cat <<'EOF'
@@ -25,6 +29,10 @@ Options:
   --skip-frontend-install  Do not run npm --prefix frontend ci
   --skip-python-install    Do not create/update venv or install deadtrees-cli
   --skip-assets            Do not download missing test assets
+  --skip-git-fetch         Check the cached base ref without fetching origin
+  --allow-stale-base       Warn instead of failing when HEAD is behind the base ref
+  --base-ref REF           Require HEAD to include REF (default: origin/main)
+  --git-preflight-only     Fetch and check the base ref, then exit
   -h, --help               Show this help
 EOF
 }
@@ -76,6 +84,23 @@ while [[ $# -gt 0 ]]; do
       ENSURE_ASSETS=false
       shift
       ;;
+    --skip-git-fetch)
+      FETCH_GIT=false
+      shift
+      ;;
+    --allow-stale-base)
+      ALLOW_STALE_BASE=true
+      shift
+      ;;
+    --base-ref)
+      [[ $# -ge 2 ]] || die "--base-ref requires a ref"
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --git-preflight-only)
+      GIT_PREFLIGHT_ONLY=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -88,6 +113,39 @@ done
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+check_git_base() {
+  local counts
+  local ahead
+  local behind
+
+  if [[ "$FETCH_GIT" == true ]]; then
+    git -C "$REPO_ROOT" remote get-url origin >/dev/null 2>&1 \
+      || die "Cannot refresh the base: git remote 'origin' is not configured"
+    log "Refreshing remote refs from origin"
+    git -C "$REPO_ROOT" fetch origin --prune
+  else
+    log "Skipping git fetch; checking cached ref $BASE_REF"
+  fi
+
+  git -C "$REPO_ROOT" rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null \
+    || die "Base ref is unavailable: $BASE_REF"
+
+  counts="$(git -C "$REPO_ROOT" rev-list --left-right --count "HEAD...$BASE_REF")"
+  read -r ahead behind <<<"$counts"
+
+  if (( behind == 0 )); then
+    log "HEAD includes current $BASE_REF"
+    return
+  fi
+
+  if [[ "$ALLOW_STALE_BASE" == true ]]; then
+    log "WARNING: HEAD is $behind commit(s) behind $BASE_REF and $ahead commit(s) ahead"
+    return
+  fi
+
+  die "HEAD is $behind commit(s) behind $BASE_REF. Merge/rebase the refreshed base or recreate the worktree. Use --allow-stale-base only when this older base is intentional."
 }
 
 detect_default_shared_root() {
@@ -278,6 +336,13 @@ ensure_assets_and_keys() {
 
 require_command git
 require_command python3
+
+check_git_base
+
+if [[ "$GIT_PREFLIGHT_ONLY" == true ]]; then
+  log "Git base preflight complete"
+  exit 0
+fi
 
 if [[ "$INSTALL_FRONTEND" == true ]]; then
   require_command npm

--- a/scripts/tests/test_setup_worktree_git_preflight.py
+++ b/scripts/tests/test_setup_worktree_git_preflight.py
@@ -1,0 +1,68 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "setup-worktree.sh"
+
+
+def run(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+	return subprocess.run(
+		args,
+		cwd=cwd,
+		check=check,
+		text=True,
+		capture_output=True,
+	)
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+	return run("git", *args, cwd=repo)
+
+
+def test_git_preflight_fetches_origin_and_rejects_a_stale_base(tmp_path: Path) -> None:
+	origin = tmp_path / "origin.git"
+	seed = tmp_path / "seed"
+	worktree = tmp_path / "worktree"
+
+	run("git", "init", "--bare", "--initial-branch=main", str(origin), cwd=tmp_path)
+	run("git", "init", "--initial-branch=main", str(seed), cwd=tmp_path)
+	git(seed, "config", "user.name", "DeadTrees Tests")
+	git(seed, "config", "user.email", "tests@deadtrees.example")
+	(seed / "README.md").write_text("initial\n")
+	git(seed, "add", "README.md")
+	git(seed, "commit", "-m", "initial")
+	git(seed, "remote", "add", "origin", str(origin))
+	git(seed, "push", "-u", "origin", "main")
+
+	run("git", "clone", str(origin), str(worktree), cwd=tmp_path)
+	(worktree / "scripts").mkdir()
+	shutil.copy2(SCRIPT, worktree / "scripts" / "setup-worktree.sh")
+
+	(seed / "README.md").write_text("initial\nnew remote work\n")
+	git(seed, "add", "README.md")
+	git(seed, "commit", "-m", "advance main")
+	git(seed, "push", "origin", "main")
+	remote_head = git(seed, "rev-parse", "HEAD").stdout.strip()
+
+	result = run(
+		"bash",
+		"scripts/setup-worktree.sh",
+		"--git-preflight-only",
+		cwd=worktree,
+		check=False,
+	)
+
+	assert result.returncode != 0
+	assert "behind origin/main" in result.stderr
+	assert git(worktree, "rev-parse", "origin/main").stdout.strip() == remote_head
+
+	git(worktree, "merge", "--ff-only", "origin/main")
+	result = run(
+		"bash",
+		"scripts/setup-worktree.sh",
+		"--git-preflight-only",
+		cwd=worktree,
+	)
+
+	assert "HEAD includes current origin/main" in result.stdout


### PR DESCRIPTION
## What changed
- limit Python and Docker Dependabot concurrency
- keep geospatial/model feature-line upgrades manual and prevent independent PyTorch/Torchvision updates
- restrict automated GDAL updates to patch/digest changes
- fetch and verify the intended remote base before worktree setup, with a regression test for stale cached `origin/main`

## Why
Recent automated updates crossed the tested Python/GDAL/model compatibility envelope and generated failing CI runs. Worktree setup also trusted a potentially stale cached remote-tracking ref.

## Validation
- `python -m pytest -q scripts/tests` (12 passed)
- `scripts/lint-python.sh`
- `scripts/lint-ast-grep.sh`
- `bash -n scripts/setup-worktree.sh`
- Dependabot YAML parse and `git diff --check`

## Risk
Compatibility upgrades now require intentional maintenance PRs. `scripts/setup-worktree.sh` will stop when the selected base is behind unless the caller explicitly opts into an older base.