### PR TITLE
fix(security): upgrade PyTorch runtimes

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -27,6 +27,6 @@ shapely
 pyogrio
 # Open-vocabulary tile search: keep the text encoder on the processor-compatible
 # PyTorch pair; the API Dockerfile installs CPU wheels for amd64.
-torch==2.4.1
-torchvision==0.19.1
+torch==2.6.0
+torchvision==0.21.0
 open-clip-torch>=2.24.0

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /app
 RUN mkdir -p /data
 
 # Keep dependency versions in processor/requirements.txt. Production amd64
-# builds default to CUDA 12.1 wheels; CPU CI overrides only the wheel source.
-ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu121
+# builds default to CUDA 12.4 wheels; CPU CI overrides only the wheel source.
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124
 COPY processor/requirements.txt /app/processor/requirements.txt
 RUN grep -E '^(torch|torchvision)==' /app/processor/requirements.txt > /tmp/torch-requirements.txt && \
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then \

--- a/processor/requirements.txt
+++ b/processor/requirements.txt
@@ -22,8 +22,8 @@ safetensors
 segmentation_models_pytorch
 # Keep this pair aligned with the model checkpoints and open-clip stack. The
 # Dockerfile selects CUDA or CPU wheels without owning a second set of pins.
-torch==2.4.1
-torchvision==0.19.1
+torch==2.6.0
+torchvision==0.21.0
 open-clip-torch>=2.24.0
 opencv-python
 xarray>=2023.1.0

--- a/processor/src/deadwood_segmentation_v1_moehring/inference/deadwood_inference.py
+++ b/processor/src/deadwood_segmentation_v1_moehring/inference/deadwood_inference.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import tempfile
-from pathlib import Path
 
 import numpy as np
 import rasterio
@@ -49,10 +48,6 @@ class DeadwoodInference:
 		self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 		self.load_model()
 
-	def get_cache_path(self):
-		model_path = Path(self.model_path)
-		return model_path.parent / f'{DEADWOOD_MODEL_NAME}_pretrained.pt'
-
 	def load_model(self):
 		version_parts = torch.__version__.split('+', 1)[0].split('.')
 		torch_version = tuple(int(part) for part in version_parts[:3])
@@ -61,23 +56,14 @@ class DeadwoodInference:
 			print('Invalid model name: ', DEADWOOD_MODEL_NAME, 'Exiting...')
 			exit()
 
-		cache_path = self.get_cache_path()
-		if cache_path.exists():
-			model = smp.Unet(
-				encoder_name='mit_b5',
-				encoder_weights=None,
-				in_channels=3,
-				classes=1,
-			).to(memory_format=torch.channels_last)
-			model.load_state_dict(torch.load(str(cache_path)))
-		else:
-			model = smp.Unet(
-				encoder_name='mit_b5',
-				encoder_weights='imagenet',
-				in_channels=3,
-				classes=1,
-			).to(memory_format=torch.channels_last)
-			torch.save(model.state_dict(), str(cache_path))
+		# The safetensors checkpoint contains the complete state dict, so no
+		# separately downloaded or pickle-serialized encoder weights are needed.
+		model = smp.Unet(
+			encoder_name='mit_b5',
+			encoder_weights=None,
+			in_channels=3,
+			classes=1,
+		).to(memory_format=torch.channels_last)
 
 		if hasattr(torch, 'compile') and (sys.version_info < (3, 12) or torch_version >= (2, 4, 0)):
 			model = torch.compile(model, backend='aot_eager')

--- a/processor/tests/test_deadwood_inference_loading.py
+++ b/processor/tests/test_deadwood_inference_loading.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.unit
+def test_deadwood_model_loads_only_the_safetensors_checkpoint(monkeypatch):
+	from processor.src.deadwood_segmentation_v1_moehring.inference import deadwood_inference
+
+	model = Mock()
+	model.to.return_value = model
+	model.eval.return_value = model
+	model_constructor = Mock(return_value=model)
+	load_model = Mock()
+
+	monkeypatch.setattr(deadwood_inference.smp, 'Unet', model_constructor)
+	monkeypatch.setattr(deadwood_inference.safetensors.torch, 'load_model', load_model)
+	monkeypatch.setattr(deadwood_inference.torch, 'compile', lambda value, **_kwargs: value)
+	monkeypatch.setattr(deadwood_inference.torch.cuda, 'is_available', lambda: False)
+
+	inference = deadwood_inference.DeadwoodInference('/models/checkpoint.safetensors')
+
+	model_constructor.assert_called_once_with(
+		encoder_name='mit_b5',
+		encoder_weights=None,
+		in_channels=3,
+		classes=1,
+	)
+	load_model.assert_called_once_with(model, '/models/checkpoint.safetensors')
+	assert inference.model is model


### PR DESCRIPTION
## Why

Dependabot reports critical `torch.load` remote-code-execution exposure in both API and processor runtimes below PyTorch 2.6. The services currently deploy PyTorch 2.4.1.

## What

- upgrade the matched runtime pair to PyTorch 2.6.0 and torchvision 0.21.0 in both services
- move the processor production wheel source from CUDA 12.1 to CUDA 12.4
- remove the redundant pickle-backed pretrained encoder cache so application model loading is safetensors-only
- add a unit regression test for the safetensors-only legacy deadwood loader

## Validation

- API and processor test images build with `pip check` clean
- processor CPU unit suite: 148 passed
- API search tests: 16 passed
- RTX 3090 / driver 535.274: all three production safetensors checkpoints load and infer under `torch 2.6.0+cu124`
- representative 512x512 combined-model pipeline completed with tiling and polygon postprocessing; peak CUDA allocation 3.76 GiB
- isolated API container served OpenAPI under `torch 2.6.0+cpu`; real OpenCLIP text inference returned a finite normalized 1024-vector
- Python lint and repository AST guardrails pass

## Risk

The processor changes its bundled CUDA runtime from 12.1 to 12.4. This was verified on the production GPU model and driver without changing the running production service.
