### PR TITLE
fix(security): remediate CodeQL findings

### DIFF
--- a/.github/workflows/frontend-hosting-merge.yml
+++ b/.github/workflows/frontend-hosting-merge.yml
@@ -13,6 +13,9 @@ concurrency:
   group: frontend-production
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend-deploy:
     name: frontend-deploy

--- a/deadtrees-cli/deadtrees_cli/dev.py
+++ b/deadtrees-cli/deadtrees_cli/dev.py
@@ -87,6 +87,14 @@ class DevCommands:
 			print(f'Error: {str(e)}')
 			raise
 
+	def _print_dev_accounts(self):
+		"""Print local account identifiers without exposing configured passwords."""
+		print('📧 Available test users:')
+		print(f'   • Test User: {settings.TEST_USER_EMAIL}')
+		print(f'   • Test User 2: {settings.TEST_USER_EMAIL2}')
+		print(f'   • Processor: {settings.PROCESSOR_USERNAME}')
+		print('   Passwords are loaded from the local environment and are not displayed.')
+
 	def _get_compose_services(self) -> List[str]:
 		"""Get the list of services defined in the test compose file."""
 		result = subprocess.run(
@@ -655,10 +663,7 @@ class DevCommands:
 				self._run_command(self._compose_lifecycle_cmd('up', flags=['-d']))
 
 			print('🚀 Development environment started!')
-			print('📧 Available test users:')
-			print(f'   • Test User: {settings.TEST_USER_EMAIL} / {settings.TEST_USER_PASSWORD}')
-			print(f'   • Test User 2: {settings.TEST_USER_EMAIL2} / {settings.TEST_USER_PASSWORD2}')
-			print(f'   • Processor: {settings.PROCESSOR_USERNAME} / {settings.PROCESSOR_PASSWORD}')
+			self._print_dev_accounts()
 			print('')
 			print('🔄 Starting continuous processor... (Press Ctrl+C to stop and cleanup)')
 

--- a/deadtrees-cli/tests/test_dev_security.py
+++ b/deadtrees-cli/tests/test_dev_security.py
@@ -1,0 +1,27 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from deadtrees_cli.dev import DevCommands
+from shared.settings import settings
+
+
+class DevAccountOutputSecurityTest(unittest.TestCase):
+	def test_dev_account_output_omits_passwords(self):
+		passwords = ('primary-secret', 'secondary-secret', 'processor-secret')
+		output = io.StringIO()
+
+		with (
+			patch.object(settings, 'TEST_USER_PASSWORD', passwords[0]),
+			patch.object(settings, 'TEST_USER_PASSWORD2', passwords[1]),
+			patch.object(settings, 'PROCESSOR_PASSWORD', passwords[2]),
+			redirect_stdout(output),
+		):
+			DevCommands()._print_dev_accounts()
+
+		printed = output.getvalue()
+		self.assertIn(settings.TEST_USER_EMAIL, printed)
+		self.assertIn(settings.TEST_USER_EMAIL2, printed)
+		self.assertIn(settings.PROCESSOR_USERNAME, printed)
+		self.assertTrue(all(password not in printed for password in passwords))

--- a/frontend/docs/scratchpad/sam_api.py
+++ b/frontend/docs/scratchpad/sam_api.py
@@ -11,7 +11,7 @@ import pathlib
 import os
 import json
 from typing import Optional, List
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
 # Modal image with dependencies
 WEIGHTS_PATH = "/tmp/Ultralytics/cache/assets/sam2.1_b.pt"
@@ -274,7 +274,7 @@ async def segment_endpoint(
 
     except Exception as e:
         print(f"Error in segmentation: {str(e)}")
-        return {"error": str(e)}
+        return JSONResponse(status_code=500, content={"error": "Segmentation failed"})
 
 
 @app.function(image=image)

--- a/scripts/export_ml_tiles.py
+++ b/scripts/export_ml_tiles.py
@@ -85,7 +85,8 @@ def download_cog_to_temp(cog_url: str) -> Path:
 	Raises:
 		Exception: If download fails
 	"""
-	temp_file = Path(tempfile.mktemp(suffix='.tif'))
+	with tempfile.NamedTemporaryFile(suffix='.tif', delete=False) as reserved_file:
+		temp_file = Path(reserved_file.name)
 
 	try:
 		urllib.request.urlretrieve(cog_url, temp_file)

--- a/scripts/tests/test_codeql_security_regressions.py
+++ b/scripts/tests/test_codeql_security_regressions.py
@@ -1,0 +1,28 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+class CodeQlSecurityRegressionTest(unittest.TestCase):
+	def test_frontend_deploy_token_is_read_only(self):
+		workflow = (REPO_ROOT / '.github/workflows/frontend-hosting-merge.yml').read_text()
+
+		self.assertIn('\npermissions:\n  contents: read\n', workflow)
+
+	def test_sam_error_response_does_not_expose_exception_details(self):
+		source = (REPO_ROOT / 'frontend/docs/scratchpad/sam_api.py').read_text()
+		module = ast.parse(source)
+		handler = next(
+			node
+			for node in ast.walk(module)
+			if isinstance(node, ast.ExceptHandler) and isinstance(node.type, ast.Name) and node.type.id == 'Exception'
+		)
+		response = next(node for node in handler.body if isinstance(node, ast.Return))
+
+		self.assertFalse(any(isinstance(node, ast.Name) and node.id == handler.name for node in ast.walk(response)))
+		self.assertTrue(
+			any(isinstance(node, ast.Constant) and node.value == 'Segmentation failed' for node in ast.walk(response))
+		)

--- a/scripts/tests/test_export_ml_tiles_security.py
+++ b/scripts/tests/test_export_ml_tiles_security.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import export_ml_tiles
+
+
+class ExportMlTilesSecurityTest(unittest.TestCase):
+	def test_download_cog_reserves_temp_file_before_writing(self):
+		def write_download(_url: str, destination: Path):
+			destination = Path(destination)
+			self.assertTrue(destination.exists())
+			destination.write_bytes(b'cog')
+
+		with patch.object(export_ml_tiles.urllib.request, 'urlretrieve', write_download):
+			temp_file = export_ml_tiles.download_cog_to_temp('https://example.test/cog.tif')
+
+		try:
+			self.assertEqual(temp_file.read_bytes(), b'cog')
+			self.assertEqual(temp_file.stat().st_mode & 0o077, 0)
+		finally:
+			temp_file.unlink(missing_ok=True)
+
+	def test_download_cog_removes_reserved_file_after_failure(self):
+		reserved_path = None
+
+		def fail_download(_url: str, destination: Path):
+			nonlocal reserved_path
+			reserved_path = Path(destination)
+			self.assertTrue(reserved_path.exists())
+			raise OSError('download failed')
+
+		with (
+			patch.object(export_ml_tiles.urllib.request, 'urlretrieve', fail_download),
+			self.assertRaisesRegex(Exception, 'Failed to download COG'),
+		):
+			export_ml_tiles.download_cog_to_temp('https://example.test/cog.tif')
+
+		self.assertIsNotNone(reserved_path)
+		self.assertFalse(reserved_path.exists())


### PR DESCRIPTION
## Why
CodeQL identified credential disclosure, insecure temporary-file allocation, overbroad workflow token defaults, and exception detail exposure in current DeadTrees code.

## What
- keep local account identifiers visible without printing configured passwords
- atomically reserve temporary COG files and preserve failure cleanup
- restrict the frontend production deploy workflow to `contents: read`
- return a generic HTTP 500 from the public SAM endpoint while retaining server-side diagnostics
- add focused regression coverage for each boundary

Alerts #2 and #20 were separately dismissed as false positives with source-level evidence; the Paramiko alerts remain excluded from this task.

## Validation
- focused `unittest` checks (5 passed)
- `scripts/lint-python.sh`
- `scripts/lint-ast-grep.sh`
- workflow YAML parse
- Python compile checks
- independent Codex autoreview: no actionable findings

## Risk
Low. Development startup output no longer includes passwords, and SAM failures now return status 500 with a stable generic message.