### PR TITLE
fix(frontend): make audit queue loading resilient

### DIFF
--- a/frontend/e2e-local/auditor-local.spec.ts
+++ b/frontend/e2e-local/auditor-local.spec.ts
@@ -161,7 +161,7 @@ let savedAoiPayloads: Array<Record<string, unknown>> = [];
 
 const installAuthenticatedUser = async (
   page: Page,
-  options: { canAudit: boolean },
+  options: { canAudit: boolean; auditDatasetRequestFails?: boolean },
 ) => {
   await installLocalSession(page, {
     user: auditor,
@@ -212,7 +212,7 @@ const installAuthenticatedUser = async (
 
 const fulfillSupabaseRequest = async (
   route: Route,
-  options: { canAudit: boolean },
+  options: { canAudit: boolean; auditDatasetRequestFails?: boolean },
 ) => {
   const request = route.request();
   const url = new URL(request.url());
@@ -249,6 +249,22 @@ const fulfillSupabaseRequest = async (
         route,
         wantsObject ? (dataset ?? null) : dataset ? [dataset] : [],
       );
+      return;
+    }
+
+    const selectedColumns = url.searchParams.get("select");
+    if (
+      options.auditDatasetRequestFails &&
+      (selectedColumns === "*" || selectedColumns?.split(",").includes("is_audited"))
+    ) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        json: {
+          code: "57014",
+          message: "canceling statement due to statement timeout",
+        },
+      });
       return;
     }
 
@@ -548,6 +564,63 @@ test.describe("auditor local e2e", () => {
     ).toBeVisible();
   });
 
+  test("audit queue uses an explicit lightweight dataset projection", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    const datasetRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      const selectedColumns = url.searchParams.get("select");
+      return (
+        url.pathname.endsWith("/v2_full_dataset_view") &&
+        (selectedColumns === "*" ||
+          selectedColumns?.split(",").includes("is_audited") === true)
+      );
+    });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+    const request = await datasetRequest;
+    const selectedColumns = new URL(request.url()).searchParams
+      .get("select")
+      ?.split(",");
+
+    expect(selectedColumns).toBeDefined();
+    expect(selectedColumns).not.toContain("*");
+    expect(selectedColumns).toEqual(
+      expect.arrayContaining([
+        "id",
+        "file_name",
+        "is_audited",
+        "is_metadata_done",
+        "phenology_probability",
+      ]),
+    );
+    await expect(page.getByText("Local Forest")).toBeVisible();
+  });
+
+  test("audit queue reports dataset load failures instead of showing zero", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, {
+      canAudit: true,
+      auditDatasetRequestFails: true,
+    });
+
+    await page.goto("/dataset-audit");
+    await dismissCookieBanner(page);
+
+    await expect(
+      page.getByText("Could not load audit datasets", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("The audit queue could not be loaded. Please try again."),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+    await expect(page.getByText("📋 Pending")).toHaveCount(0);
+  });
+
   test("auditor start action checks the lock before opening detail", async ({
     page,
   }) => {
@@ -569,6 +642,24 @@ test.describe("auditor local e2e", () => {
     await expect(page.getByText("1. Georeferencing Accuracy")).toBeVisible();
     await expect(
       page.getByRole("button", { name: /^save Save$/i }),
+    ).toBeVisible();
+  });
+
+  test("direct audit detail links retain queue navigation context", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    await page.goto(`/dataset-audit/${completeDataset.id}`);
+    await dismissCookieBanner(page);
+
+    await expect(
+      page.getByRole("heading", {
+        name: new RegExp(`Audit: ${completeDataset.id}`),
+      }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByRole("button", { name: /^right Save & Next$/i }),
     ).toBeVisible();
   });
 

--- a/frontend/src/hooks/useAuditDatasets.ts
+++ b/frontend/src/hooks/useAuditDatasets.ts
@@ -1,0 +1,61 @@
+import { useQuery } from "@tanstack/react-query";
+import { Settings } from "../config";
+import type { IDataset } from "../types/dataset";
+import { useAuth } from "./useAuthProvider";
+import { supabase } from "./useSupabase";
+
+const AUDIT_DATASET_FIELDS = [
+	"id",
+	"file_name",
+	"archived",
+	"aquisition_year",
+	"aquisition_month",
+	"aquisition_day",
+	"is_upload_done",
+	"is_odm_done",
+	"is_ortho_done",
+	"is_cog_done",
+	"is_thumbnail_done",
+	"is_deadwood_done",
+	"is_forest_cover_done",
+	"is_metadata_done",
+	"is_audited",
+	"admin_level_1",
+	"admin_level_2",
+	"admin_level_3",
+	"biome_name",
+	"has_ml_tiles",
+	"phenology_probability",
+] as const satisfies readonly (keyof IDataset)[];
+
+const AUDIT_DATASET_SELECT = AUDIT_DATASET_FIELDS.join(",");
+
+export type AuditDataset = Pick<IDataset, (typeof AUDIT_DATASET_FIELDS)[number]>;
+
+/**
+ * Lightweight dataset rows for audit queue tabs and filters.
+ *
+ * Keep this projection explicit: v2_full_dataset_view contains derived columns
+ * that can be expensive or large, and the queue loads every auditor-visible row.
+ * Audit detail routes fetch their single full dataset separately.
+ */
+export function useAuditDatasets() {
+	const { status, user } = useAuth();
+
+	return useQuery({
+		queryKey: ["audit-datasets", status, user?.id ?? "anonymous"],
+		queryFn: async () => {
+			const { data, error } = await supabase
+				.from(Settings.DATA_TABLE_FULL)
+				.select(AUDIT_DATASET_SELECT)
+				.overrideTypes<AuditDataset[], { merge: false }>();
+
+			if (error) throw error;
+			return data;
+		},
+		enabled: status !== "checking",
+		retry: 1,
+		staleTime: 5 * 60 * 1000,
+		gcTime: 10 * 60 * 1000,
+	});
+}

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -29,9 +29,10 @@ import {
 } from "@ant-design/icons";
 import { useAuth } from "../hooks/useAuthProvider";
 import { useCanAudit } from "../hooks/useUserPrivileges";
-import { useDatasets } from "../hooks/useDatasets";
+import { useDatasetById } from "../hooks/useDatasets";
+import { useAuditDatasets } from "../hooks/useAuditDatasets";
+import type { AuditDataset } from "../hooks/useAuditDatasets";
 import DatasetAuditDetail from "../components/DatasetAudit/DatasetAuditDetail";
-import { IDataset } from "../types/dataset";
 import { useDatasetAudits, DatasetAuditUserInfo, useDatasetContributors } from "../hooks/useDatasetAudit";
 import { supabase } from "../hooks/useSupabase";
 import { useFlaggedDatasets } from "../hooks/useDatasetFlags";
@@ -65,7 +66,7 @@ const PROCESSING_STATE_OPTIONS: Array<{ label: string; value: ProcessingStateFil
 	{ label: "Metadata", value: "metadata" },
 ];
 
-const PROCESSING_STATE_TO_FIELD: Record<ProcessingStateFilterKey, keyof IDataset> = {
+const PROCESSING_STATE_TO_FIELD: Record<ProcessingStateFilterKey, keyof AuditDataset> = {
 	ortho: "is_ortho_done",
 	cog: "is_cog_done",
 	thumbnail: "is_thumbnail_done",
@@ -86,18 +87,18 @@ const formatHours = (value: number | null | undefined): string => {
 // Helper function to check if a dataset is ready to be audited.
 // Auditing only depends on the legacy pipeline; it must not be gated on the v2
 // combined segmentation model, AOI generation, or the current processing status.
-const isProcessingComplete = (dataset: IDataset) => {
+const isProcessingComplete = (dataset: AuditDataset) => {
 	return isDatasetReadyForAudit(dataset);
 };
 
 // Helper to format location
-const formatLocation = (dataset: IDataset): string => {
+const formatLocation = (dataset: AuditDataset): string => {
 	const parts = [dataset.admin_level_3, dataset.admin_level_1].filter(Boolean);
 	return parts.length > 0 ? parts.join(", ") : "Unknown";
 };
 
 // Helper to format acquisition date
-const formatAcquisitionDate = (dataset: IDataset): string => {
+const formatAcquisitionDate = (dataset: AuditDataset): string => {
 	const { aquisition_year, aquisition_month, aquisition_day } = dataset;
 	if (!aquisition_year) return "Unknown";
 	const parts = [String(aquisition_year)];
@@ -119,14 +120,14 @@ const compareNullableNumbers = (a: number | null | undefined, b: number | null |
 	return aNum - bNum;
 };
 
-const getAcquisitionMonthIndex = (dataset: IDataset): number | null => {
+const getAcquisitionMonthIndex = (dataset: AuditDataset): number | null => {
 	const year = parseInt(dataset.aquisition_year, 10);
 	const month = parseInt(dataset.aquisition_month, 10);
 	if (isNaN(year) || isNaN(month) || month < 1 || month > 12) return null;
 	return year * 12 + (month - 1);
 };
 
-const getAcquisitionDateSortKey = (dataset: IDataset): number | null => {
+const getAcquisitionDateSortKey = (dataset: AuditDataset): number | null => {
 	const year = parseInt(dataset.aquisition_year, 10);
 	const month = parseInt(dataset.aquisition_month, 10);
 	const day = parseInt(dataset.aquisition_day, 10);
@@ -194,7 +195,19 @@ function DatasetAuditInner() {
 	const { user } = useAuth();
 	const isAuthLoading = false;
 	const { canAudit, isLoading: isAuditPrivilegeLoading } = useCanAudit();
-	const { data: datasets, isLoading: isDatasetLoading } = useDatasets();
+	const datasetId = id ? Number(id) : undefined;
+	const {
+		data: datasets,
+		isLoading: isDatasetLoading,
+		isError: isDatasetError,
+		refetch: refetchDatasets,
+	} = useAuditDatasets();
+	const {
+		data: detailDataset,
+		isLoading: isDetailDatasetLoading,
+		isError: isDetailDatasetError,
+		refetch: refetchDetailDataset,
+	} = useDatasetById(datasetId);
 	const { data: audits, isLoading: isAuditsLoading } = useDatasetAudits();
 	const { data: flaggedAgg = [], isLoading: isFlaggedLoading } = useFlaggedDatasets();
 	const { data: referenceDatasetIds = new Set() } = useReferenceDatasetIds();
@@ -568,10 +581,30 @@ function DatasetAuditInner() {
 
 	// Detail view
 	if (id) {
-		const dataset = datasets?.find((d) => d.id.toString() === id);
-		if (isDatasetLoading) return <div>Loading dataset...</div>;
-		if (!dataset) return <div>Dataset not found</div>;
-		return <DatasetAuditDetail dataset={dataset} />;
+		if (isDetailDatasetLoading) return <div>Loading dataset...</div>;
+		if (isDetailDatasetError) {
+			return (
+				<Result
+					status="error"
+					title="Could not load dataset"
+					subTitle="The dataset could not be loaded. Please try again."
+					extra={<Button onClick={() => refetchDetailDataset()}>Try again</Button>}
+				/>
+			);
+		}
+		if (!detailDataset) return <div>Dataset not found</div>;
+		return <DatasetAuditDetail dataset={detailDataset} />;
+	}
+
+	if (isDatasetError) {
+		return (
+			<Result
+				status="error"
+				title="Could not load audit datasets"
+				subTitle="The audit queue could not be loaded. Please try again."
+				extra={<Button onClick={() => refetchDatasets()}>Try again</Button>}
+			/>
+		);
 	}
 
 	const processingColumns: ColumnsType<ProcessingOverviewRow> = [
@@ -677,7 +710,7 @@ function DatasetAuditInner() {
 	];
 
 	// Build columns based on active tab
-	const baseColumns: ColumnsType<IDataset> = [
+	const baseColumns: ColumnsType<AuditDataset> = [
 		{
 			title: "ID",
 			dataIndex: "id",
@@ -717,7 +750,7 @@ function DatasetAuditInner() {
 	const seasonColumn = {
 		title: "Season",
 		key: "season",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const audit = auditMap.get(record.id);
 			// has_valid_phenology: true = in season, false = out of season, null = not determined
 			if (!audit || audit.has_valid_phenology === null) {
@@ -729,7 +762,7 @@ function DatasetAuditInner() {
 				<Tag color="orange">Out of Season</Tag>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aAudit = auditMap.get(a.id);
 			const bAudit = auditMap.get(b.id);
 			const rank = (val: boolean | null | undefined) => {
@@ -745,7 +778,7 @@ function DatasetAuditInner() {
 	const pendingPhenologyProbabilityColumn = {
 		title: "Phenology Prob.",
 		key: "phenology_probability",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const probability = record.phenology_probability;
 			if (typeof probability !== "number") {
 				return <Tag color="default">—</Tag>;
@@ -755,7 +788,7 @@ function DatasetAuditInner() {
 			const color = pct >= 70 ? "green" : pct >= 40 ? "gold" : "red";
 			return <Tag color={color}>{pct}%</Tag>;
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aValue = typeof a.phenology_probability === "number" ? a.phenology_probability : -1;
 			const bValue = typeof b.phenology_probability === "number" ? b.phenology_probability : -1;
 			return aValue - bValue;
@@ -767,7 +800,7 @@ function DatasetAuditInner() {
 	const notesColumn = {
 		title: "Notes",
 		key: "notes",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const audit = auditMap.get(record.id);
 			const notes = audit?.notes;
 			if (!notes) return <span className="text-gray-400">—</span>;
@@ -778,7 +811,7 @@ function DatasetAuditInner() {
 				</Tooltip>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aNotes = auditMap.get(a.id)?.notes || "";
 			const bNotes = auditMap.get(b.id)?.notes || "";
 			return compareNullableStrings(aNotes, bNotes);
@@ -789,7 +822,7 @@ function DatasetAuditInner() {
 	const flagsColumn = {
 		title: "Flags",
 		key: "flags",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const flagData = flaggedMap.get(record.id);
 			if (!flagData) return null;
 			const openCount = flagData.open_count ?? 0;
@@ -804,7 +837,7 @@ function DatasetAuditInner() {
 				</Tooltip>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aFlag = flaggedMap.get(a.id);
 			const bFlag = flaggedMap.get(b.id);
 			const aCount = (aFlag?.open_count ?? 0) + (aFlag?.acknowledged_count ?? 0);
@@ -817,7 +850,7 @@ function DatasetAuditInner() {
 	const correctionsColumn = {
 		title: "Pending Edits",
 		key: "corrections",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const count = correctionsMap.get(record.id);
 			if (!count) return <span className="text-gray-400">—</span>;
 			return (
@@ -828,14 +861,14 @@ function DatasetAuditInner() {
 				</Tooltip>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => (correctionsMap.get(a.id) || 0) - (correctionsMap.get(b.id) || 0),
+		sorter: (a: AuditDataset, b: AuditDataset) => (correctionsMap.get(a.id) || 0) - (correctionsMap.get(b.id) || 0),
 		width: 100,
 	};
 
 	const contributorColumn = {
 		title: "Contributor",
 		key: "contributor",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			// First try contributor map, then fall back to audit map
 			const email = contributorMap.get(record.id) || auditMap.get(record.id)?.uploaded_by_email;
 			if (!email) return <span className="text-gray-400">—</span>;
@@ -855,7 +888,7 @@ function DatasetAuditInner() {
 				</Tooltip>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aEmail = contributorMap.get(a.id) || auditMap.get(a.id)?.uploaded_by_email || "";
 			const bEmail = contributorMap.get(b.id) || auditMap.get(b.id)?.uploaded_by_email || "";
 			return compareNullableStrings(aEmail, bEmail);
@@ -866,7 +899,7 @@ function DatasetAuditInner() {
 	const auditorColumn = {
 		title: "Auditor",
 		key: "auditor",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const audit = auditMap.get(record.id);
 			if (!audit?.audited_by_email) return <span className="text-gray-400">—</span>;
 			return (
@@ -885,7 +918,7 @@ function DatasetAuditInner() {
 				</Tooltip>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aEmail = auditMap.get(a.id)?.audited_by_email || "";
 			const bEmail = auditMap.get(b.id)?.audited_by_email || "";
 			return compareNullableStrings(aEmail, bEmail);
@@ -896,7 +929,7 @@ function DatasetAuditInner() {
 	const statusColumn = {
 		title: "Status",
 		key: "status",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const audit = auditMap.get(record.id);
 			if (!audit) return <Tag color="orange">Not audited yet</Tag>;
 
@@ -930,7 +963,7 @@ function DatasetAuditInner() {
 				</Space>
 			);
 		},
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aAudit = auditMap.get(a.id);
 			const bAudit = auditMap.get(b.id);
 
@@ -965,7 +998,7 @@ function DatasetAuditInner() {
 	const actionsColumn = {
 		title: "Actions",
 		key: "actions",
-		render: (_: unknown, record: IDataset) => {
+		render: (_: unknown, record: AuditDataset) => {
 			const isComplete = isProcessingComplete(record);
 			const buttonLabel = record.is_audited ? "Review" : "Start Audit";
 			const tooltipText = !isComplete
@@ -987,14 +1020,14 @@ function DatasetAuditInner() {
 	const referencePatchesColumn = {
 		title: "Reference Patches",
 		key: "reference_patches",
-		render: (_: unknown, record: IDataset) => (
+		render: (_: unknown, record: AuditDataset) => (
 			<Tooltip title="Open Reference Patch Editor for this dataset">
 				<Button size="small" onClick={() => navigate(`/dataset-audit/${record.id}/reference-patches`)}>
 					{record.has_ml_tiles ? "Continue Patches" : "Generate Patches"}
 				</Button>
 			</Tooltip>
 		),
-		sorter: (a: IDataset, b: IDataset) => {
+		sorter: (a: AuditDataset, b: AuditDataset) => {
 			const aHas = a.has_ml_tiles ? 1 : 0;
 			const bHas = b.has_ml_tiles ? 1 : 0;
 			if (aHas !== bHas) return aHas - bHas;
@@ -1004,7 +1037,7 @@ function DatasetAuditInner() {
 	};
 
 	// Assemble columns based on tab
-	let columns: ColumnsType<IDataset>;
+	let columns: ColumnsType<AuditDataset>;
 	if (activeTab === "pending") {
 		// Pending: include derived phenology probability, flags and contributor
 		columns = [...baseColumns, pendingPhenologyProbabilityColumn, flagsColumn, contributorColumn, actionsColumn];


### PR DESCRIPTION
## What changed
- load the audit queue through an explicit lightweight dataset projection instead of `select(*)`
- fetch the full dataset only for the open audit detail while retaining queue navigation context
- show a retryable load error instead of silently rendering zero pending audits
- add browser regression coverage for the projection, timeout handling, and direct detail links

## Why
The full dataset view gained a derived phenology column. The unbounded wildcard response became large enough to hit the Data API statement timeout for auditors, while the page treated the failed query as an empty queue.

## Impact
Auditors should see pending audits reliably again. RLS and privilege rules are unchanged, and other dataset consumers keep their existing hooks.

## Validation
- `npm --prefix frontend test` (211 tests)
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- isolated auditor E2E suite (9 tests)
- in-app Browser smoke of queue and detail navigation
- local production-profile frontend against production Supabase (read-only)
- authenticated production projection: HTTP 200 for 8,209 rows in about 3.1s