### PR TITLE
chore(ops): harden operator workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,14 +48,64 @@ scripts/qa/validate-isolated-env.sh
 
 ## Review guidelines
 
-- Prioritize concrete P0/P1 risks: correctness bugs, security regressions, data loss, broken authorization, production deployment hazards, and missing validation for high-risk changes.
-- Treat readability, maintainability, and testability as review concerns when they create concrete future risk: duplicated workflow logic, unclear ownership, hidden side effects, brittle coupling, hard-to-test flows, oversized unstructured functions, or confusing domain names.
-- For architecture-sensitive changes, check whether the PR spreads behavior across callers, weakens locality, or introduces shallow pass-through modules that make future changes harder to verify.
-- For changed interfaces, check that callers do not need to know hidden ordering, config, error modes, permission rules, storage details, or deployment assumptions that should stay behind one module interface.
+- Review the PR merge diff and inspect affected callers, tests, contracts, and
+  surrounding code before reporting a finding. Verify each finding against the
+  actual code path; do not report speculative edge cases.
+- Report only high-confidence P0/P1 issues with a concrete correctness, security,
+  data-loss, production, testability, or maintainability risk introduced by the PR.
+- Do not approve merely because behavior appears correct or tests pass. The PR must
+  not leave the changed code structurally worse, more tangled, or materially harder
+  to understand, test, and change.
+- Be ambitious about structural simplification. For every meaningful change, ask
+  whether a "code judo" reframing could delete whole branches, flags, wrappers,
+  modes, duplicate flows, conditionals, concepts, or layers while preserving
+  behavior. Prefer deleting complexity over rearranging or distributing it.
+- Prioritize structural regressions and clear missed simplifications before local
+  cleanup: spaghetti growth, confused ownership, abstraction or boundary leaks,
+  unnecessary concepts, and oversized modules matter more than cosmetic issues.
+- Treat readability, maintainability, and testability as review concerns when they
+  create concrete future risk: duplicated workflow logic, unclear ownership, hidden
+  side effects, brittle coupling, hard-to-test flows, oversized unstructured
+  functions, or confusing domain names.
+- Flag ad-hoc conditionals, one-off booleans, nullable modes, or feature checks
+  scattered through unrelated or shared flows when they make behavior materially
+  harder to reason about. Prefer a focused abstraction, typed model, dispatcher, or
+  canonical owner that makes branches disappear.
+- For architecture-sensitive changes, check whether the PR spreads behavior across
+  callers, weakens locality, leaks feature logic into shared paths, duplicates an
+  existing canonical helper, or introduces shallow pass-through modules that make
+  future changes harder to verify.
+- Flag thin wrappers, identity abstractions, unnecessary generic mechanisms, and
+  cast-heavy or overly optional contracts when they obscure the real invariant
+  without simplifying the API.
+- For changed interfaces, check that callers do not need to know hidden ordering,
+  config, error modes, permission rules, storage details, or deployment assumptions
+  that should stay behind one module interface.
+- Treat the following as presumptive P1 blockers unless the PR provides a compelling
+  structural justification:
+  - a file crossing from below 1000 lines to above 1000 lines;
+  - new special-case branches, nullable modes, or feature checks tangled into an
+    already busy or unrelated flow;
+  - feature-specific behavior scattered across shared code instead of owned by one
+    canonical module;
+  - an unnecessary wrapper, pass-through abstraction, generic mechanism, cast, or
+    optional contract that makes the real design less direct;
+  - duplicated logic or a bespoke helper where an existing canonical helper or
+    layer already owns the concept;
+  - a refactor that moves complexity around without reducing the concepts a reader
+    must understand.
+- Flag related updates that can leave state partially applied, and flag sequential
+  orchestration of independent work when it introduces avoidable failure coupling
+  or materially complicates the flow.
 - For database, storage, deployment, or production-connected changes, require evidence of repo-approved validation and flag unsafe production assumptions.
 - For security, flag changes that weaken auth, authorization, RLS/policies, tenancy isolation, signed URL handling, upload validation, secret handling, logging of sensitive data, CORS/cookie/session controls, or privilege boundaries.
 - Treat credentials, bearer tokens, database URLs, private keys, raw production access notes, and PII in tracked files or logs as P1.
-- Do not flag subjective style preferences, formatting, or broad cleanup ideas unless they affect correctness, security, maintainability, or testability in the changed code.
+- Prefer a small number of high-conviction findings over a long list of nits. Each
+  finding should identify the concrete risk, the smallest reasonable fix, and the
+  validation that would prove the fix.
+- Do not flag subjective style preferences, formatting, naming-only suggestions, or
+  broad cleanup ideas unless they affect correctness, security, maintainability, or
+  testability in the changed code.
 
 ## Git And PRs
 

--- a/docs/agents/environment-and-access.md
+++ b/docs/agents/environment-and-access.md
@@ -174,6 +174,11 @@ test suite, local QA, browser/app verification, or a fix that should be tested
 against the integrated local environment. After finishing, stop the stack with
 `scripts/qa/env.sh down` unless the user wants to keep it running.
 
+Codex environment cleanup is wired to `scripts/qa/env.sh cleanup`, which tears
+down an already-rendered QA stack without creating new runtime state. Treat that
+as a last-resort closeout hook; still run `scripts/qa/env.sh down` explicitly
+before abandoning a worktree or thread.
+
 ## Secret Hygiene
 
 - Redact command output that includes `password`, `token`, `secret`, `key`,

--- a/docs/playbooks/operator-chat.md
+++ b/docs/playbooks/operator-chat.md
@@ -7,7 +7,8 @@ does not implement fixes directly.
 ## Contract
 
 - Run from `main`.
-- Start with `git status --branch`.
+- Start every refresh with `git fetch origin --prune`, then
+  `git status --branch`.
 - If the tree is clean and behind `origin/main`, pull with `git pull --ff-only`.
 - If the tree is dirty, do not pull or overwrite local changes until the changed
   files are understood.
@@ -41,6 +42,23 @@ this repo at the time this playbook was added:
 
 ## Cadence
 
+### Monitoring Boundary
+
+Codex operator threads are not continuous monitors. Treat this playbook as the
+procedure for a manual refresh, a scheduled wake-up, or an explicitly delegated
+check. Do not assume the main operator thread, a worker thread, or a status-check
+thread is always running in the background.
+
+For backups, use two independent signals:
+
+- freshness checks from `scripts/operator_status.py` when an operator check runs;
+- backup-server email alerts from Gmail/Zulip intake when a scheduled check,
+  weekly review, or incident follow-up runs.
+
+If backup freshness has not been checked in the current operator window, report it
+as skipped or stale evidence instead of inferring health from a previous Codex
+thread.
+
 ### Manual Status Refresh
 
 Start a manual operator refresh with the repo-local compact status script:
@@ -64,6 +82,12 @@ tracked script contains no credentials:
 - `DEADTREES_OPERATOR_STORAGE_HOST` for storage host disk probes.
 - `DEADTREES_OPERATOR_BACKUP_HOST` plus either `DEADTREES_OPERATOR_BACKUP_PATH`
   or `DEADTREES_OPERATOR_BACKUP_COMMAND` for backup freshness.
+  On the Freiburg network/VPN, prefer:
+
+  ```bash
+  DEADTREES_OPERATOR_BACKUP_HOST=remote-backup@dtbackup \
+    python3 scripts/operator_status.py --write-state --format markdown
+  ```
 
 After reading the script output, use connector checks for the surfaces that
 cannot be reliably accessed by repo-local tooling: PostHog, Linear, Gmail, and

--- a/docs/playbooks/platform-status-check.md
+++ b/docs/playbooks/platform-status-check.md
@@ -23,7 +23,7 @@ Check the surfaces relevant to the question:
 - processing server/container heartbeat when host access is needed
 - frontend smoke behavior when user-visible symptoms are possible
 - PostHog traffic, exceptions, uploads, downloads, and audit events
-- Zulip reports and automation summaries when relevant
+- Gmail backup alerts, Zulip reports, and automation summaries when relevant
 - reference exports and backups for data freshness incidents
 
 ## Operator Chat Integration
@@ -44,6 +44,36 @@ full platform check inside that broader operator cadence.
 
    Use this as the first-pass summary, then drill down only into warnings,
    failures, skipped surfaces, or user-visible symptoms.
+
+   To include backup freshness when connected to the university network or VPN,
+   point the backup probe at the backup user. The script uses the documented
+   Borgmatic path on `dtbackup`, lists the latest database and storage archives,
+   and warns when parsed archive timestamps are older than 36 hours:
+
+   ```bash
+   DEADTREES_OPERATOR_BACKUP_HOST=remote-backup@dtbackup \
+     python3 scripts/operator_status.py --write-state --format markdown
+   ```
+
+   When checking backups, also inspect backup-server email alerts for the same
+   operator window, or for the last two months during weekly/full reviews:
+
+   ```text
+   in:anywhere from:dtbackup@gmx.de after:YYYY/MM/DD before:YYYY/MM/DD
+   ```
+
+   Treat the backup surface as fully checked only when both signals are covered:
+   latest Borg archives are fresh, and recent alert emails contain no unresolved
+   `URGENT`, degraded, failed-device, rebuild, or Borgmatic failure signal.
+
+   If the backup probe fails through `dtbackup`, distinguish host reachability
+   from backup-tool access:
+
+   ```bash
+   ssh -o BatchMode=yes -o ConnectTimeout=5 dtbackup 'hostname'
+   ssh -o BatchMode=yes -o ConnectTimeout=5 remote-backup@dtbackup \
+     '/home/remote-backup/.local/bin/borgmatic --config /home/remote-backup/.config/borgmatic/database_dump.yaml list --last 1'
+   ```
 
 1. Confirm local access files exist if host or MCP access is needed:
 
@@ -70,6 +100,7 @@ full platform check inside that broader operator cadence.
    ```bash
    ssh -o BatchMode=yes -o ConnectTimeout=5 storage-server 'hostname'
    ssh -o BatchMode=yes -o ConnectTimeout=5 processing-server 'hostname'
+   ssh -o BatchMode=yes -o ConnectTimeout=5 remote-backup@dtbackup 'hostname'
    ```
 
 ## Database Queries
@@ -116,6 +147,44 @@ tail -n 80 /data/logs/api_container.log
 If processing-server SSH is blocked, use database logs as primary evidence and
 state that host-level corroboration was unavailable.
 
+## Backup Checks
+
+Backup freshness is not continuously monitored by a Codex thread. During daily
+or weekly operator checks, combine the live Borg freshness probe with a bounded
+Gmail alert search.
+
+Checklist:
+
+1. Run the Borg freshness probe with `DEADTREES_OPERATOR_BACKUP_HOST=remote-backup@dtbackup`.
+2. Search backup-server alert email from `dtbackup@gmx.de` for the check window.
+3. If any alert mentions degraded RAID, failed devices, rebuild activity, or
+   Borgmatic/backup failures, verify current host state and current archives
+   before reporting backups as healthy.
+
+Use this two-month audit query when checking whether backup-server alerting has
+reported bigger issues:
+
+```text
+in:anywhere from:dtbackup@gmx.de after:YYYY/MM/DD before:YYYY/MM/DD
+```
+
+Then narrow likely incidents with:
+
+```text
+in:anywhere from:dtbackup@gmx.de after:YYYY/MM/DD before:YYYY/MM/DD (URGENT OR Failed OR Degraded OR Rebuild OR "Device Failed" OR "Time Out Error")
+in:anywhere after:YYYY/MM/DD before:YYYY/MM/DD (borgmatic OR "remote-backup" OR database_dump OR pg_dump) (failed OR failure OR error OR warning OR cron)
+```
+
+Interpretation guide:
+
+- `RaidAlert-URGENT`, `Volume Degraded`, `RaidSet Degraded`, or `Device Failed`
+  is a real storage incident until host-side state proves recovery.
+- `Start Rebuilding`, `HotSpare Used`, and `Complete Rebuild` describe the
+  recovery sequence; confirm current `/proc/mdstat`, `/mnt/raid` mount, and
+  latest Borg archives before closing the incident.
+- monthly `raid_scrub_check.sh` cron emails that only say scrubs started are
+  informational unless followed by error output or RAID alerts.
+
 ## Final Report
 
 Include:
@@ -124,7 +193,8 @@ Include:
 - window checked with concrete dates/times
 - upload/processing throughput counts
 - failures and stuck queues with dataset IDs where useful
-- API/storage/frontend/PostHog/Zulip/export/backups status as checked
+- API/storage/frontend/PostHog/Zulip/export status as checked
+- backups status, including Borg archive freshness and backup-alert email review
 - skipped or blocked surfaces
 - confidence and one improvement for the next check
 

--- a/scripts/operator_status.py
+++ b/scripts/operator_status.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 import time
@@ -24,6 +26,8 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_API_URL = 'https://data2.deadtrees.earth/api/v1/openapi.json'
 DEFAULT_STATE_FILE = ROOT / '.local/operator/operator-state.json'
 DEFAULT_LATEST_FILE = ROOT / '.local/operator/operator-latest.md'
+DEFAULT_BACKUP_MAX_AGE_HOURS = 36
+ARCHIVE_TIMESTAMP_RE = re.compile(r'(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})')
 
 
 def utc_now() -> str:
@@ -197,12 +201,14 @@ def ssh_probe(env_name: str, command: str, timeout: int) -> dict[str, Any]:
 		return {'ok': False, 'host_env': env_name, 'error': compact_error(result)}
 
 	lines = [line.strip() for line in result['stdout'].splitlines() if line.strip()]
+	archives = parse_archive_lines(lines)
 	return {
 		'ok': True,
 		'host_env': env_name,
 		'lines': lines[:12],
 		'disks': parse_disk_lines(lines),
-		'archives': parse_archive_lines(lines),
+		'archives': archives,
+		'archive_ages_hours': parse_archive_ages_hours(archives),
 		'duration_ms': result['duration_ms'],
 	}
 
@@ -231,21 +237,60 @@ def parse_archive_lines(lines: list[str]) -> dict[str, str]:
 	return archives
 
 
+def parse_archive_ages_hours(archives: dict[str, str]) -> dict[str, float]:
+	now = datetime.now(timezone.utc)
+	ages: dict[str, float] = {}
+	for name, archive in archives.items():
+		match = ARCHIVE_TIMESTAMP_RE.search(archive)
+		if not match:
+			continue
+		try:
+			archive_time = datetime.fromisoformat(match.group(1)).replace(tzinfo=timezone.utc)
+		except ValueError:
+			continue
+		ages[name] = round((now - archive_time).total_seconds() / 3600, 1)
+	return ages
+
+
+def backup_command() -> str:
+	configured = os.environ.get('DEADTREES_OPERATOR_BACKUP_COMMAND')
+	if configured:
+		return configured
+
+	backup_path = os.environ.get('DEADTREES_OPERATOR_BACKUP_PATH')
+	if backup_path:
+		quoted_path = shlex.quote(backup_path)
+		return (
+			f"find {quoted_path} -type f -printf '%T@ %TY-%Tm-%TdT%TH:%TM %p\\n' 2>/dev/null "
+			"| sort -nr | head -n 5"
+		)
+
+	return (
+		"set -e; "
+		"borgmatic=/home/remote-backup/.local/bin/borgmatic; "
+		"config_dir=/home/remote-backup/.config/borgmatic; "
+		"if [ ! -x \"$borgmatic\" ]; then echo \"borgmatic not executable: $borgmatic\" >&2; exit 1; fi; "
+		"for spec in database_dump:database_dump.yaml storage:storage.yaml; do "
+		"name=${spec%%:*}; "
+		"config=$config_dir/${spec#*:}; "
+		"latest=$(\"$borgmatic\" --config \"$config\" list --last 1 "
+		"| awk '/^[[:alnum:]_.-]+-[0-9]{4}-[0-9]{2}-[0-9]{2}T/ {print $1}' "
+		"| tail -n 1); "
+		"test -n \"$latest\"; "
+		"printf 'archive=%s:%s\\n' \"$name\" \"$latest\"; "
+		"done"
+	)
+
+
 def host_summaries(timeout: int) -> dict[str, Any]:
 	df_command = (
 		"printf 'host=%s\\n' \"$(hostname)\"; "
 		"df -P / /data 2>/dev/null | awk 'NR>1 {print \"disk=\" $6 \":\" $5}'"
 	)
-	backup_command = os.environ.get(
-		'DEADTREES_OPERATOR_BACKUP_COMMAND',
-		"test -n \"$DEADTREES_OPERATOR_BACKUP_PATH\" && "
-		"find \"$DEADTREES_OPERATOR_BACKUP_PATH\" -type f -printf '%T@ %TY-%Tm-%TdT%TH:%TM %p\\n' 2>/dev/null "
-		"| sort -nr | head -n 5",
-	)
 	return {
 		'processing': ssh_probe('DEADTREES_OPERATOR_PROCESSING_HOST', df_command, timeout),
 		'storage': ssh_probe('DEADTREES_OPERATOR_STORAGE_HOST', df_command, timeout),
-		'backups': ssh_probe('DEADTREES_OPERATOR_BACKUP_HOST', backup_command, timeout),
+		'backups': ssh_probe('DEADTREES_OPERATOR_BACKUP_HOST', backup_command(), timeout),
 	}
 
 
@@ -303,6 +348,11 @@ def classify(snapshot: dict[str, Any]) -> tuple[str, list[str], list[str]]:
 		for path, percent in value.get('disks', {}).items():
 			if percent >= 80:
 				risks.append(f'{key} disk {path} is {percent}% full')
+		if key == 'backups' and value.get('archive_ages_hours'):
+			max_age_hours = int(os.environ.get('DEADTREES_OPERATOR_BACKUP_MAX_AGE_HOURS', DEFAULT_BACKUP_MAX_AGE_HOURS))
+			for archive_name, age_hours in value['archive_ages_hours'].items():
+				if age_hours > max_age_hours:
+					risks.append(f'{archive_name} backup archive is {age_hours}h old')
 
 	for key, value in snapshot['connectors'].items():
 		if value.get('ok') is None:
@@ -413,7 +463,15 @@ def render_markdown(snapshot: dict[str, Any]) -> str:
 		if value.get('disks'):
 			parts.append('disks ' + ', '.join(f'{path}={percent}%' for path, percent in value['disks'].items()))
 		if value.get('archives'):
-			parts.append('archives ' + ', '.join(f'{name}={archive}' for name, archive in value['archives'].items()))
+			archive_ages = value.get('archive_ages_hours', {})
+			parts.append(
+				'archives '
+				+ ', '.join(
+					f'{name}={archive}'
+					+ (f' age={archive_ages[name]}h' if name in archive_ages else '')
+					for name, archive in value['archives'].items()
+				)
+			)
 		summary = '; '.join(parts)
 		if not summary:
 			summary = '; '.join(value.get('lines', [])[:4]) if value.get('lines') else value.get('skipped') or value.get('error')

--- a/scripts/qa/env.sh
+++ b/scripts/qa/env.sh
@@ -16,7 +16,7 @@ vite_session_name() {
 
 usage() {
 	cat >&2 <<'USAGE'
-Usage: scripts/qa/env.sh <render|up|status|reset|down>
+Usage: scripts/qa/env.sh <render|up|status|reset|down|cleanup>
 
 Manages the local isolated QA environment for this worktree.
 
@@ -26,12 +26,36 @@ Commands:
   status  Check Supabase/Auth, API, Mailpit, and frontend readiness.
   reset   Reseed qa-full and refresh fixture assets.
   down    Stop Vite, app services, and isolated Supabase.
+  cleanup Stop an already-rendered QA stack without creating new runtime state.
 USAGE
 }
 
 source_isolated_env() {
 	local env_file
 	env_file="$("$REPO_ROOT/scripts/dev/isolated-supabase.sh" env)"
+	set -a
+	# shellcheck disable=SC1090
+	source "$env_file"
+	set +a
+}
+
+existing_isolated_env_file() {
+	if [[ -n "${DEADTREES_ISOLATED_ENV_FILE:-}" && -f "$DEADTREES_ISOLATED_ENV_FILE" ]]; then
+		printf '%s\n' "$DEADTREES_ISOLATED_ENV_FILE"
+		return 0
+	fi
+	if [[ -f "$REPO_ROOT/.local/supabase/current.env" ]]; then
+		printf '%s\n' "$REPO_ROOT/.local/supabase/current.env"
+		return 0
+	fi
+	return 1
+}
+
+source_existing_isolated_env() {
+	local env_file
+	if ! env_file="$(existing_isolated_env_file)"; then
+		return 1
+	fi
 	set -a
 	# shellcheck disable=SC1090
 	source "$env_file"
@@ -246,6 +270,22 @@ down() {
 	source_isolated_env
 	stop_vite
 	"$REPO_ROOT/venv/bin/deadtrees" dev stop || true
+	export DEADTREES_WORKTREE_SLUG="${DEADTREES_WORKTREE_SLUG:-$DEADTREES_ISOLATED_SLUG}"
+	"$REPO_ROOT/scripts/dev/isolated-supabase.sh" stop || true
+}
+
+cleanup() {
+	if ! source_existing_isolated_env; then
+		echo "No rendered QA environment found; nothing to clean up."
+		return 0
+	fi
+	stop_vite
+	if [[ -x "$REPO_ROOT/venv/bin/deadtrees" ]]; then
+		"$REPO_ROOT/venv/bin/deadtrees" dev stop || true
+	else
+		echo "Missing $REPO_ROOT/venv/bin/deadtrees; skipping app service cleanup."
+	fi
+	export DEADTREES_WORKTREE_SLUG="${DEADTREES_WORKTREE_SLUG:-$DEADTREES_ISOLATED_SLUG}"
 	"$REPO_ROOT/scripts/dev/isolated-supabase.sh" stop || true
 }
 
@@ -265,6 +305,9 @@ case "$COMMAND" in
 		;;
 	down)
 		down
+		;;
+	cleanup)
+		cleanup
 		;;
 	-h|--help|"")
 		usage


### PR DESCRIPTION
## What changed

- strengthens the repository review guidance for high-confidence structural findings
- makes Operator refreshes fetch remote state first and verifies Borg backup freshness with age thresholds
- documents backup-alert correlation through Gmail and adds a non-creating QA cleanup command

## Why

The main Operator checkout had drifted behind its remote view, backup checks did not reliably verify the documented Borg archives, and automated cleanup needed a way to tear down only an already-rendered isolated environment.

## Impact

Operators get fresher repository context and explicit backup evidence. Codex and developers can clean up isolated QA stacks without accidentally rendering or starting new runtime state.

## Validation

- `python3 -m py_compile scripts/operator_status.py`
- `ruff check scripts/operator_status.py`
- `python3 scripts/operator_status.py --skip-network --format json`
- live read-only Borg probe via `remote-backup@dtbackup` returned fresh database and storage archives
- `bash -n scripts/qa/env.sh`
- `scripts/qa/env.sh --help`
- `git diff --check origin/main`

## Risk

The new `cleanup` command only acts when an existing isolated environment file is present. The live validation was read-only and did not mutate production.