### PR TITLE
feat(priwa): streamline field and review workflows

### DIFF
--- a/frontend/e2e-local/priwa-field-write-flows.spec.ts
+++ b/frontend/e2e-local/priwa-field-write-flows.spec.ts
@@ -112,7 +112,11 @@ test.describe("PRIWA local field write flows", () => {
       `${page.viewportSize()!.height}px`,
     );
     await expect(page.getByLabel("Bohrmehl")).toBeVisible();
-    await expect(page.getByLabel("Kommentar")).toBeVisible();
+    const comment = page.getByLabel("Kommentar");
+    await expect(comment).toBeVisible();
+    await comment.fill("Bleibt beim Drehen erhalten");
+    await page.setViewportSize({ width: 820, height: 852 });
+    await expect(comment).toHaveValue("Bleibt beim Drehen erhalten");
   });
 
   test("offline create, update, and delete sync into local Supabase", async ({

--- a/frontend/e2e-local/priwa-field-write-flows.spec.ts
+++ b/frontend/e2e-local/priwa-field-write-flows.spec.ts
@@ -60,12 +60,70 @@ test.describe("PRIWA local field write flows", () => {
     await deleteAuthUsersByEmail(adminClient, fieldUserEmail);
   });
 
+  test("mobile field controls keep map actions compact and the form open", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 393, height: 852 });
+    await signInFieldUser(page);
+    const fieldMap = page.getByTestId("priwa-field-map");
+    await expect(fieldMap).toBeVisible();
+    const viewportCoverage = await fieldMap.evaluate((element) => {
+      const bounds = element.getBoundingClientRect();
+      return {
+        bottom: bounds.bottom,
+        documentHeight: document.documentElement.scrollHeight,
+        top: bounds.top,
+        viewportHeight: window.innerHeight,
+      };
+    });
+    expect(viewportCoverage.top).toBeLessThanOrEqual(0);
+    expect(viewportCoverage.bottom).toBeGreaterThanOrEqual(
+      viewportCoverage.viewportHeight,
+    );
+    expect(viewportCoverage.documentHeight).toBeLessThanOrEqual(
+      viewportCoverage.viewportHeight,
+    );
+    await expect(
+      page.getByText("Standort-Button antippen", { exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText("Offline nur im Build", { exact: true }),
+    ).toHaveCount(0);
+
+    await expect(
+      page.getByRole("button", { name: "Zu Karte wechseln" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Baumliste öffnen" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Punkt aufnehmen" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "PRIWA Feldaktionen" }),
+    ).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Punkt aufnehmen" }).click();
+    const captureDrawer = page.locator(
+      ".priwa-point-drawer-root .ant-drawer-content-wrapper",
+    );
+    await expect(captureDrawer).toHaveCSS(
+      "height",
+      `${page.viewportSize()!.height}px`,
+    );
+    await expect(page.getByLabel("Bohrmehl")).toBeVisible();
+    await expect(page.getByLabel("Kommentar")).toBeVisible();
+  });
+
   test("offline create, update, and delete sync into local Supabase", async ({
     context,
     page,
   }) => {
     await signInFieldUser(page);
     await expect(page.getByTestId("priwa-field-map")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Befliegung/ }),
+    ).toBeVisible();
     await expectOfflineBasemapControl(page);
     await page.evaluate(() => {
       window.localStorage.setItem(
@@ -88,6 +146,10 @@ test.describe("PRIWA local field write flows", () => {
     );
     expect(createdRow.name).toBe("Stefan Treyer");
     expect(createdRow.gruene_nadeln_am_boden).toBe("nein");
+    await expect(
+      page.getByText(/Synchronisiert\.\.\.|ausstehend|Sync Fehler/i),
+    ).toHaveCount(0);
+    await expectResizableDesktopPointTable(page);
 
     await context.setOffline(true);
     await editFirstPointBaumnr(page, updatedBaumnr);
@@ -96,6 +158,9 @@ test.describe("PRIWA local field write flows", () => {
     await context.setOffline(false);
     await waitForBrowserOnlineState(page, true);
     await waitForPointRow(updatedBaumnr, (row) => row.deleted_at === null);
+    await expect(
+      page.getByText(/Synchronisiert\.\.\.|ausstehend|Sync Fehler/i),
+    ).toHaveCount(0);
 
     await context.setOffline(true);
     await deleteFirstPoint(page);
@@ -116,7 +181,13 @@ async function createMapEstimatedPoint(page: Page, pointBaumnr: string) {
 
   await page.getByRole("button", { name: "Auf Karte setzen" }).click();
   await page.getByRole("button", { name: "Punkt übernehmen" }).click();
-  await expect(page.getByText("Position gesetzt")).toBeVisible();
+  await expect(
+    page.getByText("Auf Karte gesetzt", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Geschätzt", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Auf Karte setzen" }),
+  ).toHaveAttribute("aria-pressed", "true");
   await expectCommentCounterClearOfSaveButton(page);
 
   await page.getByLabel("Baumnr").fill(pointBaumnr);
@@ -137,22 +208,23 @@ async function expectCommentCounterClearOfSaveButton(page: Page) {
   await expect(counter).toBeVisible();
   await expect(saveButton).toBeVisible();
 
-  const counterBox = await counter.boundingBox();
-  const saveButtonBox = await saveButton.boundingBox();
+  await expect
+    .poll(async () => {
+      const counterBox = await counter.boundingBox();
+      const saveButtonBox = await saveButton.boundingBox();
 
-  expect(counterBox).not.toBeNull();
-  expect(saveButtonBox).not.toBeNull();
-  expect(counterBox!.y + counterBox!.height).toBeLessThan(saveButtonBox!.y);
+      if (!counterBox || !saveButtonBox) return Number.NEGATIVE_INFINITY;
+      return saveButtonBox.y - (counterBox.y + counterBox.height);
+    })
+    .toBeGreaterThan(0);
 }
 
 async function expectOfflineBasemapControl(page: Page) {
-  await page.getByRole("button", { name: "Layer auswählen" }).click();
-  await expect(page.getByText("Kartenbasis")).toBeVisible();
-  await expect(page.getByText("Luftbild", { exact: true })).toBeVisible();
-  await page.getByText("Karte", { exact: true }).click();
+  await page.getByRole("button", { name: "Zu Karte wechseln" }).click();
+  await expect(
+    page.getByRole("button", { name: "Zu Luftbild wechseln" }),
+  ).toBeVisible();
   await expect(page.locator(".ol-layer").first()).toBeVisible();
-  await expect(page.getByText("Offline-Karten")).toBeHidden();
-  await page.keyboard.press("Escape");
 
   await page.getByRole("button", { name: "Offline-Karten speichern" }).click();
   await expect(page.getByText("Offline-Karten")).toBeVisible();
@@ -162,10 +234,75 @@ async function expectOfflineBasemapControl(page: Page) {
   await page.keyboard.press("Escape");
 }
 
+async function expectResizableDesktopPointTable(page: Page) {
+  await page.getByRole("button", { name: "Punktliste öffnen" }).click();
+
+  const panel = page.getByTestId("priwa-point-list-panel");
+  const resizeHandle = page.getByRole("separator", {
+    name: "Tabellenbreite ändern",
+  });
+  const tableBody = panel.locator(".ant-table-body");
+  await expect(panel).toBeVisible();
+  await expect(resizeHandle).toBeVisible();
+  await expect(panel.locator(".ant-table-sticky-holder")).toBeVisible();
+  await expect(tableBody).toBeVisible();
+  expect(
+    await tableBody.evaluate(
+      (element) => element.scrollWidth > element.clientWidth,
+    ),
+  ).toBe(true);
+
+  const initialWidth = await panel.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  expect(initialWidth).toBeLessThanOrEqual(page.viewportSize()!.width - 30);
+
+  await resizeHandle.press("ArrowLeft");
+  await expect
+    .poll(() =>
+      panel.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeLessThan(initialWidth);
+
+  const widthBeforeDrag = await panel.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  const handleBox = await resizeHandle.boundingBox();
+  expect(handleBox).not.toBeNull();
+  await page.mouse.move(
+    handleBox!.x + handleBox!.width / 2,
+    handleBox!.y + handleBox!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox!.x - 64,
+    handleBox!.y + handleBox!.height / 2,
+  );
+  await page.mouse.up();
+  await expect
+    .poll(() =>
+      panel.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeLessThan(widthBeforeDrag);
+  expect(
+    await panel.evaluate((element) => element.getBoundingClientRect().right),
+  ).toBeLessThan(page.viewportSize()!.width - 80);
+
+  await page.getByRole("button", { name: "Schließen" }).click();
+  await expect(panel).toBeHidden();
+}
+
 async function editFirstPointBaumnr(page: Page, pointBaumnr: string) {
   await page.getByRole("button", { name: "Punktliste öffnen" }).click();
   await page.getByRole("button", { name: "Punkt bearbeiten" }).first().click();
   await expect(page.getByText("Käferbaum bearbeiten")).toBeVisible();
+  await expect(
+    page.getByText("Auf Karte gesetzt", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Geschätzt", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Auf Karte setzen" }),
+  ).toHaveAttribute("aria-pressed", "true");
 
   await page.getByLabel("Baumnr").fill(pointBaumnr);
   await page.getByRole("button", { name: "Aktualisieren" }).click();

--- a/frontend/src/components/PriwaField/PriwaBaseLayerControl.tsx
+++ b/frontend/src/components/PriwaField/PriwaBaseLayerControl.tsx
@@ -1,5 +1,5 @@
-import { GlobalOutlined } from "@ant-design/icons";
-import { Button, Popover, Segmented } from "antd";
+import { GlobalOutlined, PictureOutlined } from "@ant-design/icons";
+import { Button, Tooltip } from "antd";
 
 import type { PriwaBaseLayer } from "./types";
 
@@ -12,34 +12,22 @@ export default function PriwaBaseLayerControl({
   value,
   onChange,
 }: PriwaBaseLayerControlProps) {
+  const isAerial = value === "aerial";
+  const actionLabel = isAerial
+    ? "Zu Karte wechseln"
+    : "Zu Luftbild wechseln";
+
   return (
-    <Popover
-      trigger="click"
-      placement="rightTop"
-      content={
-        <div className="w-56">
-          <div className="mb-2 text-sm font-medium text-slate-900">
-            Kartenbasis
-          </div>
-          <Segmented<PriwaBaseLayer>
-            block
-            value={value}
-            options={[
-              { label: "Luftbild", value: "aerial" },
-              { label: "Karte", value: "topographic" },
-            ]}
-            onChange={onChange}
-          />
-        </div>
-      }
-    >
+    <Tooltip title={actionLabel} placement="right">
       <Button
         className="pointer-events-auto shadow-md"
         shape="circle"
         size="large"
-        icon={<GlobalOutlined />}
-        aria-label="Layer auswählen"
+        icon={isAerial ? <PictureOutlined /> : <GlobalOutlined />}
+        aria-label={actionLabel}
+        data-active-layer={value}
+        onClick={() => onChange(isAerial ? "topographic" : "aerial")}
       />
-    </Popover>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Tooltip, message } from "antd";
+import { Alert, Button, FloatButton, Tooltip, message } from "antd";
 import {
   AimOutlined,
   EnvironmentOutlined,
@@ -259,6 +259,7 @@ export default function PriwaFieldMap({
     saveGroup,
     deleteGroup,
     assignFlight,
+    setMosaicVisibility,
     createGroup,
     createGroupForFlight,
   } = review;
@@ -423,14 +424,10 @@ export default function PriwaFieldMap({
     source.clear();
     points.forEach((point) =>
       source.addFeature(
-        createPriwaPointFeature(
-          point,
-          selectedTreeIds.has(point.id),
-          !isMobile && selectedTreeIds.size === 0,
-        ),
+        createPriwaPointFeature(point, selectedTreeIds.has(point.id)),
       ),
     );
-  }, [isMobile, points, selectedTreeIds]);
+  }, [points, selectedTreeIds]);
 
   useEffect(() => {
     if (
@@ -586,9 +583,7 @@ export default function PriwaFieldMap({
       ? "Richtung: Standort-Button antippen"
       : userLocation.isLocating
         ? "Standort wird angefragt"
-        : locationButtonActive
-          ? null
-          : "Standort-Button antippen";
+        : null;
   const handleAddPoint = useCallback(
     async (point: IPriwaPoint) => {
       await onAddPoint(point);
@@ -669,6 +664,7 @@ export default function PriwaFieldMap({
               aria-label="Aktuelle Position aktivieren"
             />
           </Tooltip>
+          <PriwaBaseLayerControl value={baseLayer} onChange={setBaseLayer} />
           <PriwaOfflineMapControl
             area={offlineBasemapArea}
             cacheState={basemapCacheState}
@@ -676,8 +672,13 @@ export default function PriwaFieldMap({
             onCache={handleCacheBasemapArea}
             onClear={handleClearBasemapArea}
           />
-          {!isMobile && (
-            <PriwaBaseLayerControl value={baseLayer} onChange={setBaseLayer} />
+          {isMobile && (
+            <PriwaMobileFieldTools
+              points={points}
+              groups={groups}
+              onEditPoint={openPointForEditing}
+              onZoomToPoint={focusPointOnMap}
+            />
           )}
           {!isMobile && !isPointListOpen && !isDrawerOpen && (
             <Tooltip title="Käferbaum aufnehmen">
@@ -694,6 +695,21 @@ export default function PriwaFieldMap({
         </div>
       )}
 
+      {isMobile && !isDrawerOpen && !isPointListOpen && !isPlacingPoint && (
+        <FloatButton
+          className="priwa-add-point-fab"
+          shape="circle"
+          icon={<PlusOutlined />}
+          tooltip={{ title: "Punkt aufnehmen", placement: "left" }}
+          onClick={openNewPointDrawer}
+          aria-label="Punkt aufnehmen"
+          style={{
+            right: "max(20px, calc(env(safe-area-inset-right, 0px) + 20px))",
+            bottom: "max(20px, calc(env(safe-area-inset-bottom, 0px) + 20px))",
+          }}
+        />
+      )}
+
       {!isMobile && !isPointListOpen && !isPlacingPoint && (
         <PriwaReviewWorkbench
           items={reviewItems}
@@ -703,6 +719,7 @@ export default function PriwaFieldMap({
           isLoading={isWorkspaceLoading}
           isSavingGroup={isSavingGroup}
           isClassifyingFlight={isClassifyingFlight}
+          enabledMosaicIds={enabledMosaicIds}
           onSelect={selectReviewItem}
           onOpenData={() => {
             setFocusedPointId(null);
@@ -712,22 +729,11 @@ export default function PriwaFieldMap({
           onFocusTree={focusPointOnMap}
           onEditTree={openPointForEditing}
           onEditGroup={setGroupEditorDraft}
-          onConfirmSuggestion={saveGroup}
+          onSaveGroup={saveGroup}
           onAssignFlight={assignFlight}
+          onSetMosaicVisibility={setMosaicVisibility}
           onSetFlightType={setFlightType}
           onCreateGroupForFlight={createGroupForFlight}
-        />
-      )}
-
-      {isMobile && !isDrawerOpen && !isPlacingPoint && (
-        <PriwaMobileFieldTools
-          points={points}
-          groups={groups}
-          baseLayer={baseLayer}
-          onBaseLayerChange={setBaseLayer}
-          onAddPoint={openNewPointDrawer}
-          onEditPoint={openPointForEditing}
-          onZoomToPoint={focusPointOnMap}
         />
       )}
 

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -793,6 +793,7 @@ export default function PriwaFieldMap({
       )}
 
       <PriwaPointDrawer
+        key={formSessionId}
         isMobile={isMobile}
         open={isDrawerOpen}
         formSessionId={formSessionId}

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, FloatButton, Tooltip, message } from "antd";
+import { Alert, Button, FloatButton, Grid, Tooltip, message } from "antd";
 import {
   AimOutlined,
   EnvironmentOutlined,
@@ -162,8 +162,10 @@ export default function PriwaFieldMap({
   const [formSessionId, setFormSessionId] = useState(0);
   const [isPointListOpen, setPointListOpen] = useState(false);
   const [focusedPointId, setFocusedPointId] = useState<string | null>(null);
+  const [reviewPointId, setReviewPointId] = useState<string | null>(null);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
   const isMobile = useIsMobile();
+  const screens = Grid.useBreakpoint();
   const userLocation = useUserLocationLayer(mapRef);
   const {
     layer: userLocationLayer,
@@ -424,10 +426,14 @@ export default function PriwaFieldMap({
     source.clear();
     points.forEach((point) =>
       source.addFeature(
-        createPriwaPointFeature(point, selectedTreeIds.has(point.id)),
+        createPriwaPointFeature(
+          point,
+          selectedTreeIds.has(point.id),
+          point.id === reviewPointId,
+        ),
       ),
     );
-  }, [points, selectedTreeIds]);
+  }, [points, reviewPointId, selectedTreeIds]);
 
   useEffect(() => {
     if (
@@ -506,14 +512,48 @@ export default function PriwaFieldMap({
   );
 
   useEffect(() => {
-    selectReviewItemFromMosaicRef.current = selectReviewItemFromMosaic;
-    selectReviewItemFromGroupRef.current = selectReviewItemFromGroup;
-    selectReviewItemFromPointRef.current = selectReviewItemFromPoint;
+    selectReviewItemFromMosaicRef.current = (mosaicId) => {
+      setReviewPointId(null);
+      selectReviewItemFromMosaic(mosaicId);
+    };
+    selectReviewItemFromGroupRef.current = (groupId) => {
+      setReviewPointId(null);
+      selectReviewItemFromGroup(groupId);
+    };
+    selectReviewItemFromPointRef.current = (point) => {
+      setReviewPointId(point.id);
+      selectReviewItemFromPoint(point);
+    };
   }, [
     selectReviewItemFromGroup,
     selectReviewItemFromMosaic,
     selectReviewItemFromPoint,
   ]);
+
+  useEffect(() => {
+    if (reviewPointId && !points.some((point) => point.id === reviewPointId)) {
+      setReviewPointId(null);
+    }
+  }, [points, reviewPointId]);
+
+  const selectReviewPoint = useCallback(
+    (point: IPriwaPoint) => {
+      setReviewPointId(point.id);
+      selectReviewItemFromPoint(point);
+      focusPointOnMap(point);
+    },
+    [focusPointOnMap, selectReviewItemFromPoint],
+  );
+
+  const openReviewPointForEditing = useCallback(
+    (point: IPriwaPoint) => {
+      setReviewPointId(point.id);
+      selectReviewItemFromPoint(point);
+      focusPointOnMap(point);
+      openPointForEditing(point);
+    },
+    [focusPointOnMap, openPointForEditing, selectReviewItemFromPoint],
+  );
 
   const openNewPointDrawer = useCallback(() => {
     setPointListOpen(false);
@@ -720,14 +760,20 @@ export default function PriwaFieldMap({
           isSavingGroup={isSavingGroup}
           isClassifyingFlight={isClassifyingFlight}
           enabledMosaicIds={enabledMosaicIds}
+          selectedTreeId={reviewPointId}
           onSelect={selectReviewItem}
           onOpenData={() => {
+            setReviewPointId(null);
             setFocusedPointId(null);
             setPointListOpen(true);
           }}
-          onCreateGroup={createGroup}
-          onFocusTree={focusPointOnMap}
-          onEditTree={openPointForEditing}
+          onCreateGroup={() => {
+            setReviewPointId(null);
+            createGroup();
+          }}
+          onFocusTree={selectReviewPoint}
+          onEditTree={openReviewPointForEditing}
+          onCloseTree={() => setReviewPointId(null)}
           onEditGroup={setGroupEditorDraft}
           onSaveGroup={saveGroup}
           onAssignFlight={assignFlight}
@@ -812,6 +858,14 @@ export default function PriwaFieldMap({
         onRequestMapPlacement={requestMapPlacement}
         onPreviewCoordinate={handlePreviewCoordinate}
         onZoomToPoint={zoomToCoordinate}
+        presentation={
+          !isMobile &&
+          !!screens.xl &&
+          !!editingPoint &&
+          editingPoint.id === reviewPointId
+            ? "review-inspector"
+            : "overlay"
+        }
       />
 
       <PriwaBefallsgruppeEditor

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, FloatButton, Grid, Tooltip, message } from "antd";
+import { Alert, Button, FloatButton, Tooltip, message } from "antd";
 import {
   AimOutlined,
   EnvironmentOutlined,
@@ -40,6 +40,10 @@ import PriwaBaseLayerControl from "./PriwaBaseLayerControl";
 import PriwaMobileFieldTools from "./PriwaMobileFieldTools";
 import PriwaOfflineMapControl from "./PriwaOfflineMapControl";
 import PriwaReviewWorkbench from "./PriwaReviewWorkbench";
+import {
+  getPriwaReviewMapCenter,
+  getPriwaReviewTargetPixel,
+} from "./priwaReviewMapFocus";
 import { usePriwaOfflineBasemap } from "./usePriwaOfflineBasemap";
 import { usePriwaReviewController } from "./usePriwaReviewController";
 import { usePriwaReviewMapLayers } from "./usePriwaReviewMapLayers";
@@ -165,7 +169,6 @@ export default function PriwaFieldMap({
   const [reviewPointId, setReviewPointId] = useState<string | null>(null);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
   const isMobile = useIsMobile();
-  const screens = Grid.useBreakpoint();
   const userLocation = useUserLocationLayer(mapRef);
   const {
     layer: userLocationLayer,
@@ -511,6 +514,39 @@ export default function PriwaFieldMap({
     [selectMatchedMosaicForPoint, zoomToCoordinate],
   );
 
+  const focusReviewPointOnMap = useCallback((point: IPriwaPoint) => {
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        const map = mapRef.current;
+        const mapSize = map?.getSize();
+        const view = map?.getView();
+        if (!map || !mapSize || !view) return;
+
+        const zoom = 20;
+        const resolution = view.getResolutionForZoom(zoom);
+        const mapRect = map.getTargetElement().getBoundingClientRect();
+        const queueRect = document
+          .querySelector<HTMLElement>("[data-priwa-review-queue-panel]")
+          ?.getBoundingClientRect();
+        const treePanelRect = document
+          .querySelector<HTMLElement>("[data-priwa-review-tree-panel]")
+          ?.getBoundingClientRect();
+        const targetPixel = getPriwaReviewTargetPixel(
+          mapRect,
+          queueRect ?? null,
+          treePanelRect ?? null,
+        );
+        const center = getPriwaReviewMapCenter(
+          fromLonLat([point.lon, point.lat]),
+          mapSize,
+          targetPixel,
+          resolution,
+        );
+        view.animate({ center, zoom, duration: 500 });
+      }),
+    );
+  }, []);
+
   useEffect(() => {
     selectReviewItemFromMosaicRef.current = (mosaicId) => {
       setReviewPointId(null);
@@ -523,8 +559,10 @@ export default function PriwaFieldMap({
     selectReviewItemFromPointRef.current = (point) => {
       setReviewPointId(point.id);
       selectReviewItemFromPoint(point);
+      focusReviewPointOnMap(point);
     };
   }, [
+    focusReviewPointOnMap,
     selectReviewItemFromGroup,
     selectReviewItemFromMosaic,
     selectReviewItemFromPoint,
@@ -540,19 +578,22 @@ export default function PriwaFieldMap({
     (point: IPriwaPoint) => {
       setReviewPointId(point.id);
       selectReviewItemFromPoint(point);
-      focusPointOnMap(point);
+      selectMatchedMosaicForPoint(point);
+      focusReviewPointOnMap(point);
     },
-    [focusPointOnMap, selectReviewItemFromPoint],
+    [
+      focusReviewPointOnMap,
+      selectMatchedMosaicForPoint,
+      selectReviewItemFromPoint,
+    ],
   );
 
   const openReviewPointForEditing = useCallback(
     (point: IPriwaPoint) => {
-      setReviewPointId(point.id);
-      selectReviewItemFromPoint(point);
-      focusPointOnMap(point);
-      openPointForEditing(point);
+      selectReviewPoint(point);
+      requestAnimationFrame(() => openPointForEditing(point));
     },
-    [focusPointOnMap, openPointForEditing, selectReviewItemFromPoint],
+    [openPointForEditing, selectReviewPoint],
   );
 
   const openNewPointDrawer = useCallback(() => {
@@ -672,6 +713,11 @@ export default function PriwaFieldMap({
 
   const dataErrorMessage =
     errorMessage ?? groupsErrorMessage ?? cogErrorMessage;
+  const isReviewTreeEditing =
+    !isMobile &&
+    isDrawerOpen &&
+    !!editingPoint &&
+    editingPoint.id === reviewPointId;
 
   return (
     <div
@@ -750,7 +796,7 @@ export default function PriwaFieldMap({
         />
       )}
 
-      {!isMobile && !isPointListOpen && !isPlacingPoint && (
+      {!isMobile && !isPointListOpen && (
         <PriwaReviewWorkbench
           items={reviewItems}
           points={points}
@@ -761,6 +807,8 @@ export default function PriwaFieldMap({
           isClassifyingFlight={isClassifyingFlight}
           enabledMosaicIds={enabledMosaicIds}
           selectedTreeId={reviewPointId}
+          isTreeEditing={isReviewTreeEditing}
+          isHidden={isPlacingPoint}
           onSelect={selectReviewItem}
           onOpenData={() => {
             setReviewPointId(null);
@@ -858,14 +906,7 @@ export default function PriwaFieldMap({
         onRequestMapPlacement={requestMapPlacement}
         onPreviewCoordinate={handlePreviewCoordinate}
         onZoomToPoint={zoomToCoordinate}
-        presentation={
-          !isMobile &&
-          !!screens.xl &&
-          !!editingPoint &&
-          editingPoint.id === reviewPointId
-            ? "review-inspector"
-            : "overlay"
-        }
+        presentation={isReviewTreeEditing ? "embedded" : "overlay"}
       />
 
       <PriwaBefallsgruppeEditor

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -559,10 +559,8 @@ export default function PriwaFieldMap({
     selectReviewItemFromPointRef.current = (point) => {
       setReviewPointId(point.id);
       selectReviewItemFromPoint(point);
-      focusReviewPointOnMap(point);
     };
   }, [
-    focusReviewPointOnMap,
     selectReviewItemFromGroup,
     selectReviewItemFromMosaic,
     selectReviewItemFromPoint,
@@ -579,13 +577,16 @@ export default function PriwaFieldMap({
       setReviewPointId(point.id);
       selectReviewItemFromPoint(point);
       selectMatchedMosaicForPoint(point);
+    },
+    [selectMatchedMosaicForPoint, selectReviewItemFromPoint],
+  );
+
+  const focusSelectedReviewPoint = useCallback(
+    (point: IPriwaPoint) => {
+      selectReviewPoint(point);
       focusReviewPointOnMap(point);
     },
-    [
-      focusReviewPointOnMap,
-      selectMatchedMosaicForPoint,
-      selectReviewItemFromPoint,
-    ],
+    [focusReviewPointOnMap, selectReviewPoint],
   );
 
   const openReviewPointForEditing = useCallback(
@@ -819,7 +820,8 @@ export default function PriwaFieldMap({
             setReviewPointId(null);
             createGroup();
           }}
-          onFocusTree={selectReviewPoint}
+          onSelectTree={selectReviewPoint}
+          onFocusTree={focusSelectedReviewPoint}
           onEditTree={openReviewPointForEditing}
           onCloseTree={() => setReviewPointId(null)}
           onEditGroup={setGroupEditorDraft}

--- a/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
@@ -1,22 +1,14 @@
-import {
-  EnvironmentOutlined,
-  PlusOutlined,
-  SearchOutlined,
-  UnorderedListOutlined,
-} from "@ant-design/icons";
-import { Button, Drawer, Empty, Input } from "antd";
+import { SearchOutlined, UnorderedListOutlined } from "@ant-design/icons";
+import { Button, Drawer, Empty, Input, Tooltip } from "antd";
 import { useMemo, useState } from "react";
 
 import { indexPriwaBefallsgruppenByTreeId } from "./priwaBefallsgruppenState";
 import PriwaPointCompactList from "./PriwaPointCompactList";
-import type { IPriwaBefallsgruppe, IPriwaPoint, PriwaBaseLayer } from "./types";
+import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
 
 interface PriwaMobileFieldToolsProps {
   points: IPriwaPoint[];
   groups: IPriwaBefallsgruppe[];
-  baseLayer: PriwaBaseLayer;
-  onBaseLayerChange: (baseLayer: PriwaBaseLayer) => void;
-  onAddPoint: () => void;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
 }
@@ -24,9 +16,6 @@ interface PriwaMobileFieldToolsProps {
 export default function PriwaMobileFieldTools({
   points,
   groups,
-  baseLayer,
-  onBaseLayerChange,
-  onAddPoint,
   onEditPoint,
   onZoomToPoint,
 }: PriwaMobileFieldToolsProps) {
@@ -54,38 +43,17 @@ export default function PriwaMobileFieldTools({
 
   return (
     <>
-      <nav
-        aria-label="PRIWA Feldaktionen"
-        className="pointer-events-auto absolute bottom-3 left-3 right-3 z-[56] grid grid-cols-[1fr_1.35fr_1fr] gap-2 rounded-2xl border border-slate-200 bg-white/95 p-2 shadow-xl backdrop-blur md:hidden"
-        style={{
-          paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 8px)",
-        }}
-      >
+      <Tooltip title="Bäume" placement="right">
         <Button
-          className="h-12"
+          className="pointer-events-auto shadow-md md:hidden"
+          shape="circle"
+          size="large"
           icon={<UnorderedListOutlined />}
           onClick={() => setTreeListOpen(true)}
-        >
-          Bäume
-        </Button>
-        <Button
-          className="h-12"
-          type="primary"
-          icon={<PlusOutlined />}
-          onClick={onAddPoint}
-        >
-          Aufnehmen
-        </Button>
-        <Button
-          className="h-12"
-          icon={<EnvironmentOutlined />}
-          onClick={() =>
-            onBaseLayerChange(baseLayer === "aerial" ? "topographic" : "aerial")
-          }
-        >
-          {baseLayer === "aerial" ? "Karte" : "Luftbild"}
-        </Button>
-      </nav>
+          aria-label="Baumliste öffnen"
+          aria-pressed={isTreeListOpen}
+        />
+      </Tooltip>
 
       <Drawer
         title={`Käferbäume (${points.length})`}

--- a/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
+++ b/frontend/src/components/PriwaField/PriwaOfflineStatus.tsx
@@ -27,19 +27,21 @@ export default function PriwaOfflineStatus({
     isOnline,
   );
   const syncLabel = getSyncLabel(syncSummary);
-  const label = syncLabel ?? statusView.label;
+  const label = syncLabel ?? statusView?.label;
   const color =
     syncSummary && syncSummary.failed > 0
       ? "error"
       : syncSummary && syncSummary.total > 0
         ? "processing"
-        : statusView.color;
+        : (statusView?.color ?? "default");
   const tooltipTitle =
     serviceWorker.errorMessage ??
     (syncSummary && syncSummary.total > 0
       ? `${syncSummary.pending} ausstehend, ${syncSummary.syncing} wird synchronisiert, ${syncSummary.failed} fehlgeschlagen`
-      : statusView.label);
+      : statusView?.label);
   const hasSyncWork = (syncSummary?.total ?? 0) > 0;
+  if (!label || !tooltipTitle) return null;
+
   const statusTag = (
     <Tag
       className="pointer-events-auto m-0 rounded-md border-0 px-2.5 py-1 text-xs font-medium shadow-sm"

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -206,7 +206,7 @@ interface PriwaPointDrawerProps {
   onRequestMapPlacement: () => void;
   onPreviewCoordinate: (coordinate: IPriwaCoordinate | null) => void;
   onZoomToPoint: (coordinate: IPriwaCoordinate) => void;
-  presentation?: "overlay" | "review-inspector";
+  presentation?: "overlay" | "embedded";
 }
 
 export default function PriwaPointDrawer({
@@ -227,7 +227,7 @@ export default function PriwaPointDrawer({
   onZoomToPoint,
   presentation = "overlay",
 }: PriwaPointDrawerProps) {
-  const isReviewInspector = presentation === "review-inspector";
+  const isEmbedded = presentation === "embedded";
   const [form] = Form.useForm<IPriwaPointFormValues>();
   const [rawQrValue, setRawQrValue] = useState("");
   const [coordinate, setCoordinate] = useState<IPriwaCoordinate | null>(null);
@@ -422,21 +422,19 @@ export default function PriwaPointDrawer({
       open={open}
       onClose={onClose}
       placement={isMobile ? "bottom" : "right"}
-      width={
-        isMobile ? undefined : isReviewInspector ? "100%" : "min(430px, 100vw)"
-      }
+      width={isMobile ? undefined : isEmbedded ? "100%" : "min(430px, 100vw)"}
       height={isMobile ? "100dvh" : undefined}
-      getContainer={isReviewInspector ? false : undefined}
-      mask={!isReviewInspector}
+      getContainer={
+        isEmbedded
+          ? () => document.getElementById("priwa-review-tree-panel")!
+          : undefined
+      }
+      mask={!isEmbedded}
       rootStyle={
-        isReviewInspector
+        isEmbedded
           ? {
               position: "absolute",
-              bottom: "1.25rem",
-              left: "auto",
-              right: "24.5rem",
-              top: "6rem",
-              width: "22rem",
+              inset: 0,
             }
           : undefined
       }
@@ -456,7 +454,7 @@ export default function PriwaPointDrawer({
           maxHeight: "100dvh",
           maxWidth: "100vw",
           overflowX: "hidden",
-          ...(isReviewInspector
+          ...(isEmbedded
             ? {
                 border: "1px solid rgb(226 232 240)",
                 borderRadius: 12,

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -12,7 +12,6 @@ import {
 } from "antd";
 import {
   AimOutlined,
-  CheckCircleFilled,
   DownOutlined,
   EnvironmentOutlined,
   QrcodeOutlined,
@@ -22,6 +21,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 import { parseGoogleMapsCoordinates } from "./parseGoogleMapsCoordinates";
+import { getPriwaCoordinateSourcePresentation } from "./priwaCoordinateSource";
 import QrCoordinateScanner from "./QrCoordinateScanner";
 import type {
   IPriwaCoordinate,
@@ -38,6 +38,9 @@ import type {
 } from "./types";
 
 const today = () => new Date().toISOString().slice(0, 10);
+
+const defaultFormSectionKeys = (isMobile: boolean) =>
+  isMobile ? ["baum", "befall", "optional"] : ["baum"];
 
 const observerOptions: Array<{ label: string; value: PriwaObserverName }> = [
   { label: "Sigi Huber", value: "Sigi Huber" },
@@ -228,7 +231,9 @@ export default function PriwaPointDrawer({
   const [coordinateSource, setCoordinateSource] =
     useState<PriwaCoordinateSource>("qr");
   const [isQrScannerOpen, setQrScannerOpen] = useState(false);
-  const [activeCollapseKeys, setActiveCollapseKeys] = useState<string[]>([]);
+  const [activeCollapseKeys, setActiveCollapseKeys] = useState<string[]>(() =>
+    defaultFormSectionKeys(isMobile),
+  );
   const [defaultObserverName, setDefaultObserverName] =
     useState<PriwaObserverName>(() => loadStoredObserverName());
 
@@ -243,14 +248,14 @@ export default function PriwaPointDrawer({
     if (editingPoint) {
       form.setFieldsValue(createFormValuesFromPoint(editingPoint));
       setRawQrValue(editingPoint.rawQrValue ?? "");
-      setActiveCollapseKeys(["baum"]);
+      setActiveCollapseKeys(defaultFormSectionKeys(isMobile));
       return;
     }
 
     form.setFieldsValue(createDefaultFormValues(loadStoredObserverName()));
     setRawQrValue("");
-    setActiveCollapseKeys(["baum"]);
-  }, [editingPoint, form, formSessionId]);
+    setActiveCollapseKeys(defaultFormSectionKeys(isMobile));
+  }, [editingPoint, form, formSessionId, isMobile]);
 
   useEffect(() => {
     if (!open) return;
@@ -292,21 +297,31 @@ export default function PriwaPointDrawer({
 
   const effectiveCoordinate = coordinate ?? currentUserCoordinate;
   const willUseEstimatedGps = !coordinate && !!currentUserCoordinate;
-  const positionLabel = willUseEstimatedGps
-    ? "GPS geschätzt"
+  const effectiveCoordinateSource = willUseEstimatedGps
+    ? "gps"
     : coordinate
-      ? coordinateSource === "qr"
-        ? "QR"
-        : coordinateSource === "map"
-          ? "Karte"
-          : "GPS"
-      : "Keine Position";
-  const positionDetail = effectiveCoordinate
+      ? coordinateSource
+      : null;
+  const isEstimatedPosition =
+    effectiveCoordinateSource !== null && effectiveCoordinateSource !== "qr";
+  const positionLabel = effectiveCoordinateSource
+    ? getPriwaCoordinateSourcePresentation(effectiveCoordinateSource).detailLabel
+    : "Keine Position";
+  const positionQualityLabel = isEstimatedPosition
+    ? "Geschätzt"
+    : "Bestätigt";
+  const positionCoordinates = effectiveCoordinate
     ? `${effectiveCoordinate.lat.toFixed(5)}, ${effectiveCoordinate.lon.toFixed(5)}`
-    : "QR, GPS oder Karte";
-  const hasConfirmedLocation = !!coordinate;
-  const requiresBaumnr =
-    willUseEstimatedGps || (hasConfirmedLocation && coordinateSource !== "qr");
+    : null;
+  const positionIcon =
+    effectiveCoordinateSource === "qr" ? (
+      <QrcodeOutlined />
+    ) : effectiveCoordinateSource === "map" ? (
+      <AimOutlined />
+    ) : (
+      <EnvironmentOutlined />
+    );
+  const requiresBaumnr = isEstimatedPosition;
 
   const handleSave = async () => {
     if (!effectiveCoordinate) return;
@@ -408,7 +423,7 @@ export default function PriwaPointDrawer({
       onClose={onClose}
       placement={isMobile ? "bottom" : "right"}
       width={isMobile ? undefined : "min(430px, 100vw)"}
-      height={isMobile ? "88dvh" : undefined}
+      height={isMobile ? "100dvh" : undefined}
       rootClassName="priwa-point-drawer-root"
       className="priwa-point-drawer"
       destroyOnClose={false}
@@ -431,8 +446,10 @@ export default function PriwaPointDrawer({
       <div className="space-y-3">
         <section
           className={
-            hasConfirmedLocation
+            effectiveCoordinate && !isEstimatedPosition
               ? "rounded-md border border-emerald-500 bg-emerald-50 p-2.5 shadow-sm shadow-emerald-900/10"
+              : effectiveCoordinate
+                ? "rounded-md border border-amber-400 bg-amber-50 p-2.5 shadow-sm shadow-amber-900/10"
               : "rounded-md border border-gray-200 bg-gray-50 p-2.5"
           }
         >
@@ -440,36 +457,45 @@ export default function PriwaPointDrawer({
             <div className="flex min-w-0 items-center gap-2">
               <div
                 className={
-                  hasConfirmedLocation
+                  effectiveCoordinate && !isEstimatedPosition
                     ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white"
+                    : effectiveCoordinate
+                      ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-500 text-white"
                     : "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500"
                 }
               >
-                {hasConfirmedLocation ? (
-                  <CheckCircleFilled />
-                ) : (
-                  <EnvironmentOutlined />
-                )}
+                {positionIcon}
               </div>
               <div className="min-w-0">
                 <Typography.Text
                   strong
                   className={
-                    hasConfirmedLocation ? "text-emerald-900" : "text-gray-900"
+                    effectiveCoordinate && !isEstimatedPosition
+                      ? "text-emerald-900"
+                      : effectiveCoordinate
+                        ? "text-amber-900"
+                        : "text-gray-900"
                   }
                 >
-                  {hasConfirmedLocation ? "Position gesetzt" : positionLabel}
+                  {positionLabel}
                 </Typography.Text>
                 <div
                   className={
-                    hasConfirmedLocation
+                    effectiveCoordinate && !isEstimatedPosition
                       ? "truncate text-xs font-medium text-emerald-800"
+                      : effectiveCoordinate
+                        ? "truncate text-xs font-medium text-amber-800"
                       : "truncate text-xs text-gray-500"
                   }
                 >
-                  {hasConfirmedLocation
-                    ? `${positionLabel} · ${positionDetail}`
-                    : positionDetail}
+                  {positionCoordinates ? (
+                    <>
+                      <span>{positionQualityLabel}</span>
+                      <span>{` · ${positionCoordinates}`}</span>
+                    </>
+                  ) : (
+                    "QR, GPS oder Karte"
+                  )}
                 </div>
               </div>
             </div>
@@ -478,23 +504,29 @@ export default function PriwaPointDrawer({
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<QrcodeOutlined />}
+                type={effectiveCoordinateSource === "qr" ? "primary" : "default"}
                 onClick={() => setQrScannerOpen(true)}
                 aria-label="QR scannen"
+                aria-pressed={effectiveCoordinateSource === "qr"}
               />
               <Button
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<EnvironmentOutlined />}
+                type={effectiveCoordinateSource === "gps" ? "primary" : "default"}
                 disabled={!currentUserCoordinate}
                 onClick={useCurrentGpsCoordinate}
                 aria-label="GPS übernehmen"
+                aria-pressed={effectiveCoordinateSource === "gps"}
               />
               <Button
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<AimOutlined />}
+                type={effectiveCoordinateSource === "map" ? "primary" : "default"}
                 onClick={onRequestMapPlacement}
                 aria-label="Auf Karte setzen"
+                aria-pressed={effectiveCoordinateSource === "map"}
               />
             </div>
           </div>

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -248,14 +248,12 @@ export default function PriwaPointDrawer({
     if (editingPoint) {
       form.setFieldsValue(createFormValuesFromPoint(editingPoint));
       setRawQrValue(editingPoint.rawQrValue ?? "");
-      setActiveCollapseKeys(defaultFormSectionKeys(isMobile));
       return;
     }
 
     form.setFieldsValue(createDefaultFormValues(loadStoredObserverName()));
     setRawQrValue("");
-    setActiveCollapseKeys(defaultFormSectionKeys(isMobile));
-  }, [editingPoint, form, formSessionId, isMobile]);
+  }, [editingPoint, form, formSessionId]);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -206,6 +206,7 @@ interface PriwaPointDrawerProps {
   onRequestMapPlacement: () => void;
   onPreviewCoordinate: (coordinate: IPriwaCoordinate | null) => void;
   onZoomToPoint: (coordinate: IPriwaCoordinate) => void;
+  presentation?: "overlay" | "review-inspector";
 }
 
 export default function PriwaPointDrawer({
@@ -224,7 +225,9 @@ export default function PriwaPointDrawer({
   onRequestMapPlacement,
   onPreviewCoordinate,
   onZoomToPoint,
+  presentation = "overlay",
 }: PriwaPointDrawerProps) {
+  const isReviewInspector = presentation === "review-inspector";
   const [form] = Form.useForm<IPriwaPointFormValues>();
   const [rawQrValue, setRawQrValue] = useState("");
   const [coordinate, setCoordinate] = useState<IPriwaCoordinate | null>(null);
@@ -303,11 +306,10 @@ export default function PriwaPointDrawer({
   const isEstimatedPosition =
     effectiveCoordinateSource !== null && effectiveCoordinateSource !== "qr";
   const positionLabel = effectiveCoordinateSource
-    ? getPriwaCoordinateSourcePresentation(effectiveCoordinateSource).detailLabel
+    ? getPriwaCoordinateSourcePresentation(effectiveCoordinateSource)
+        .detailLabel
     : "Keine Position";
-  const positionQualityLabel = isEstimatedPosition
-    ? "Geschätzt"
-    : "Bestätigt";
+  const positionQualityLabel = isEstimatedPosition ? "Geschätzt" : "Bestätigt";
   const positionCoordinates = effectiveCoordinate
     ? `${effectiveCoordinate.lat.toFixed(5)}, ${effectiveCoordinate.lon.toFixed(5)}`
     : null;
@@ -420,8 +422,24 @@ export default function PriwaPointDrawer({
       open={open}
       onClose={onClose}
       placement={isMobile ? "bottom" : "right"}
-      width={isMobile ? undefined : "min(430px, 100vw)"}
+      width={
+        isMobile ? undefined : isReviewInspector ? "100%" : "min(430px, 100vw)"
+      }
       height={isMobile ? "100dvh" : undefined}
+      getContainer={isReviewInspector ? false : undefined}
+      mask={!isReviewInspector}
+      rootStyle={
+        isReviewInspector
+          ? {
+              position: "absolute",
+              bottom: "1.25rem",
+              left: "auto",
+              right: "24.5rem",
+              top: "6rem",
+              width: "22rem",
+            }
+          : undefined
+      }
       rootClassName="priwa-point-drawer-root"
       className="priwa-point-drawer"
       destroyOnClose={false}
@@ -438,6 +456,14 @@ export default function PriwaPointDrawer({
           maxHeight: "100dvh",
           maxWidth: "100vw",
           overflowX: "hidden",
+          ...(isReviewInspector
+            ? {
+                border: "1px solid rgb(226 232 240)",
+                borderRadius: 12,
+                boxShadow: "0 20px 25px -5px rgb(15 23 42 / 0.18)",
+                overflowY: "hidden",
+              }
+            : {}),
         },
       }}
     >
@@ -448,7 +474,7 @@ export default function PriwaPointDrawer({
               ? "rounded-md border border-emerald-500 bg-emerald-50 p-2.5 shadow-sm shadow-emerald-900/10"
               : effectiveCoordinate
                 ? "rounded-md border border-amber-400 bg-amber-50 p-2.5 shadow-sm shadow-amber-900/10"
-              : "rounded-md border border-gray-200 bg-gray-50 p-2.5"
+                : "rounded-md border border-gray-200 bg-gray-50 p-2.5"
           }
         >
           <div className="flex items-center justify-between gap-3">
@@ -459,7 +485,7 @@ export default function PriwaPointDrawer({
                     ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white"
                     : effectiveCoordinate
                       ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-500 text-white"
-                    : "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500"
+                      : "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500"
                 }
               >
                 {positionIcon}
@@ -483,7 +509,7 @@ export default function PriwaPointDrawer({
                       ? "truncate text-xs font-medium text-emerald-800"
                       : effectiveCoordinate
                         ? "truncate text-xs font-medium text-amber-800"
-                      : "truncate text-xs text-gray-500"
+                        : "truncate text-xs text-gray-500"
                   }
                 >
                   {positionCoordinates ? (
@@ -502,7 +528,9 @@ export default function PriwaPointDrawer({
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<QrcodeOutlined />}
-                type={effectiveCoordinateSource === "qr" ? "primary" : "default"}
+                type={
+                  effectiveCoordinateSource === "qr" ? "primary" : "default"
+                }
                 onClick={() => setQrScannerOpen(true)}
                 aria-label="QR scannen"
                 aria-pressed={effectiveCoordinateSource === "qr"}
@@ -511,7 +539,9 @@ export default function PriwaPointDrawer({
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<EnvironmentOutlined />}
-                type={effectiveCoordinateSource === "gps" ? "primary" : "default"}
+                type={
+                  effectiveCoordinateSource === "gps" ? "primary" : "default"
+                }
                 disabled={!currentUserCoordinate}
                 onClick={useCurrentGpsCoordinate}
                 aria-label="GPS übernehmen"
@@ -521,7 +551,9 @@ export default function PriwaPointDrawer({
                 className="h-11 w-12"
                 style={{ height: 44, minWidth: 48, width: 48 }}
                 icon={<AimOutlined />}
-                type={effectiveCoordinateSource === "map" ? "primary" : "default"}
+                type={
+                  effectiveCoordinateSource === "map" ? "primary" : "default"
+                }
                 onClick={onRequestMapPlacement}
                 aria-label="Auf Karte setzen"
                 aria-pressed={effectiveCoordinateSource === "map"}

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,17 +1,10 @@
-import {
-  ColumnWidthOutlined,
-  DownloadOutlined,
-  EnvironmentOutlined,
-} from "@ant-design/icons";
+import { DownloadOutlined, EnvironmentOutlined } from "@ant-design/icons";
 import { Button, Empty, Segmented } from "antd";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type {
-  CSSProperties,
-  KeyboardEvent as ReactKeyboardEvent,
-  PointerEvent as ReactPointerEvent,
-} from "react";
+import type { CSSProperties } from "react";
 
 import PriwaPointCompactList from "./PriwaPointCompactList";
+import PriwaPointPanelResizeHandle from "./PriwaPointPanelResizeHandle";
 import PriwaPointTable from "./PriwaPointTable";
 import { indexPriwaBefallsgruppenByTreeId } from "./priwaBefallsgruppenState";
 import { downloadPriwaPointsCsv } from "./priwaPointCsv";
@@ -23,9 +16,6 @@ type PriwaPointView = "list" | "table";
 
 const PRIWA_POINT_VIEW_STORAGE_KEY = "deadtrees-priwa-field:point-view";
 const DEFAULT_DESKTOP_PANEL_WIDTH = "calc(100vw - 2rem)";
-const MIN_DESKTOP_PANEL_WIDTH = 560;
-const DESKTOP_PANEL_VIEWPORT_MARGIN = 32;
-const KEYBOARD_RESIZE_STEP = 32;
 
 const loadInitialPointView = (): PriwaPointView => {
   if (typeof window === "undefined") return "table";
@@ -66,13 +56,7 @@ export default function PriwaPointListPanel({
   const [filter, setFilter] = useState<PriwaPointFilter>("all");
   const [view, setView] = useState<PriwaPointView>(loadInitialPointView);
   const panelRef = useRef<HTMLElement | null>(null);
-  const desktopPanelWidthRef = useRef<number | null>(null);
-  const pendingDesktopPanelWidthRef = useRef<number | null>(null);
-  const resizeAnimationFrameRef = useRef<number | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
-  const resizeStartRef = useRef<{ clientX: number; width: number } | null>(
-    null,
-  );
   const groupByTreeId = useMemo(
     () => indexPriwaBefallsgruppenByTreeId(groups),
     [groups],
@@ -107,95 +91,14 @@ export default function PriwaPointListPanel({
     }
   };
 
-  const clampDesktopPanelWidth = useCallback((width: number) => {
-    const maxWidth = Math.max(
-      MIN_DESKTOP_PANEL_WIDTH,
-      window.innerWidth - DESKTOP_PANEL_VIEWPORT_MARGIN,
-    );
-    return Math.min(maxWidth, Math.max(MIN_DESKTOP_PANEL_WIDTH, width));
-  }, []);
-
-  const resizeDesktopPanel = useCallback(
-    (width: number) => {
-      pendingDesktopPanelWidthRef.current = clampDesktopPanelWidth(width);
-      if (resizeAnimationFrameRef.current !== null) return;
-
-      resizeAnimationFrameRef.current = window.requestAnimationFrame(() => {
-        const nextWidth = pendingDesktopPanelWidthRef.current;
-        if (nextWidth !== null) {
-          desktopPanelWidthRef.current = nextWidth;
-          panelRef.current?.style.setProperty(
-            "--priwa-point-panel-width",
-            `${nextWidth}px`,
-          );
-        }
-        resizeAnimationFrameRef.current = null;
-      });
-    },
-    [clampDesktopPanelWidth],
-  );
-
-  const startDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const panelWidth = panelRef.current?.getBoundingClientRect().width;
-    if (!panelWidth) return;
-
-    resizeStartRef.current = { clientX: event.clientX, width: panelWidth };
-    event.currentTarget.setPointerCapture(event.pointerId);
-    event.preventDefault();
-  };
-
-  const continueDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const resizeStart = resizeStartRef.current;
-    if (!resizeStart) return;
-
-    resizeDesktopPanel(
-      resizeStart.width + (event.clientX - resizeStart.clientX),
-    );
-  };
-
-  const finishDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
-    resizeStartRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-  };
-
-  const resizeDesktopPanelWithKeyboard = (
-    event: ReactKeyboardEvent<HTMLDivElement>,
-  ) => {
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-
-    const currentWidth = panelRef.current?.getBoundingClientRect().width;
-    if (!currentWidth) return;
-
-    resizeDesktopPanel(
-      currentWidth +
-        (event.key === "ArrowRight"
-          ? KEYBOARD_RESIZE_STEP
-          : -KEYBOARD_RESIZE_STEP),
-    );
-    event.preventDefault();
-  };
-
   const getTableScrollContainer = useCallback(
     () => contentRef.current ?? window,
     [],
   );
 
   const panelStyle = {
-    "--priwa-point-panel-width": desktopPanelWidthRef.current
-      ? `${desktopPanelWidthRef.current}px`
-      : DEFAULT_DESKTOP_PANEL_WIDTH,
+    "--priwa-point-panel-width": DEFAULT_DESKTOP_PANEL_WIDTH,
   } as CSSProperties;
-
-  useEffect(
-    () => () => {
-      if (resizeAnimationFrameRef.current !== null) {
-        window.cancelAnimationFrame(resizeAnimationFrameRef.current);
-      }
-    },
-    [],
-  );
 
   useEffect(() => {
     if (!focusedPointId) return;
@@ -226,25 +129,7 @@ export default function PriwaPointListPanel({
       style={panelStyle}
       className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[64dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-auto md:top-24 md:w-[var(--priwa-point-panel-width)] md:max-w-[calc(100vw-2rem)] md:max-h-[calc(100dvh-8rem)]"
     >
-      <div
-        role="separator"
-        aria-label="Tabellenbreite ändern"
-        aria-orientation="vertical"
-        tabIndex={0}
-        title="Tabellenbreite ändern"
-        data-testid="priwa-point-list-resize-handle"
-        className="absolute right-0 top-1/2 z-10 hidden h-14 w-6 -translate-y-1/2 cursor-col-resize touch-none items-center justify-center rounded-l-md border border-r-0 border-slate-300 bg-white/95 text-slate-500 shadow-sm outline-none hover:border-emerald-500 hover:text-emerald-700 focus-visible:border-emerald-500 focus-visible:text-emerald-700 md:flex"
-        onPointerDown={startDesktopResize}
-        onPointerMove={continueDesktopResize}
-        onPointerUp={finishDesktopResize}
-        onPointerCancel={finishDesktopResize}
-        onLostPointerCapture={() => {
-          resizeStartRef.current = null;
-        }}
-        onKeyDown={resizeDesktopPanelWithKeyboard}
-      >
-        <ColumnWidthOutlined />
-      </div>
+      <PriwaPointPanelResizeHandle panelRef={panelRef} />
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-slate-950">Käferbäume</div>

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,4 +1,8 @@
-import { DownloadOutlined, EnvironmentOutlined } from "@ant-design/icons";
+import {
+  ColumnWidthOutlined,
+  DownloadOutlined,
+  EnvironmentOutlined,
+} from "@ant-design/icons";
 import { Button, Empty, Segmented } from "antd";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -61,10 +65,10 @@ export default function PriwaPointListPanel({
 }: PriwaPointListPanelProps) {
   const [filter, setFilter] = useState<PriwaPointFilter>("all");
   const [view, setView] = useState<PriwaPointView>(loadInitialPointView);
-  const [desktopPanelWidth, setDesktopPanelWidth] = useState<number | null>(
-    null,
-  );
   const panelRef = useRef<HTMLElement | null>(null);
+  const desktopPanelWidthRef = useRef<number | null>(null);
+  const pendingDesktopPanelWidthRef = useRef<number | null>(null);
+  const resizeAnimationFrameRef = useRef<number | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const resizeStartRef = useRef<{ clientX: number; width: number } | null>(
     null,
@@ -112,7 +116,22 @@ export default function PriwaPointListPanel({
   }, []);
 
   const resizeDesktopPanel = useCallback(
-    (width: number) => setDesktopPanelWidth(clampDesktopPanelWidth(width)),
+    (width: number) => {
+      pendingDesktopPanelWidthRef.current = clampDesktopPanelWidth(width);
+      if (resizeAnimationFrameRef.current !== null) return;
+
+      resizeAnimationFrameRef.current = window.requestAnimationFrame(() => {
+        const nextWidth = pendingDesktopPanelWidthRef.current;
+        if (nextWidth !== null) {
+          desktopPanelWidthRef.current = nextWidth;
+          panelRef.current?.style.setProperty(
+            "--priwa-point-panel-width",
+            `${nextWidth}px`,
+          );
+        }
+        resizeAnimationFrameRef.current = null;
+      });
+    },
     [clampDesktopPanelWidth],
   );
 
@@ -146,8 +165,7 @@ export default function PriwaPointListPanel({
   ) => {
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
 
-    const currentWidth =
-      desktopPanelWidth ?? panelRef.current?.getBoundingClientRect().width;
+    const currentWidth = panelRef.current?.getBoundingClientRect().width;
     if (!currentWidth) return;
 
     resizeDesktopPanel(
@@ -165,10 +183,19 @@ export default function PriwaPointListPanel({
   );
 
   const panelStyle = {
-    "--priwa-point-panel-width": desktopPanelWidth
-      ? `${desktopPanelWidth}px`
+    "--priwa-point-panel-width": desktopPanelWidthRef.current
+      ? `${desktopPanelWidthRef.current}px`
       : DEFAULT_DESKTOP_PANEL_WIDTH,
   } as CSSProperties;
+
+  useEffect(
+    () => () => {
+      if (resizeAnimationFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeAnimationFrameRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!focusedPointId) return;
@@ -206,7 +233,7 @@ export default function PriwaPointListPanel({
         tabIndex={0}
         title="Tabellenbreite ändern"
         data-testid="priwa-point-list-resize-handle"
-        className="absolute right-0 top-1/2 z-10 hidden h-24 w-2 -translate-y-1/2 cursor-col-resize touch-none bg-transparent outline-none after:absolute after:bottom-0 after:right-0 after:top-0 after:w-0.5 after:bg-slate-300 hover:after:bg-emerald-500 focus-visible:after:bg-emerald-500 md:block"
+        className="absolute right-0 top-1/2 z-10 hidden h-14 w-6 -translate-y-1/2 cursor-col-resize touch-none items-center justify-center rounded-l-md border border-r-0 border-slate-300 bg-white/95 text-slate-500 shadow-sm outline-none hover:border-emerald-500 hover:text-emerald-700 focus-visible:border-emerald-500 focus-visible:text-emerald-700 md:flex"
         onPointerDown={startDesktopResize}
         onPointerMove={continueDesktopResize}
         onPointerUp={finishDesktopResize}
@@ -215,7 +242,9 @@ export default function PriwaPointListPanel({
           resizeStartRef.current = null;
         }}
         onKeyDown={resizeDesktopPanelWithKeyboard}
-      />
+      >
+        <ColumnWidthOutlined />
+      </div>
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-slate-950">Käferbäume</div>

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -1,6 +1,11 @@
 import { DownloadOutlined, EnvironmentOutlined } from "@ant-design/icons";
 import { Button, Empty, Segmented } from "antd";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from "react";
 
 import PriwaPointCompactList from "./PriwaPointCompactList";
 import PriwaPointTable from "./PriwaPointTable";
@@ -13,6 +18,10 @@ type PriwaPointFilter = "all" | "qa";
 type PriwaPointView = "list" | "table";
 
 const PRIWA_POINT_VIEW_STORAGE_KEY = "deadtrees-priwa-field:point-view";
+const DEFAULT_DESKTOP_PANEL_WIDTH = "calc(100vw - 2rem)";
+const MIN_DESKTOP_PANEL_WIDTH = 560;
+const DESKTOP_PANEL_VIEWPORT_MARGIN = 32;
+const KEYBOARD_RESIZE_STEP = 32;
 
 const loadInitialPointView = (): PriwaPointView => {
   if (typeof window === "undefined") return "table";
@@ -52,7 +61,14 @@ export default function PriwaPointListPanel({
 }: PriwaPointListPanelProps) {
   const [filter, setFilter] = useState<PriwaPointFilter>("all");
   const [view, setView] = useState<PriwaPointView>(loadInitialPointView);
+  const [desktopPanelWidth, setDesktopPanelWidth] = useState<number | null>(
+    null,
+  );
+  const panelRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const resizeStartRef = useRef<{ clientX: number; width: number } | null>(
+    null,
+  );
   const groupByTreeId = useMemo(
     () => indexPriwaBefallsgruppenByTreeId(groups),
     [groups],
@@ -87,6 +103,73 @@ export default function PriwaPointListPanel({
     }
   };
 
+  const clampDesktopPanelWidth = useCallback((width: number) => {
+    const maxWidth = Math.max(
+      MIN_DESKTOP_PANEL_WIDTH,
+      window.innerWidth - DESKTOP_PANEL_VIEWPORT_MARGIN,
+    );
+    return Math.min(maxWidth, Math.max(MIN_DESKTOP_PANEL_WIDTH, width));
+  }, []);
+
+  const resizeDesktopPanel = useCallback(
+    (width: number) => setDesktopPanelWidth(clampDesktopPanelWidth(width)),
+    [clampDesktopPanelWidth],
+  );
+
+  const startDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const panelWidth = panelRef.current?.getBoundingClientRect().width;
+    if (!panelWidth) return;
+
+    resizeStartRef.current = { clientX: event.clientX, width: panelWidth };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const continueDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeStart = resizeStartRef.current;
+    if (!resizeStart) return;
+
+    resizeDesktopPanel(
+      resizeStart.width + (event.clientX - resizeStart.clientX),
+    );
+  };
+
+  const finishDesktopResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    resizeStartRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const resizeDesktopPanelWithKeyboard = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+
+    const currentWidth =
+      desktopPanelWidth ?? panelRef.current?.getBoundingClientRect().width;
+    if (!currentWidth) return;
+
+    resizeDesktopPanel(
+      currentWidth +
+        (event.key === "ArrowRight"
+          ? KEYBOARD_RESIZE_STEP
+          : -KEYBOARD_RESIZE_STEP),
+    );
+    event.preventDefault();
+  };
+
+  const getTableScrollContainer = useCallback(
+    () => contentRef.current ?? window,
+    [],
+  );
+
+  const panelStyle = {
+    "--priwa-point-panel-width": desktopPanelWidth
+      ? `${desktopPanelWidth}px`
+      : DEFAULT_DESKTOP_PANEL_WIDTH,
+  } as CSSProperties;
+
   useEffect(() => {
     if (!focusedPointId) return;
 
@@ -110,7 +193,29 @@ export default function PriwaPointListPanel({
   }, [filter, focusedPointId, view, visiblePoints]);
 
   return (
-    <section className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[64dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-4 md:top-24 md:max-h-[calc(100dvh-8rem)]">
+    <section
+      ref={panelRef}
+      data-testid="priwa-point-list-panel"
+      style={panelStyle}
+      className="pointer-events-auto absolute inset-x-2 bottom-2 z-[58] flex max-h-[64dvh] flex-col overflow-hidden rounded-md bg-white shadow-xl ring-1 ring-slate-900/10 md:bottom-5 md:left-4 md:right-auto md:top-24 md:w-[var(--priwa-point-panel-width)] md:max-w-[calc(100vw-2rem)] md:max-h-[calc(100dvh-8rem)]"
+    >
+      <div
+        role="separator"
+        aria-label="Tabellenbreite ändern"
+        aria-orientation="vertical"
+        tabIndex={0}
+        title="Tabellenbreite ändern"
+        data-testid="priwa-point-list-resize-handle"
+        className="absolute right-0 top-1/2 z-10 hidden h-24 w-2 -translate-y-1/2 cursor-col-resize touch-none bg-transparent outline-none after:absolute after:bottom-0 after:right-0 after:top-0 after:w-0.5 after:bg-slate-300 hover:after:bg-emerald-500 focus-visible:after:bg-emerald-500 md:block"
+        onPointerDown={startDesktopResize}
+        onPointerMove={continueDesktopResize}
+        onPointerUp={finishDesktopResize}
+        onPointerCancel={finishDesktopResize}
+        onLostPointerCapture={() => {
+          resizeStartRef.current = null;
+        }}
+        onKeyDown={resizeDesktopPanelWithKeyboard}
+      />
       <header className="flex items-start justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-slate-950">Käferbäume</div>
@@ -218,6 +323,7 @@ export default function PriwaPointListPanel({
             points={visiblePoints}
             groupByTreeId={groupByTreeId}
             focusedPointId={focusedPointId}
+            getScrollContainer={getTableScrollContainer}
             onEditPoint={onEditPoint}
             onZoomToPoint={onZoomToPoint}
           />

--- a/frontend/src/components/PriwaField/PriwaPointPanelResizeHandle.test.ts
+++ b/frontend/src/components/PriwaField/PriwaPointPanelResizeHandle.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { clampPriwaPointPanelWidth } from "./PriwaPointPanelResizeHandle";
+
+describe("clampPriwaPointPanelWidth", () => {
+  it("keeps the panel usable and inside the viewport", () => {
+    expect(clampPriwaPointPanelWidth(320, 1200)).toBe(560);
+    expect(clampPriwaPointPanelWidth(720, 1200)).toBe(720);
+    expect(clampPriwaPointPanelWidth(1400, 1200)).toBe(1168);
+  });
+});

--- a/frontend/src/components/PriwaField/PriwaPointPanelResizeHandle.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointPanelResizeHandle.tsx
@@ -1,0 +1,135 @@
+import { ColumnWidthOutlined } from "@ant-design/icons";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from "react";
+
+const MIN_PANEL_WIDTH = 560;
+const VIEWPORT_MARGIN = 32;
+const KEYBOARD_RESIZE_STEP = 32;
+
+export const clampPriwaPointPanelWidth = (
+  width: number,
+  viewportWidth: number,
+) => {
+  const maxWidth = Math.max(MIN_PANEL_WIDTH, viewportWidth - VIEWPORT_MARGIN);
+  return Math.min(maxWidth, Math.max(MIN_PANEL_WIDTH, width));
+};
+
+interface PriwaPointPanelResizeHandleProps {
+  panelRef: RefObject<HTMLElement>;
+}
+
+export default function PriwaPointPanelResizeHandle({
+  panelRef,
+}: PriwaPointPanelResizeHandleProps) {
+  const panelWidthRef = useRef<number | null>(null);
+  const pendingPanelWidthRef = useRef<number | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const resizeStartRef = useRef<{ clientX: number; width: number } | null>(
+    null,
+  );
+
+  const applyPanelWidth = useCallback(
+    (width: number) => {
+      pendingPanelWidthRef.current = clampPriwaPointPanelWidth(
+        width,
+        window.innerWidth,
+      );
+      if (animationFrameRef.current !== null) return;
+
+      animationFrameRef.current = window.requestAnimationFrame(() => {
+        const nextWidth = pendingPanelWidthRef.current;
+        if (nextWidth !== null) {
+          panelWidthRef.current = nextWidth;
+          panelRef.current?.style.setProperty(
+            "--priwa-point-panel-width",
+            `${nextWidth}px`,
+          );
+        }
+        animationFrameRef.current = null;
+      });
+    },
+    [panelRef],
+  );
+
+  useLayoutEffect(() => {
+    if (panelWidthRef.current !== null) {
+      panelRef.current?.style.setProperty(
+        "--priwa-point-panel-width",
+        `${panelWidthRef.current}px`,
+      );
+    }
+  });
+
+  useEffect(
+    () => () => {
+      if (animationFrameRef.current !== null) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const panelWidth = panelRef.current?.getBoundingClientRect().width;
+    if (!panelWidth) return;
+
+    resizeStartRef.current = { clientX: event.clientX, width: panelWidth };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const continueResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeStart = resizeStartRef.current;
+    if (!resizeStart) return;
+
+    applyPanelWidth(resizeStart.width + (event.clientX - resizeStart.clientX));
+  };
+
+  const finishResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    resizeStartRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const resizeWithKeyboard = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+
+    const currentWidth = panelRef.current?.getBoundingClientRect().width;
+    if (!currentWidth) return;
+
+    applyPanelWidth(
+      currentWidth +
+        (event.key === "ArrowRight"
+          ? KEYBOARD_RESIZE_STEP
+          : -KEYBOARD_RESIZE_STEP),
+    );
+    event.preventDefault();
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-label="Tabellenbreite ändern"
+      aria-orientation="vertical"
+      tabIndex={0}
+      title="Tabellenbreite ändern"
+      data-testid="priwa-point-list-resize-handle"
+      className="absolute right-0 top-1/2 z-10 hidden h-14 w-6 -translate-y-1/2 cursor-col-resize touch-none items-center justify-center rounded-l-md border border-r-0 border-slate-300 bg-white/95 text-slate-500 shadow-sm outline-none hover:border-emerald-500 hover:text-emerald-700 focus-visible:border-emerald-500 focus-visible:text-emerald-700 md:flex"
+      onPointerDown={startResize}
+      onPointerMove={continueResize}
+      onPointerUp={finishResize}
+      onPointerCancel={finishResize}
+      onLostPointerCapture={() => {
+        resizeStartRef.current = null;
+      }}
+      onKeyDown={resizeWithKeyboard}
+    >
+      <ColumnWidthOutlined />
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointTable.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointTable.tsx
@@ -20,6 +20,7 @@ interface PriwaPointTableProps {
   points: IPriwaPoint[];
   groupByTreeId: Record<string, IPriwaBefallsgruppe>;
   focusedPointId?: string | null;
+  getScrollContainer: () => Window | HTMLElement;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
 }
@@ -28,6 +29,7 @@ export default function PriwaPointTable({
   points,
   groupByTreeId,
   focusedPointId = null,
+  getScrollContainer,
   onEditPoint,
   onZoomToPoint,
 }: PriwaPointTableProps) {
@@ -150,6 +152,7 @@ export default function PriwaPointTable({
       dataSource={points}
       pagination={false}
       scroll={{ x: "max-content" }}
+      sticky={{ getContainer: getScrollContainer }}
       rowClassName={(point) =>
         point.id === focusedPointId
           ? "priwa-point-table-row-focused cursor-pointer"

--- a/frontend/src/components/PriwaField/PriwaReviewDetailsLayout.test.ts
+++ b/frontend/src/components/PriwaField/PriwaReviewDetailsLayout.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { getPriwaReviewDetailsLayoutState } from "./PriwaReviewDetailsLayout";
+
+describe("PRIWA review details layout", () => {
+  it("replaces the detail panel with the tree on narrower desktops", () => {
+    expect(getPriwaReviewDetailsLayoutState(false, true)).toEqual({
+      showGroup: false,
+      treePlacement: "detail",
+    });
+  });
+
+  it("shows tree and group beside each other above the desktop breakpoint", () => {
+    expect(getPriwaReviewDetailsLayoutState(true, true)).toEqual({
+      showGroup: true,
+      treePlacement: "adjacent",
+    });
+  });
+
+  it("keeps the group panel when no tree is selected", () => {
+    expect(getPriwaReviewDetailsLayoutState(false, false)).toEqual({
+      showGroup: true,
+      treePlacement: null,
+    });
+  });
+});

--- a/frontend/src/components/PriwaField/PriwaReviewDetailsLayout.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewDetailsLayout.tsx
@@ -1,0 +1,61 @@
+import { Grid } from "antd";
+import type { ReactNode } from "react";
+
+interface PriwaReviewDetailsLayoutProps {
+  groupContent: ReactNode;
+  treeContent: ReactNode | null;
+  isTreeEditing: boolean;
+}
+
+const detailPanelClass =
+  "pointer-events-auto absolute bottom-5 right-4 top-24 w-[23rem] rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur";
+
+const adjacentTreePanelClass =
+  "pointer-events-auto absolute bottom-5 right-[24.5rem] top-24 w-[22rem] rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur";
+
+export const getPriwaReviewDetailsLayoutState = (
+  isWide: boolean,
+  hasTree: boolean,
+) => ({
+  showGroup: !hasTree || isWide,
+  treePlacement: hasTree ? (isWide ? "adjacent" : "detail") : null,
+});
+
+export default function PriwaReviewDetailsLayout({
+  groupContent,
+  treeContent,
+  isTreeEditing,
+}: PriwaReviewDetailsLayoutProps) {
+  const screens = Grid.useBreakpoint();
+  const isWide = !!screens.xl;
+  const layout = getPriwaReviewDetailsLayoutState(isWide, !!treeContent);
+
+  return (
+    <>
+      {treeContent && (
+        <aside
+          id="priwa-review-tree-panel"
+          data-priwa-review-tree-panel
+          data-testid="priwa-tree-inspector-panel"
+          className={`${
+            layout.treePlacement === "adjacent"
+              ? adjacentTreePanelClass
+              : detailPanelClass
+          } ${isTreeEditing ? "overflow-hidden" : "overflow-y-auto p-4"}`}
+        >
+          {treeContent}
+        </aside>
+      )}
+
+      {layout.showGroup && (
+        <aside
+          data-priwa-review-detail-panel
+          data-testid="priwa-review-detail-panel"
+          className={`${detailPanelClass} overflow-y-auto p-4`}
+        >
+          {groupContent}
+        </aside>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaReviewFlightCard.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewFlightCard.tsx
@@ -1,0 +1,89 @@
+import { EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
+import { Button, Checkbox, Tooltip } from "antd";
+import type { ReactNode } from "react";
+
+import { formatPriwaReviewDate } from "./priwaReviewPresentation";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+
+interface PriwaReviewFlightCardProps {
+  mosaic: IPriwaMosaic;
+  tone: "assigned" | "suggested";
+  isVisible: boolean;
+  isAssigned: boolean;
+  isSaving: boolean;
+  assignmentLabel: string;
+  assignmentAriaLabel: string;
+  onVisibilityChange: (isVisible: boolean) => void;
+  onAssignmentChange: (isAssigned: boolean) => void;
+  children?: ReactNode;
+}
+
+export default function PriwaReviewFlightCard({
+  mosaic,
+  tone,
+  isVisible,
+  isAssigned,
+  isSaving,
+  assignmentLabel,
+  assignmentAriaLabel,
+  onVisibilityChange,
+  onAssignmentChange,
+  children,
+}: PriwaReviewFlightCardProps) {
+  const isSuggested = tone === "suggested";
+
+  return (
+    <div
+      className={`rounded-md border px-3 py-2.5 ${
+        isSuggested
+          ? "border-blue-200 bg-blue-50"
+          : "border-slate-200 bg-slate-50"
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div
+            className={`truncate text-sm font-medium ${
+              isSuggested ? "text-blue-950" : "text-slate-950"
+            }`}
+            title={mosaic.label}
+          >
+            {mosaic.label}
+          </div>
+          <div
+            className={`mt-0.5 text-xs ${
+              isSuggested ? "text-blue-800" : "text-slate-500"
+            }`}
+          >
+            {isSuggested && "Vorschlag · "}Aufnahme{" "}
+            {formatPriwaReviewDate(mosaic.captureDate)}
+          </div>
+        </div>
+        <Tooltip
+          title={isVisible ? "Befliegung ausblenden" : "Befliegung einblenden"}
+        >
+          <Button
+            size="small"
+            type={isVisible ? "primary" : "default"}
+            icon={isVisible ? <EyeOutlined /> : <EyeInvisibleOutlined />}
+            aria-label={
+              isVisible ? "Befliegung ausblenden" : "Befliegung einblenden"
+            }
+            aria-pressed={isVisible}
+            onClick={() => onVisibilityChange(!isVisible)}
+          />
+        </Tooltip>
+      </div>
+      <Checkbox
+        className="mt-2 text-xs"
+        checked={isAssigned}
+        disabled={isSaving}
+        aria-label={assignmentAriaLabel}
+        onChange={(event) => onAssignmentChange(event.target.checked)}
+      >
+        {assignmentLabel}
+      </Checkbox>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -27,6 +27,7 @@ interface PriwaReviewGroupDetailsProps {
   isSavingGroup: boolean;
   isClassifyingFlight: boolean;
   enabledMosaicIds: Set<string>;
+  selectedTreeId: string | null;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
   onEditGroup: (draft: IPriwaBefallsgruppeSaveInput) => void;
@@ -46,6 +47,7 @@ export default function PriwaReviewGroupDetails({
   isSavingGroup,
   isClassifyingFlight,
   enabledMosaicIds,
+  selectedTreeId,
   onFocusTree,
   onEditTree,
   onEditGroup,
@@ -133,7 +135,14 @@ export default function PriwaReviewGroupDetails({
             const point = pointsById.get(treeId);
             if (!point) return null;
             return (
-              <div key={treeId} className="flex items-center gap-2 px-2.5 py-2">
+              <div
+                key={treeId}
+                className={`flex items-center gap-2 px-2.5 py-2 transition ${
+                  selectedTreeId === treeId
+                    ? "bg-emerald-50 ring-1 ring-inset ring-emerald-300"
+                    : ""
+                }`}
+              >
                 <button
                   type="button"
                   className="min-w-0 flex-1 text-left"

--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import type { IPriwaBefallsgruppeSaveInput, IPriwaPoint } from "./types";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
 import {
+  reconcilePriwaDatasetAssignments,
   setPriwaDatasetAssignment,
   type IPriwaGroupReviewItem,
 } from "./priwaReviewWorkspace";
@@ -66,11 +67,18 @@ export default function PriwaReviewGroupDetails({
   const [suggestedAssignmentIds, setSuggestedAssignmentIds] = useState(
     item.draft.datasetIds,
   );
+  const eligibleSuggestedAssignmentIds = reconcilePriwaDatasetAssignments(
+    suggestedAssignmentIds,
+    item.suggestedDatasetIds,
+  );
 
   const setAssignment = (mosaic: IPriwaMosaic, isAssigned: boolean) => {
     if (item.kind === "suggested-group") {
       setSuggestedAssignmentIds((currentIds) =>
-        setPriwaDatasetAssignment(currentIds, mosaic.id, isAssigned),
+        reconcilePriwaDatasetAssignments(
+          setPriwaDatasetAssignment(currentIds, mosaic.id, isAssigned),
+          item.suggestedDatasetIds,
+        ),
       );
       return;
     }
@@ -211,7 +219,7 @@ export default function PriwaReviewGroupDetails({
               isVisible={enabledMosaicIds.has(mosaic.id)}
               isAssigned={
                 item.kind === "suggested-group" &&
-                suggestedAssignmentIds.includes(mosaic.id)
+                eligibleSuggestedAssignmentIds.includes(mosaic.id)
               }
               isSaving={isSavingGroup}
               assignmentLabel={
@@ -261,7 +269,7 @@ export default function PriwaReviewGroupDetails({
             onClick={() =>
               void onSaveGroup({
                 ...item.draft,
-                datasetIds: suggestedAssignmentIds,
+                datasetIds: eligibleSuggestedAssignmentIds,
               })
             }
           >
@@ -276,7 +284,7 @@ export default function PriwaReviewGroupDetails({
               ...item.draft,
               datasetIds:
                 item.kind === "suggested-group"
-                  ? suggestedAssignmentIds
+                  ? eligibleSuggestedAssignmentIds
                   : item.draft.datasetIds,
             })
           }

--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -4,15 +4,20 @@ import {
   EditOutlined,
 } from "@ant-design/icons";
 import { Button, Tag } from "antd";
+import { useEffect, useState } from "react";
 
 import type { IPriwaBefallsgruppeSaveInput, IPriwaPoint } from "./types";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
-import type { IPriwaGroupReviewItem } from "./priwaReviewWorkspace";
+import {
+  setPriwaDatasetAssignment,
+  type IPriwaGroupReviewItem,
+} from "./priwaReviewWorkspace";
 import {
   formatPriwaReviewDate,
   getPriwaGroupDateRange,
   priwaReviewStatusPresentation,
 } from "./priwaReviewPresentation";
+import PriwaReviewFlightCard from "./PriwaReviewFlightCard";
 
 interface PriwaReviewGroupDetailsProps {
   item: IPriwaGroupReviewItem;
@@ -20,11 +25,13 @@ interface PriwaReviewGroupDetailsProps {
   mosaics: IPriwaMosaic[];
   isSavingGroup: boolean;
   isClassifyingFlight: boolean;
+  enabledMosaicIds: Set<string>;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
   onEditGroup: (draft: IPriwaBefallsgruppeSaveInput) => void;
-  onConfirmSuggestion: (draft: IPriwaBefallsgruppeSaveInput) => Promise<void>;
+  onSaveGroup: (draft: IPriwaBefallsgruppeSaveInput) => Promise<void>;
   onAssignFlight: (groupId: string, datasetId: string) => Promise<void>;
+  onSetMosaicVisibility: (mosaicId: string, isVisible: boolean) => void;
   onSetFlightType: (
     datasetId: string,
     flightType: PriwaFlightType,
@@ -37,11 +44,13 @@ export default function PriwaReviewGroupDetails({
   mosaics,
   isSavingGroup,
   isClassifyingFlight,
+  enabledMosaicIds,
   onFocusTree,
   onEditTree,
   onEditGroup,
-  onConfirmSuggestion,
+  onSaveGroup,
   onAssignFlight,
+  onSetMosaicVisibility,
   onSetFlightType,
 }: PriwaReviewGroupDetailsProps) {
   const pointsById = new Map(points.map((point) => [point.id, point]));
@@ -54,6 +63,36 @@ export default function PriwaReviewGroupDetails({
     const mosaic = mosaicsById.get(id);
     return mosaic ? [mosaic] : [];
   });
+  const [suggestedAssignmentIds, setSuggestedAssignmentIds] = useState(
+    item.draft.datasetIds,
+  );
+
+  useEffect(() => {
+    setSuggestedAssignmentIds(item.draft.datasetIds);
+  }, [item.key, item.draft.datasetIds]);
+
+  const setAssignment = (mosaic: IPriwaMosaic, isAssigned: boolean) => {
+    if (item.kind === "suggested-group") {
+      setSuggestedAssignmentIds((currentIds) =>
+        setPriwaDatasetAssignment(currentIds, mosaic.id, isAssigned),
+      );
+      return;
+    }
+
+    if (isAssigned && item.group) {
+      void onAssignFlight(item.group.id, mosaic.id);
+      return;
+    }
+
+    void onSaveGroup({
+      ...item.draft,
+      datasetIds: setPriwaDatasetAssignment(
+        item.assignedDatasetIds,
+        mosaic.id,
+        false,
+      ),
+    });
+  };
 
   return (
     <div className="space-y-5">
@@ -127,18 +166,27 @@ export default function PriwaReviewGroupDetails({
         <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
           Umfeldbefliegung
         </h3>
+        <p className="-mt-1 mb-2 text-xs text-slate-500">
+          Auge: auf Karte anzeigen · Auswahl: der Gruppe zuordnen
+        </p>
         <div className="space-y-2">
           {assignedMosaics.map((mosaic) => (
-            <div
+            <PriwaReviewFlightCard
               key={mosaic.id}
-              className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5"
+              mosaic={mosaic}
+              tone="assigned"
+              isVisible={enabledMosaicIds.has(mosaic.id)}
+              isAssigned
+              isSaving={isSavingGroup}
+              assignmentLabel="Dieser Gruppe zugeordnet"
+              assignmentAriaLabel={`Zuordnung von ${mosaic.label} zur Gruppe aufheben`}
+              onVisibilityChange={(isVisible) =>
+                onSetMosaicVisibility(mosaic.id, isVisible)
+              }
+              onAssignmentChange={(isAssigned) =>
+                setAssignment(mosaic, isAssigned)
+              }
             >
-              <div className="text-sm font-medium text-slate-950">
-                {mosaic.label}
-              </div>
-              <div className="mt-0.5 text-xs text-slate-500">
-                Aufnahme {formatPriwaReviewDate(mosaic.captureDate)}
-              </div>
               {mosaic.flightType === "umfeldbefliegung" ? (
                 <div className="mt-2 flex items-center gap-1.5 text-xs font-medium text-emerald-700">
                   <CheckCircleFilled /> Als Umfeldbefliegung bestätigt
@@ -156,33 +204,38 @@ export default function PriwaReviewGroupDetails({
                   Befliegung bestätigen
                 </Button>
               )}
-            </div>
+            </PriwaReviewFlightCard>
           ))}
 
           {suggestedMosaics.map((mosaic) => (
-            <div
+            <PriwaReviewFlightCard
               key={mosaic.id}
-              className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2.5"
+              mosaic={mosaic}
+              tone="suggested"
+              isVisible={enabledMosaicIds.has(mosaic.id)}
+              isAssigned={
+                item.kind === "suggested-group" &&
+                suggestedAssignmentIds.includes(mosaic.id)
+              }
+              isSaving={isSavingGroup}
+              assignmentLabel={
+                item.kind === "suggested-group"
+                  ? "Beim Übernehmen zuordnen"
+                  : "Dieser Gruppe zuordnen"
+              }
+              assignmentAriaLabel={
+                item.kind === "suggested-group"
+                  ? `${mosaic.label} beim Übernehmen zuordnen`
+                  : `${mosaic.label} dieser Gruppe zuordnen`
+              }
+              onVisibilityChange={(isVisible) =>
+                onSetMosaicVisibility(mosaic.id, isVisible)
+              }
+              onAssignmentChange={(isAssigned) =>
+                setAssignment(mosaic, isAssigned)
+              }
             >
-              <div className="text-sm font-medium text-blue-950">
-                {mosaic.label}
-              </div>
-              <div className="mt-0.5 text-xs text-blue-800">
-                Vorschlag · Aufnahme {formatPriwaReviewDate(mosaic.captureDate)}
-              </div>
               <div className="mt-2 flex flex-wrap gap-2">
-                {item.group && (
-                  <Button
-                    size="small"
-                    type="primary"
-                    loading={isSavingGroup}
-                    onClick={() =>
-                      void onAssignFlight(item.group!.id, mosaic.id)
-                    }
-                  >
-                    Befliegung zuordnen
-                  </Button>
-                )}
                 <Button
                   size="small"
                   danger
@@ -192,7 +245,7 @@ export default function PriwaReviewGroupDetails({
                   Nicht PRIWA-relevant
                 </Button>
               </div>
-            </div>
+            </PriwaReviewFlightCard>
           ))}
 
           {assignedMosaics.length === 0 && suggestedMosaics.length === 0 && (
@@ -209,7 +262,12 @@ export default function PriwaReviewGroupDetails({
             type="primary"
             icon={<CheckCircleFilled />}
             loading={isSavingGroup}
-            onClick={() => void onConfirmSuggestion(item.draft)}
+            onClick={() =>
+              void onSaveGroup({
+                ...item.draft,
+                datasetIds: suggestedAssignmentIds,
+              })
+            }
           >
             Vorschlag übernehmen
           </Button>
@@ -217,7 +275,15 @@ export default function PriwaReviewGroupDetails({
         <Button
           icon={<EditOutlined />}
           disabled={isSavingGroup}
-          onClick={() => onEditGroup(item.draft)}
+          onClick={() =>
+            onEditGroup({
+              ...item.draft,
+              datasetIds:
+                item.kind === "suggested-group"
+                  ? suggestedAssignmentIds
+                  : item.draft.datasetIds,
+            })
+          }
         >
           Zusammensetzung bearbeiten
         </Button>

--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -4,7 +4,7 @@ import {
   EditOutlined,
 } from "@ant-design/icons";
 import { Button, Tag } from "antd";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { IPriwaBefallsgruppeSaveInput, IPriwaPoint } from "./types";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
@@ -66,10 +66,6 @@ export default function PriwaReviewGroupDetails({
   const [suggestedAssignmentIds, setSuggestedAssignmentIds] = useState(
     item.draft.datasetIds,
   );
-
-  useEffect(() => {
-    setSuggestedAssignmentIds(item.draft.datasetIds);
-  }, [item.key, item.draft.datasetIds]);
 
   const setAssignment = (mosaic: IPriwaMosaic, isAssigned: boolean) => {
     if (item.kind === "suggested-group") {

--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -28,6 +28,7 @@ interface PriwaReviewGroupDetailsProps {
   isClassifyingFlight: boolean;
   enabledMosaicIds: Set<string>;
   selectedTreeId: string | null;
+  onSelectTree: (point: IPriwaPoint) => void;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
   onEditGroup: (draft: IPriwaBefallsgruppeSaveInput) => void;
@@ -48,6 +49,7 @@ export default function PriwaReviewGroupDetails({
   isClassifyingFlight,
   enabledMosaicIds,
   selectedTreeId,
+  onSelectTree,
   onFocusTree,
   onEditTree,
   onEditGroup,
@@ -146,7 +148,7 @@ export default function PriwaReviewGroupDetails({
                 <button
                   type="button"
                   className="min-w-0 flex-1 text-left"
-                  onClick={() => onFocusTree(point)}
+                  onClick={() => onSelectTree(point)}
                 >
                   <span className="block truncate text-sm font-medium text-slate-900">
                     {point.baumnr ? `Baum ${point.baumnr}` : "Ohne Baumnr"}

--- a/frontend/src/components/PriwaField/PriwaReviewTreeInspector.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewTreeInspector.tsx
@@ -1,0 +1,172 @@
+import {
+  AimOutlined,
+  CloseOutlined,
+  EditOutlined,
+  EnvironmentOutlined,
+  QrcodeOutlined,
+} from "@ant-design/icons";
+import { Button, Tag } from "antd";
+
+import { getPriwaCoordinateSourcePresentation } from "./priwaCoordinateSource";
+import { getPriwaFundLabel, getPriwaPointTitle } from "./priwaPointQa";
+import { formatPriwaReviewDate } from "./priwaReviewPresentation";
+import type { IPriwaPoint } from "./types";
+
+interface PriwaReviewTreeInspectorProps {
+  point: IPriwaPoint;
+  onClose: () => void;
+  onEdit: (point: IPriwaPoint) => void;
+  onFocus: (point: IPriwaPoint) => void;
+}
+
+const yesNoLabel = (value: string) => {
+  if (value === "ja") return "Ja";
+  if (value === "nein") return "Nein";
+  if (value === "ja_kein_buchdrucker") return "Ja, kein Buchdrucker";
+  return value;
+};
+
+const percentLabel = (value: string) =>
+  value.replace("bis25%", "Bis 25%").replace("bis50%", "Bis 50%");
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+        {label}
+      </dt>
+      <dd className="mt-0.5 break-words text-sm text-slate-800">{value}</dd>
+    </div>
+  );
+}
+
+export default function PriwaReviewTreeInspector({
+  point,
+  onClose,
+  onEdit,
+  onFocus,
+}: PriwaReviewTreeInspectorProps) {
+  const source = getPriwaCoordinateSourcePresentation(point.coordinateSource);
+  const positionConfirmed = point.coordinateSource === "qr";
+  const sourceIcon =
+    point.coordinateSource === "qr" ? (
+      <QrcodeOutlined />
+    ) : point.coordinateSource === "map" ? (
+      <AimOutlined />
+    ) : (
+      <EnvironmentOutlined />
+    );
+
+  return (
+    <div data-testid="priwa-tree-inspector" className="space-y-4">
+      <header className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+            Ausgewählter Käferbaum
+          </p>
+          <h2 className="mt-1 truncate text-lg font-semibold text-slate-950">
+            {getPriwaPointTitle(point)}
+          </h2>
+          <p className="mt-0.5 text-xs text-slate-500">
+            {point.baumart} · {formatPriwaReviewDate(point.datum)}
+          </p>
+        </div>
+        <Button
+          type="text"
+          size="small"
+          icon={<CloseOutlined />}
+          aria-label="Baumdetails schließen"
+          onClick={onClose}
+        />
+      </header>
+
+      <section
+        className={`rounded-lg border p-3 ${
+          positionConfirmed
+            ? "border-emerald-200 bg-emerald-50"
+            : "border-amber-200 bg-amber-50"
+        }`}
+      >
+        <div className="flex items-start gap-2.5">
+          <div
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white ${
+              positionConfirmed ? "bg-emerald-600" : "bg-amber-500"
+            }`}
+          >
+            {sourceIcon}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-sm font-semibold text-slate-900">
+                {source.detailLabel}
+              </span>
+              <Tag className="m-0" color={positionConfirmed ? "green" : "gold"}>
+                {positionConfirmed ? "Bestätigt" : "Geschätzt"}
+              </Tag>
+            </div>
+            <p className="mt-1 font-mono text-xs text-slate-600">
+              {point.lat.toFixed(5)}, {point.lon.toFixed(5)}
+            </p>
+          </div>
+          <Button
+            size="small"
+            icon={<AimOutlined />}
+            aria-label="Baum auf Karte zeigen"
+            onClick={() => onFocus(point)}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Baum
+        </h3>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-lg border border-slate-200 bg-white p-3">
+          <Detail label="Baumnr" value={point.baumnr || "Ohne Baumnr"} />
+          <Detail label="Fund" value={getPriwaFundLabel(point)} />
+          <Detail label="Baumart" value={point.baumart} />
+          <Detail label="Datum" value={formatPriwaReviewDate(point.datum)} />
+          <Detail label="Aufnahme durch" value={point.name} />
+        </dl>
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Befallsmerkmale
+        </h3>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-lg border border-slate-200 bg-white p-3">
+          <Detail label="Bohrmehl" value={yesNoLabel(point.bm)} />
+          <Detail label="Bohrloch" value={yesNoLabel(point.bohrloch)} />
+          <Detail label="Harz" value={point.harz} />
+          <Detail
+            label="Grüne Nadeln"
+            value={yesNoLabel(point.grueneNadelnAmBoden)}
+          />
+          <Detail label="Nadelverfärbung" value={point.nadel} />
+          <Detail label="Nadelverlust" value={percentLabel(point.kv)} />
+          <Detail label="Rindenverlust" value={percentLabel(point.rinde)} />
+        </dl>
+      </section>
+
+      {point.kom && (
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Kommentar
+          </h3>
+          <p className="rounded-lg border border-slate-200 bg-white p-3 text-sm text-slate-700">
+            {point.kom}
+          </p>
+        </section>
+      )}
+
+      <Button
+        block
+        type="primary"
+        icon={<EditOutlined />}
+        onClick={() => onEdit(point)}
+      >
+        Käferbaum bearbeiten
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaReviewTreeInspector.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewTreeInspector.tsx
@@ -31,11 +31,13 @@ const percentLabel = (value: string) =>
 
 function Detail({ label, value }: { label: string; value: string }) {
   return (
-    <div className="min-w-0">
-      <dt className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+    <div className="min-w-0 !text-left">
+      <dt className="!text-left text-[11px] font-medium uppercase tracking-wide text-slate-400">
         {label}
       </dt>
-      <dd className="mt-0.5 break-words text-sm text-slate-800">{value}</dd>
+      <dd className="m-0 mt-0.5 break-words !text-left text-sm text-slate-800">
+        {value}
+      </dd>
     </div>
   );
 }

--- a/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
@@ -196,6 +196,7 @@ export default function PriwaReviewWorkbench({
           <PriwaReviewUploadDetails item={selectedItem} {...detailProps} />
         ) : (
           <PriwaReviewGroupDetails
+            key={selectedItem.key}
             item={selectedItem}
             points={points}
             mosaics={mosaics}

--- a/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined, TableOutlined } from "@ant-design/icons";
 import { Button, Empty, Segmented, Tag } from "antd";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import UploadButton from "../Upload/UploadButton";
 import PriwaReviewDetailsLayout from "./PriwaReviewDetailsLayout";
@@ -22,6 +22,7 @@ import {
   filterForPriwaReviewItem,
   filterPriwaReviewItems,
   resolvePriwaFilteredReviewSelection,
+  shouldClosePriwaReviewTree,
   type PriwaReviewFilter,
 } from "./priwaReviewQueue";
 
@@ -40,6 +41,7 @@ interface PriwaReviewWorkbenchProps {
   onSelect: (item: IPriwaReviewItem) => void;
   onOpenData: () => void;
   onCreateGroup: () => void;
+  onSelectTree: (point: IPriwaPoint) => void;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
   onCloseTree: () => void;
@@ -128,22 +130,22 @@ export default function PriwaReviewWorkbench({
   );
   const openCount = items.filter(isOpenPriwaReviewItem).length;
   const selectedTree =
-    selectedItem?.kind !== "unassigned-upload" &&
     selectedTreeId &&
-    selectedItem.treeIds.includes(selectedTreeId)
+    (isTreeEditing ||
+      (selectedItem?.kind !== "unassigned-upload" &&
+        selectedItem.treeIds.includes(selectedTreeId)))
       ? (points.find((point) => point.id === selectedTreeId) ?? null)
       : null;
 
-  const selectItem = (item: IPriwaReviewItem) => {
-    if (
-      selectedTreeId &&
-      (item.kind === "unassigned-upload" ||
-        !item.treeIds.includes(selectedTreeId))
-    ) {
-      onCloseTree();
-    }
-    onSelect(item);
-  };
+  const selectItem = useCallback(
+    (item: IPriwaReviewItem) => {
+      if (shouldClosePriwaReviewTree(item, selectedTreeId)) {
+        onCloseTree();
+      }
+      onSelect(item);
+    },
+    [onCloseTree, onSelect, selectedTreeId],
+  );
 
   useEffect(() => {
     previousSelectedKeyRef.current = selectedKey;
@@ -153,12 +155,12 @@ export default function PriwaReviewWorkbench({
       return;
     }
     if (selectedItem && selectedItem.key !== selectedKey) {
-      onSelect(selectedItem);
+      selectItem(selectedItem);
     }
   }, [
     externallySelectedItem,
     filter,
-    onSelect,
+    selectItem,
     selectedItem,
     selectedKey,
     selectionChanged,

--- a/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import UploadButton from "../Upload/UploadButton";
 import PriwaReviewGroupDetails from "./PriwaReviewGroupDetails";
+import PriwaReviewTreeInspector from "./PriwaReviewTreeInspector";
 import PriwaReviewUploadDetails from "./PriwaReviewUploadDetails";
 import {
   formatPriwaReviewDate,
@@ -30,11 +31,13 @@ interface PriwaReviewWorkbenchProps {
   isSavingGroup: boolean;
   isClassifyingFlight: boolean;
   enabledMosaicIds: Set<string>;
+  selectedTreeId: string | null;
   onSelect: (item: IPriwaReviewItem) => void;
   onOpenData: () => void;
   onCreateGroup: () => void;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
+  onCloseTree: () => void;
   onEditGroup: (draft: IPriwaBefallsgruppeSaveInput) => void;
   onSaveGroup: (draft: IPriwaBefallsgruppeSaveInput) => Promise<void>;
   onAssignFlight: (groupId: string, datasetId: string) => Promise<void>;
@@ -95,9 +98,11 @@ export default function PriwaReviewWorkbench({
   mosaics,
   selectedKey,
   isLoading,
+  selectedTreeId,
   onSelect,
   onOpenData,
   onCreateGroup,
+  onCloseTree,
   ...detailProps
 }: PriwaReviewWorkbenchProps) {
   const [filter, setFilter] = useState<PriwaReviewFilter>("open");
@@ -110,6 +115,23 @@ export default function PriwaReviewWorkbench({
     visibleItems[0] ??
     null;
   const openCount = items.filter(isOpenPriwaReviewItem).length;
+  const selectedTree =
+    selectedItem?.kind !== "unassigned-upload" &&
+    selectedTreeId &&
+    selectedItem.treeIds.includes(selectedTreeId)
+      ? (points.find((point) => point.id === selectedTreeId) ?? null)
+      : null;
+
+  const selectItem = (item: IPriwaReviewItem) => {
+    if (
+      selectedTreeId &&
+      (item.kind === "unassigned-upload" ||
+        !item.treeIds.includes(selectedTreeId))
+    ) {
+      onCloseTree();
+    }
+    onSelect(item);
+  };
 
   useEffect(() => {
     if (selectedItem && selectedItem.key !== selectedKey) {
@@ -144,7 +166,10 @@ export default function PriwaReviewWorkbench({
             block
             size="small"
             value={filter}
-            onChange={setFilter}
+            onChange={(nextFilter) => {
+              onCloseTree();
+              setFilter(nextFilter);
+            }}
             options={[
               { label: "Offen", value: "open" },
               { label: "Fertig", value: "complete" },
@@ -159,7 +184,7 @@ export default function PriwaReviewWorkbench({
               item={item}
               points={points}
               isSelected={item.key === selectedItem?.key}
-              onSelect={() => onSelect(item)}
+              onSelect={() => selectItem(item)}
             />
           ))}
           {!isLoading && visibleItems.length === 0 && (
@@ -185,24 +210,54 @@ export default function PriwaReviewWorkbench({
         </footer>
       </aside>
 
-      <aside className="pointer-events-auto absolute bottom-5 right-4 top-24 w-[23rem] overflow-y-auto rounded-xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur">
-        {!selectedItem ? (
-          <Empty
-            className="pt-24"
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="Eintrag zum Prüfen auswählen"
+      {selectedTree && (
+        <aside
+          data-testid="priwa-tree-inspector-panel"
+          className="pointer-events-auto absolute bottom-5 right-[24.5rem] top-24 hidden w-[22rem] overflow-y-auto rounded-xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur min-[1200px]:block"
+        >
+          <PriwaReviewTreeInspector
+            point={selectedTree}
+            onClose={onCloseTree}
+            onEdit={detailProps.onEditTree}
+            onFocus={detailProps.onFocusTree}
           />
-        ) : selectedItem.kind === "unassigned-upload" ? (
-          <PriwaReviewUploadDetails item={selectedItem} {...detailProps} />
-        ) : (
-          <PriwaReviewGroupDetails
-            key={selectedItem.key}
-            item={selectedItem}
-            points={points}
-            mosaics={mosaics}
-            {...detailProps}
-          />
+        </aside>
+      )}
+
+      <aside
+        data-testid="priwa-review-detail-panel"
+        className="pointer-events-auto absolute bottom-5 right-4 top-24 w-[23rem] overflow-y-auto rounded-xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur"
+      >
+        {selectedTree && (
+          <div className="min-[1200px]:hidden">
+            <PriwaReviewTreeInspector
+              point={selectedTree}
+              onClose={onCloseTree}
+              onEdit={detailProps.onEditTree}
+              onFocus={detailProps.onFocusTree}
+            />
+          </div>
         )}
+        <div className={selectedTree ? "hidden min-[1200px]:block" : ""}>
+          {!selectedItem ? (
+            <Empty
+              className="pt-24"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="Eintrag zum Prüfen auswählen"
+            />
+          ) : selectedItem.kind === "unassigned-upload" ? (
+            <PriwaReviewUploadDetails item={selectedItem} {...detailProps} />
+          ) : (
+            <PriwaReviewGroupDetails
+              key={selectedItem.key}
+              item={selectedItem}
+              points={points}
+              mosaics={mosaics}
+              selectedTreeId={selectedTreeId}
+              {...detailProps}
+            />
+          )}
+        </div>
       </aside>
     </div>
   );

--- a/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
@@ -29,14 +29,16 @@ interface PriwaReviewWorkbenchProps {
   isLoading: boolean;
   isSavingGroup: boolean;
   isClassifyingFlight: boolean;
+  enabledMosaicIds: Set<string>;
   onSelect: (item: IPriwaReviewItem) => void;
   onOpenData: () => void;
   onCreateGroup: () => void;
   onFocusTree: (point: IPriwaPoint) => void;
   onEditTree: (point: IPriwaPoint) => void;
   onEditGroup: (draft: IPriwaBefallsgruppeSaveInput) => void;
-  onConfirmSuggestion: (draft: IPriwaBefallsgruppeSaveInput) => Promise<void>;
+  onSaveGroup: (draft: IPriwaBefallsgruppeSaveInput) => Promise<void>;
   onAssignFlight: (groupId: string, datasetId: string) => Promise<void>;
+  onSetMosaicVisibility: (mosaicId: string, isVisible: boolean) => void;
   onSetFlightType: (
     datasetId: string,
     flightType: PriwaFlightType,
@@ -179,7 +181,7 @@ export default function PriwaReviewWorkbench({
           <Button icon={<PlusOutlined />} onClick={onCreateGroup}>
             Neue Gruppe
           </Button>
-          <UploadButton label="Befliegung hochladen" size="middle" />
+          <UploadButton label="Befliegung" size="middle" />
         </footer>
       </aside>
 

--- a/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewWorkbench.tsx
@@ -1,8 +1,9 @@
 import { PlusOutlined, TableOutlined } from "@ant-design/icons";
 import { Button, Empty, Segmented, Tag } from "antd";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import UploadButton from "../Upload/UploadButton";
+import PriwaReviewDetailsLayout from "./PriwaReviewDetailsLayout";
 import PriwaReviewGroupDetails from "./PriwaReviewGroupDetails";
 import PriwaReviewTreeInspector from "./PriwaReviewTreeInspector";
 import PriwaReviewUploadDetails from "./PriwaReviewUploadDetails";
@@ -18,7 +19,9 @@ import {
   type IPriwaReviewItem,
 } from "./priwaReviewWorkspace";
 import {
+  filterForPriwaReviewItem,
   filterPriwaReviewItems,
+  resolvePriwaFilteredReviewSelection,
   type PriwaReviewFilter,
 } from "./priwaReviewQueue";
 
@@ -32,6 +35,8 @@ interface PriwaReviewWorkbenchProps {
   isClassifyingFlight: boolean;
   enabledMosaicIds: Set<string>;
   selectedTreeId: string | null;
+  isTreeEditing: boolean;
+  isHidden?: boolean;
   onSelect: (item: IPriwaReviewItem) => void;
   onOpenData: () => void;
   onCreateGroup: () => void;
@@ -99,6 +104,8 @@ export default function PriwaReviewWorkbench({
   selectedKey,
   isLoading,
   selectedTreeId,
+  isTreeEditing,
+  isHidden = false,
   onSelect,
   onOpenData,
   onCreateGroup,
@@ -110,10 +117,15 @@ export default function PriwaReviewWorkbench({
     () => filterPriwaReviewItems(items, filter),
     [filter, items],
   );
-  const selectedItem =
-    visibleItems.find((item) => item.key === selectedKey) ??
-    visibleItems[0] ??
-    null;
+  const previousSelectedKeyRef = useRef<string | null>(null);
+  const selectionChanged = selectedKey !== previousSelectedKeyRef.current;
+  const externallySelectedItem = items.find((item) => item.key === selectedKey);
+  const selectedItem = resolvePriwaFilteredReviewSelection(
+    items,
+    filter,
+    selectedKey,
+    selectionChanged,
+  );
   const openCount = items.filter(isOpenPriwaReviewItem).length;
   const selectedTree =
     selectedItem?.kind !== "unassigned-upload" &&
@@ -134,14 +146,62 @@ export default function PriwaReviewWorkbench({
   };
 
   useEffect(() => {
+    previousSelectedKeyRef.current = selectedKey;
+    if (selectionChanged && externallySelectedItem) {
+      const matchingFilter = filterForPriwaReviewItem(externallySelectedItem);
+      if (matchingFilter !== filter) setFilter(matchingFilter);
+      return;
+    }
     if (selectedItem && selectedItem.key !== selectedKey) {
       onSelect(selectedItem);
     }
-  }, [onSelect, selectedItem, selectedKey]);
+  }, [
+    externallySelectedItem,
+    filter,
+    onSelect,
+    selectedItem,
+    selectedKey,
+    selectionChanged,
+  ]);
+
+  const groupContent = !selectedItem ? (
+    <Empty
+      className="pt-24"
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      description="Eintrag zum Prüfen auswählen"
+    />
+  ) : selectedItem.kind === "unassigned-upload" ? (
+    <PriwaReviewUploadDetails item={selectedItem} {...detailProps} />
+  ) : (
+    <PriwaReviewGroupDetails
+      key={selectedItem.key}
+      item={selectedItem}
+      points={points}
+      mosaics={mosaics}
+      selectedTreeId={selectedTreeId}
+      {...detailProps}
+    />
+  );
+
+  const treeContent = selectedTree ? (
+    <PriwaReviewTreeInspector
+      point={selectedTree}
+      onClose={onCloseTree}
+      onEdit={detailProps.onEditTree}
+      onFocus={detailProps.onFocusTree}
+    />
+  ) : null;
 
   return (
-    <div className="pointer-events-none absolute inset-0 z-[52] hidden md:block">
-      <aside className="pointer-events-auto absolute bottom-5 left-4 top-24 flex w-[21rem] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur">
+    <div
+      className={`pointer-events-none absolute inset-0 z-[52] hidden md:block ${
+        isHidden ? "invisible" : ""
+      }`}
+    >
+      <aside
+        data-priwa-review-queue-panel
+        className="pointer-events-auto absolute bottom-5 left-4 top-24 flex w-[21rem] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur"
+      >
         <header className="border-b border-slate-200 px-3 py-3">
           <div className="flex items-start justify-between gap-2">
             <div>
@@ -169,6 +229,8 @@ export default function PriwaReviewWorkbench({
             onChange={(nextFilter) => {
               onCloseTree();
               setFilter(nextFilter);
+              const firstItem = filterPriwaReviewItems(items, nextFilter)[0];
+              if (firstItem) onSelect(firstItem);
             }}
             options={[
               { label: "Offen", value: "open" },
@@ -210,55 +272,11 @@ export default function PriwaReviewWorkbench({
         </footer>
       </aside>
 
-      {selectedTree && (
-        <aside
-          data-testid="priwa-tree-inspector-panel"
-          className="pointer-events-auto absolute bottom-5 right-[24.5rem] top-24 hidden w-[22rem] overflow-y-auto rounded-xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur min-[1200px]:block"
-        >
-          <PriwaReviewTreeInspector
-            point={selectedTree}
-            onClose={onCloseTree}
-            onEdit={detailProps.onEditTree}
-            onFocus={detailProps.onFocusTree}
-          />
-        </aside>
-      )}
-
-      <aside
-        data-testid="priwa-review-detail-panel"
-        className="pointer-events-auto absolute bottom-5 right-4 top-24 w-[23rem] overflow-y-auto rounded-xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur"
-      >
-        {selectedTree && (
-          <div className="min-[1200px]:hidden">
-            <PriwaReviewTreeInspector
-              point={selectedTree}
-              onClose={onCloseTree}
-              onEdit={detailProps.onEditTree}
-              onFocus={detailProps.onFocusTree}
-            />
-          </div>
-        )}
-        <div className={selectedTree ? "hidden min-[1200px]:block" : ""}>
-          {!selectedItem ? (
-            <Empty
-              className="pt-24"
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="Eintrag zum Prüfen auswählen"
-            />
-          ) : selectedItem.kind === "unassigned-upload" ? (
-            <PriwaReviewUploadDetails item={selectedItem} {...detailProps} />
-          ) : (
-            <PriwaReviewGroupDetails
-              key={selectedItem.key}
-              item={selectedItem}
-              points={points}
-              mosaics={mosaics}
-              selectedTreeId={selectedTreeId}
-              {...detailProps}
-            />
-          )}
-        </div>
-      </aside>
+      <PriwaReviewDetailsLayout
+        groupContent={groupContent}
+        treeContent={treeContent}
+        isTreeEditing={isTreeEditing}
+      />
     </div>
   );
 }

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  createPriwaCogLayers,
-  resolvePriwaCogUrl,
-} from "./createPriwaCogLayer";
+import { resolvePriwaCogUrl } from "./createPriwaCogLayer";
 
 describe("resolvePriwaCogUrl", () => {
   it("keeps absolute COG URLs unchanged", () => {
@@ -16,14 +13,5 @@ describe("resolvePriwaCogUrl", () => {
     expect(resolvePriwaCogUrl("priwa/project-1/flight.tif")).toContain(
       "/cogs/v1/priwa/project-1/flight.tif",
     );
-  });
-
-  it("creates one map layer per PRIWA mosaic", () => {
-    expect(
-      createPriwaCogLayers([
-        { cogUrl: "priwa/project-1/flight-a.tif" },
-        { cogUrl: "priwa/project-1/flight-b.tif" },
-      ]),
-    ).toHaveLength(2);
   });
 });

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.ts
@@ -35,6 +35,3 @@ export const createPriwaCogLayer = (cog: IPriwaCogLayerSource) =>
     cacheSize: 4096,
     preload: 0,
   });
-
-export const createPriwaCogLayers = (cogs: IPriwaCogLayerSource[]) =>
-  cogs.map((cog) => createPriwaCogLayer(cog));

--- a/frontend/src/components/PriwaField/createPriwaMosaicFootprintLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaMosaicFootprintLayer.test.ts
@@ -29,7 +29,29 @@ describe("createPriwaMosaicFootprintLayer", () => {
 
     expect(feature?.get("mosaicId")).toBe("10513");
     expect(feature?.getGeometry()?.getType()).toBe("Polygon");
-    expect(feature?.getStyle()).toBeTruthy();
+    const styles = feature?.getStyle();
+    expect(Array.isArray(styles)).toBe(true);
+    if (!Array.isArray(styles)) throw new Error("Expected layered COG style");
+    expect(styles).toHaveLength(2);
+    expect(styles?.[0].getStroke()?.getWidth()).toBe(5);
+    expect(styles?.[1].getStroke()?.getColor()).toBe(
+      "rgba(251, 146, 60, 1)",
+    );
+  });
+
+  it("uses a high-contrast cyan accent for hidden COG boundaries", () => {
+    const feature = createPriwaMosaicFootprintFeature({
+      mosaic,
+      isSelected: false,
+      isVisible: false,
+    });
+    const styles = feature?.getStyle();
+
+    expect(Array.isArray(styles)).toBe(true);
+    if (!Array.isArray(styles)) throw new Error("Expected layered COG style");
+    expect(styles?.[1].getStroke()?.getColor()).toBe(
+      "rgba(34, 211, 238, 1)",
+    );
   });
 
   it("skips mosaics without parseable bbox values", () => {

--- a/frontend/src/components/PriwaField/createPriwaMosaicFootprintLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaMosaicFootprintLayer.ts
@@ -13,51 +13,40 @@ export interface IPriwaMosaicFootprintFeatureOptions {
   isVisible: boolean;
 }
 
-const visibleStyle = new Style({
+const boundaryHaloStyle = new Style({
   stroke: new Stroke({
-    color: "rgba(249, 115, 22, 0.95)",
+    color: "rgba(15, 23, 42, 0.9)",
+    width: 5,
+  }),
+});
+
+const visibleAccentStyle = new Style({
+  stroke: new Stroke({
+    color: "rgba(251, 146, 60, 1)",
     width: 2.5,
     lineDash: [8, 5],
   }),
 });
 
-const hiddenStyle = new Style({
+const hiddenAccentStyle = new Style({
   stroke: new Stroke({
-    color: "rgba(100, 116, 139, 0.9)",
-    width: 2,
+    color: "rgba(34, 211, 238, 1)",
+    width: 2.5,
     lineDash: [3, 5],
   }),
 });
 
-const selectedVisibleStyle = new Style({
+const selectedHaloStyle = new Style({
   stroke: new Stroke({
     color: "rgba(255, 255, 255, 0.98)",
-    width: 5,
+    width: 6,
   }),
 });
 
-const selectedAccentStyle = new Style({
-  stroke: new Stroke({
-    color: "rgba(249, 115, 22, 0.98)",
-    width: 2,
-    lineDash: [8, 5],
-  }),
-});
-
-const selectedHiddenStyle = new Style({
-  stroke: new Stroke({
-    color: "rgba(15, 23, 42, 0.98)",
-    width: 5,
-  }),
-});
-
-const selectedHiddenAccentStyle = new Style({
-  stroke: new Stroke({
-    color: "rgba(203, 213, 225, 0.98)",
-    width: 2,
-    lineDash: [3, 5],
-  }),
-});
+const styleForFootprint = (isSelected: boolean, isVisible: boolean) => [
+  isSelected ? selectedHaloStyle : boundaryHaloStyle,
+  isVisible ? visibleAccentStyle : hiddenAccentStyle,
+];
 
 export const createPriwaMosaicFootprintFeature = ({
   mosaic,
@@ -75,15 +64,7 @@ export const createPriwaMosaicFootprintFeature = ({
     mosaicId: mosaic.id,
   });
   feature.setId(`priwa-mosaic-footprint-${mosaic.id}`);
-  feature.setStyle(
-    isSelected
-      ? isVisible
-        ? [selectedVisibleStyle, selectedAccentStyle]
-        : [selectedHiddenStyle, selectedHiddenAccentStyle]
-      : isVisible
-        ? visibleStyle
-        : hiddenStyle,
-  );
+  feature.setStyle(styleForFootprint(isSelected, isVisible));
 
   return feature;
 };

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.test.ts
@@ -44,17 +44,18 @@ describe("createPriwaPointFeature", () => {
     ["qr", "QR"],
     ["gps", "GPS"],
     ["map", "Karte"],
-  ] as const)("labels %s coordinates as %s", (coordinateSource, sourceLabel) => {
-    const feature = createPriwaPointFeature({ ...point, coordinateSource });
-    const styles = feature.getStyleFunction()?.(feature, 0.5);
-    const styleList = Array.isArray(styles) ? styles : [styles];
+  ] as const)(
+    "labels %s coordinates as %s",
+    (coordinateSource, sourceLabel) => {
+      const feature = createPriwaPointFeature({ ...point, coordinateSource });
+      const styles = feature.getStyleFunction()?.(feature, 0.5);
+      const styleList = Array.isArray(styles) ? styles : [styles];
 
-    expect(
-      styleList
-        .map((style) => style?.getText()?.getText())
-        .filter(Boolean),
-    ).toContain(sourceLabel);
-  });
+      expect(
+        styleList.map((style) => style?.getText()?.getText()).filter(Boolean),
+      ).toContain(sourceLabel);
+    },
+  );
 
   it("shows mobile tree numbers nearby and hides them at overview zoom", () => {
     const feature = createPriwaPointFeature(point);
@@ -94,6 +95,23 @@ describe("createPriwaPointFeature", () => {
         return (
           image instanceof CircleStyle &&
           image.getStroke()?.getLineDash()?.join() === "4,4"
+        );
+      }),
+    ).toBe(true);
+  });
+
+  it("adds a distinct focus ring for the tree shown in the inspector", () => {
+    const feature = createPriwaPointFeature(point, true, true);
+    const styles = feature.getStyleFunction()?.(feature, 0.5);
+    const styleList = Array.isArray(styles) ? styles : [styles];
+
+    expect(
+      styleList.some((style) => {
+        const image = style?.getImage();
+        return (
+          image instanceof CircleStyle &&
+          image.getRadius() === 20 &&
+          image.getStroke()?.getColor() === "rgba(245, 158, 11, 0.98)"
         );
       }),
     ).toBe(true);

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { Circle as CircleStyle } from "ol/style";
 
 import type { IPriwaPoint } from "./types";
 import { createPriwaPointFeature } from "./createPriwaPointLayer";
@@ -26,7 +27,7 @@ const point: IPriwaPoint = {
 };
 
 describe("createPriwaPointFeature", () => {
-  it("uses the tree number as the compact desktop map label", () => {
+  it("shows the tree number and coordinate source as separate compact labels", () => {
     const feature = createPriwaPointFeature(point);
     const styles = feature.getStyleFunction()?.(feature, 0.5);
     const styleList = Array.isArray(styles) ? styles : [styles];
@@ -34,14 +35,67 @@ describe("createPriwaPointFeature", () => {
       .map((style) => style?.getText()?.getText())
       .filter(Boolean);
 
-    expect(labels).toContain("Baum 101");
+    expect(labels).toContain("101");
+    expect(labels).toContain("QR");
+    expect(labels).not.toContain("Baum 101");
   });
 
-  it("can suppress labels for dense or mobile map views", () => {
-    const feature = createPriwaPointFeature(point, false, false);
+  it.each([
+    ["qr", "QR"],
+    ["gps", "GPS"],
+    ["map", "Karte"],
+  ] as const)("labels %s coordinates as %s", (coordinateSource, sourceLabel) => {
+    const feature = createPriwaPointFeature({ ...point, coordinateSource });
     const styles = feature.getStyleFunction()?.(feature, 0.5);
     const styleList = Array.isArray(styles) ? styles : [styles];
 
-    expect(styleList.every((style) => !style?.getText()?.getText())).toBe(true);
+    expect(
+      styleList
+        .map((style) => style?.getText()?.getText())
+        .filter(Boolean),
+    ).toContain(sourceLabel);
+  });
+
+  it("shows mobile tree numbers nearby and hides them at overview zoom", () => {
+    const feature = createPriwaPointFeature(point);
+    const nearbyStyles = feature.getStyleFunction()?.(feature, 2);
+    const nearbyStyleList = Array.isArray(nearbyStyles)
+      ? nearbyStyles
+      : [nearbyStyles];
+    const overviewStyles = feature.getStyleFunction()?.(feature, 2.5);
+    const overviewStyleList = Array.isArray(overviewStyles)
+      ? overviewStyles
+      : [overviewStyles];
+
+    expect(
+      nearbyStyleList
+        .map((style) => style?.getText()?.getText())
+        .filter(Boolean),
+    ).toContain("101");
+    expect(
+      overviewStyleList.every((style) => !style?.getText()?.getText()),
+    ).toBe(true);
+  });
+
+  it("marks estimated coordinates with the established dashed warning ring", () => {
+    const estimatedPoint: IPriwaPoint = {
+      ...point,
+      coordinateSource: "gps",
+      gps: "nein",
+      isEstimatedLocation: true,
+    };
+    const feature = createPriwaPointFeature(estimatedPoint);
+    const styles = feature.getStyleFunction()?.(feature, 0.5);
+    const styleList = Array.isArray(styles) ? styles : [styles];
+
+    expect(
+      styleList.some((style) => {
+        const image = style?.getImage();
+        return (
+          image instanceof CircleStyle &&
+          image.getStroke()?.getLineDash()?.join() === "4,4"
+        );
+      }),
+    ).toBe(true);
   });
 });

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.ts
@@ -5,6 +5,7 @@ import { fromLonLat } from "ol/proj";
 import VectorSource from "ol/source/Vector";
 import { Circle as CircleStyle, Fill, Stroke, Style, Text } from "ol/style";
 
+import { getPriwaCoordinateSourcePresentation } from "./priwaCoordinateSource";
 import type { IPriwaCoordinate, IPriwaPoint, PriwaFund } from "./types";
 
 const fundColors: Record<PriwaFund, string> = {
@@ -14,15 +15,17 @@ const fundColors: Record<PriwaFund, string> = {
   unsicher: "rgba(217, 119, 6, 0.96)",
 };
 
+const MAX_POINT_LABEL_RESOLUTION = 2.4;
+
 const formatPointDate = (value: string) => {
   const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
   return match ? `${match[3]}.${match[2]}.${match[1]}` : value;
 };
 
 const pointLabel = (point: IPriwaPoint, resolution: number) => {
-  if (resolution > 1.2) return undefined;
+  if (resolution > MAX_POINT_LABEL_RESOLUTION) return undefined;
   return point.baumnr
-    ? `Baum ${point.baumnr}`
+    ? point.baumnr
     : `${point.baumart} · ${formatPointDate(point.datum)}`;
 };
 
@@ -30,9 +33,12 @@ const pointStyle = (
   point: IPriwaPoint,
   resolution: number,
   isSelected: boolean,
-  showLabel: boolean,
 ) => {
-  const label = showLabel ? pointLabel(point, resolution) : undefined;
+  const label = pointLabel(point, resolution);
+  const sourceLabel =
+    resolution <= MAX_POINT_LABEL_RESOLUTION
+      ? getPriwaCoordinateSourcePresentation(point.coordinateSource).mapLabel
+      : undefined;
   const coreStyle = new Style({
     image: new CircleStyle({
       radius: point.isEstimatedLocation ? 7 : 8,
@@ -54,6 +60,18 @@ const pointStyle = (
         })
       : undefined,
   });
+  const sourceStyle = sourceLabel
+    ? new Style({
+        text: new Text({
+          text: sourceLabel,
+          offsetY: 19,
+          font: "600 10px Inter, system-ui, sans-serif",
+          fill: new Fill({ color: "#374151" }),
+          backgroundFill: new Fill({ color: "rgba(255,255,255,0.9)" }),
+          padding: [1, 3, 1, 3],
+        }),
+      })
+    : null;
 
   const syncStyle =
     point.syncStatus && point.syncStatus !== "synced"
@@ -88,6 +106,7 @@ const pointStyle = (
       ...(selectionStyle ? [selectionStyle] : []),
       ...(syncStyle ? [syncStyle] : []),
       coreStyle,
+      ...(sourceStyle ? [sourceStyle] : []),
     ];
     return styles.length === 1 ? coreStyle : styles;
   }
@@ -107,13 +126,13 @@ const pointStyle = (
       }),
     }),
     coreStyle,
+    ...(sourceStyle ? [sourceStyle] : []),
   ];
 };
 
 export const createPriwaPointFeature = (
   point: IPriwaPoint,
   isSelected = false,
-  showLabel = true,
 ) => {
   const feature = new Feature({
     geometry: new Point(fromLonLat([point.lon, point.lat])),
@@ -121,7 +140,7 @@ export const createPriwaPointFeature = (
   });
   feature.setId(point.id);
   feature.setStyle((_feature, resolution) =>
-    pointStyle(point, resolution, isSelected, showLabel),
+    pointStyle(point, resolution, isSelected),
   );
   return feature;
 };

--- a/frontend/src/components/PriwaField/createPriwaPointLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaPointLayer.ts
@@ -33,6 +33,7 @@ const pointStyle = (
   point: IPriwaPoint,
   resolution: number,
   isSelected: boolean,
+  isFocused: boolean,
 ) => {
   const label = pointLabel(point, resolution);
   const sourceLabel =
@@ -100,10 +101,20 @@ const pointStyle = (
         }),
       })
     : null;
+  const focusStyle = isFocused
+    ? new Style({
+        image: new CircleStyle({
+          radius: 20,
+          fill: new Fill({ color: "rgba(255,255,255,0.01)" }),
+          stroke: new Stroke({ color: "rgba(245, 158, 11, 0.98)", width: 4 }),
+        }),
+      })
+    : null;
 
   if (!point.isEstimatedLocation) {
     const styles = [
       ...(selectionStyle ? [selectionStyle] : []),
+      ...(focusStyle ? [focusStyle] : []),
       ...(syncStyle ? [syncStyle] : []),
       coreStyle,
       ...(sourceStyle ? [sourceStyle] : []),
@@ -113,6 +124,7 @@ const pointStyle = (
 
   return [
     ...(selectionStyle ? [selectionStyle] : []),
+    ...(focusStyle ? [focusStyle] : []),
     ...(syncStyle ? [syncStyle] : []),
     new Style({
       image: new CircleStyle({
@@ -133,6 +145,7 @@ const pointStyle = (
 export const createPriwaPointFeature = (
   point: IPriwaPoint,
   isSelected = false,
+  isFocused = false,
 ) => {
   const feature = new Feature({
     geometry: new Point(fromLonLat([point.lon, point.lat])),
@@ -140,7 +153,7 @@ export const createPriwaPointFeature = (
   });
   feature.setId(point.id);
   feature.setStyle((_feature, resolution) =>
-    pointStyle(point, resolution, isSelected),
+    pointStyle(point, resolution, isSelected, isFocused),
   );
   return feature;
 };

--- a/frontend/src/components/PriwaField/priwaCoordinateSource.ts
+++ b/frontend/src/components/PriwaField/priwaCoordinateSource.ts
@@ -1,0 +1,19 @@
+import type { PriwaCoordinateSource } from "./types";
+
+interface IPriwaCoordinateSourcePresentation {
+  mapLabel: string;
+  detailLabel: string;
+}
+
+const presentations: Record<
+  PriwaCoordinateSource,
+  IPriwaCoordinateSourcePresentation
+> = {
+  qr: { mapLabel: "QR", detailLabel: "QR-Code" },
+  gps: { mapLabel: "GPS", detailLabel: "GPS-Position" },
+  map: { mapLabel: "Karte", detailLabel: "Auf Karte gesetzt" },
+};
+
+export const getPriwaCoordinateSourcePresentation = (
+  source: PriwaCoordinateSource,
+) => presentations[source];

--- a/frontend/src/components/PriwaField/priwaFlightReviewState.test.ts
+++ b/frontend/src/components/PriwaField/priwaFlightReviewState.test.ts
@@ -3,24 +3,29 @@ import { describe, expect, it } from "vitest";
 import { reconcilePriwaMosaicVisibility } from "./priwaFlightReviewState";
 
 describe("PRIWA flight-review visibility state", () => {
-  it("enables newly matched flights without re-enabling a known hidden flight", () => {
+  it("keeps visibility explicit when new matched flights arrive", () => {
     expect(
       reconcilePriwaMosaicVisibility(
         new Set(["visible-known"]),
-        new Set(["visible-known", "hidden-known"]),
         ["visible-known", "hidden-known", "new-match"],
-        new Set(["visible-known", "hidden-known", "new-match"]),
       ),
-    ).toEqual(new Set(["visible-known", "new-match"]));
+    ).toEqual(new Set(["visible-known"]));
+  });
+
+  it("does not load every matched flight before a review item is selected", () => {
+    expect(
+      reconcilePriwaMosaicVisibility(
+        new Set(),
+        ["match-one", "match-two", "match-three"],
+      ),
+    ).toEqual(new Set());
   });
 
   it("removes flights that no longer belong to the review catalog", () => {
     expect(
       reconcilePriwaMosaicVisibility(
         new Set(["removed", "remaining"]),
-        new Set(["removed", "remaining"]),
         ["remaining"],
-        new Set(),
       ),
     ).toEqual(new Set(["remaining"]));
   });

--- a/frontend/src/components/PriwaField/priwaFlightReviewState.ts
+++ b/frontend/src/components/PriwaField/priwaFlightReviewState.ts
@@ -1,13 +1,7 @@
 export const reconcilePriwaMosaicVisibility = (
   currentEnabledIds: ReadonlySet<string>,
-  previousKnownIds: ReadonlySet<string>,
   reviewMosaicIds: string[],
-  matchedMosaicIds: ReadonlySet<string>,
 ) =>
   new Set(
-    reviewMosaicIds.filter(
-      (mosaicId) =>
-        currentEnabledIds.has(mosaicId) ||
-        (!previousKnownIds.has(mosaicId) && matchedMosaicIds.has(mosaicId)),
-    ),
+    reviewMosaicIds.filter((mosaicId) => currentEnabledIds.has(mosaicId)),
   );

--- a/frontend/src/components/PriwaField/priwaMosaicMatching.test.ts
+++ b/frontend/src/components/PriwaField/priwaMosaicMatching.test.ts
@@ -4,6 +4,7 @@ import type { IPriwaPoint } from "./types";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
 import {
   PRIWA_MOSAIC_MATCH_MAX_DAYS,
+  matchPriwaPointsToMosaicCandidates,
   matchPriwaPointsToMosaics,
 } from "./priwaMosaicMatching";
 
@@ -104,6 +105,24 @@ describe("matchPriwaPointsToMosaics", () => {
         mosaicId: "after",
         daysApart: 1,
       },
+    ]);
+  });
+
+  it("keeps every spatial and date-valid flight available for review", () => {
+    const fiveDaysBefore = mosaic({
+      id: "before",
+      captureDate: "2026-06-10",
+    });
+    const oneDayAfter = mosaic({ id: "after", captureDate: "2026-06-16" });
+
+    expect(
+      matchPriwaPointsToMosaicCandidates(
+        [point()],
+        [fiveDaysBefore, oneDayAfter],
+      ),
+    ).toEqual([
+      { pointId: "point-1", mosaicId: "after", daysApart: 1 },
+      { pointId: "point-1", mosaicId: "before", daysApart: 5 },
     ]);
   });
 

--- a/frontend/src/components/PriwaField/priwaMosaicMatching.ts
+++ b/frontend/src/components/PriwaField/priwaMosaicMatching.ts
@@ -152,6 +152,25 @@ export const matchPriwaPointsToMosaics = (
   mosaics: IPriwaMosaic[],
   maxDaysApart = PRIWA_MOSAIC_MATCH_MAX_DAYS,
 ): IPriwaPointMosaicMatch[] => {
+  const candidates = matchPriwaPointsToMosaicCandidates(
+    points,
+    mosaics,
+    maxDaysApart,
+  );
+  const matchedPointIds = new Set<string>();
+
+  return candidates.filter(({ pointId }) => {
+    if (matchedPointIds.has(pointId)) return false;
+    matchedPointIds.add(pointId);
+    return true;
+  });
+};
+
+export const matchPriwaPointsToMosaicCandidates = (
+  points: IPriwaPoint[],
+  mosaics: IPriwaMosaic[],
+  maxDaysApart = PRIWA_MOSAIC_MATCH_MAX_DAYS,
+): IPriwaPointMosaicMatch[] => {
   const normalizedMaxDays = Math.max(0, Math.floor(maxDaysApart));
 
   return points.flatMap((point) => {
@@ -170,15 +189,10 @@ export const matchPriwaPointsToMosaics = (
       return [{ mosaic, captureDay, daysApart }];
     });
 
-    const bestCandidate = candidates.sort(compareCandidates)[0];
-    if (!bestCandidate) return [];
-
-    return [
-      {
-        pointId: point.id,
-        mosaicId: bestCandidate.mosaic.id,
-        daysApart: bestCandidate.daysApart,
-      },
-    ];
+    return candidates.sort(compareCandidates).map(({ mosaic, daysApart }) => ({
+      pointId: point.id,
+      mosaicId: mosaic.id,
+      daysApart,
+    }));
   });
 };

--- a/frontend/src/components/PriwaField/priwaOfflineStatus.test.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineStatus.test.ts
@@ -43,14 +43,8 @@ describe("PRIWA offline status labels", () => {
     });
   });
 
-  it("handles disabled and unexpected states with the build-only fallback", () => {
-    expect(getPriwaOfflineStatusView("disabled", true)).toEqual({
-      label: "Offline nur im Build",
-      color: "default",
-    });
-    expect(getPriwaOfflineStatusView("unknown" as never, true)).toEqual({
-      label: "Offline nur im Build",
-      color: "default",
-    });
+  it("hides development-only and unexpected online states", () => {
+    expect(getPriwaOfflineStatusView("disabled", true)).toBeNull();
+    expect(getPriwaOfflineStatusView("unknown" as never, true)).toBeNull();
   });
 });

--- a/frontend/src/components/PriwaField/priwaOfflineStatusView.ts
+++ b/frontend/src/components/PriwaField/priwaOfflineStatusView.ts
@@ -8,7 +8,7 @@ export interface IPriwaOfflineStatusView {
 export const getPriwaOfflineStatusView = (
   serviceWorkerStatus: PriwaServiceWorkerStatus,
   isOnline: boolean,
-): IPriwaOfflineStatusView => {
+): IPriwaOfflineStatusView | null => {
   if (!isOnline && serviceWorkerStatus === "ready") {
     return { label: "Offline bereit", color: "success" };
   }
@@ -33,9 +33,5 @@ export const getPriwaOfflineStatusView = (
     return { label: "Offline nicht unterstützt", color: "warning" };
   }
 
-  if (serviceWorkerStatus === "disabled") {
-    return { label: "Offline nur im Build", color: "default" };
-  }
-
-  return { label: "Offline nur im Build", color: "default" };
+  return null;
 };

--- a/frontend/src/components/PriwaField/priwaReviewMapFocus.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewMapFocus.test.ts
@@ -9,6 +9,7 @@ const queue = { left: 16, right: 352, top: 96, bottom: 780 };
 
 describe("PRIWA review map focus", () => {
   it.each([
+    [1200, 456],
     [1280, 536],
     [1440, 696],
   ])(

--- a/frontend/src/components/PriwaField/priwaReviewMapFocus.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewMapFocus.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPriwaReviewMapCenter,
+  getPriwaReviewTargetPixel,
+} from "./priwaReviewMapFocus";
+
+const queue = { left: 16, right: 352, top: 96, bottom: 780 };
+
+describe("PRIWA review map focus", () => {
+  it.each([
+    [1280, 536],
+    [1440, 696],
+  ])(
+    "keeps a focused tree in the visible map gap at %ipx",
+    (viewportWidth, treePanelLeft) => {
+      const map = { left: 0, right: viewportWidth, top: 0, bottom: 800 };
+      const treePanel = {
+        left: treePanelLeft,
+        right: treePanelLeft + 352,
+        top: 96,
+        bottom: 780,
+      };
+      const target = getPriwaReviewTargetPixel(map, queue, treePanel);
+
+      expect(target.x).toBeGreaterThan(queue.right);
+      expect(target.x).toBeLessThan(treePanel.left);
+
+      const center = getPriwaReviewMapCenter(
+        [1000, 2000],
+        [viewportWidth, 800],
+        target,
+        0.25,
+      );
+      const focusedPixelX = viewportWidth / 2 + (1000 - center[0]) / 0.25;
+      expect(focusedPixelX).toBeCloseTo(target.x);
+    },
+  );
+});

--- a/frontend/src/components/PriwaField/priwaReviewMapFocus.ts
+++ b/frontend/src/components/PriwaField/priwaReviewMapFocus.ts
@@ -11,8 +11,6 @@ interface IPriwaReviewTargetPixel {
 }
 
 const PANEL_GAP_PX = 16;
-const MIN_VISIBLE_MAP_WIDTH_PX = 96;
-
 export const getPriwaReviewTargetPixel = (
   mapRect: IPriwaReviewRect,
   queueRect: IPriwaReviewRect | null,
@@ -24,8 +22,8 @@ export const getPriwaReviewTargetPixel = (
   const visibleRight = treePanelRect
     ? Math.min(mapRect.right, treePanelRect.left - PANEL_GAP_PX)
     : mapRect.right;
-  const hasUsefulGap = visibleRight - visibleLeft >= MIN_VISIBLE_MAP_WIDTH_PX;
-  const targetX = hasUsefulGap
+  const hasVisibleGap = visibleRight > visibleLeft;
+  const targetX = hasVisibleGap
     ? (visibleLeft + visibleRight) / 2
     : (mapRect.left + mapRect.right) / 2;
 

--- a/frontend/src/components/PriwaField/priwaReviewMapFocus.ts
+++ b/frontend/src/components/PriwaField/priwaReviewMapFocus.ts
@@ -1,0 +1,46 @@
+interface IPriwaReviewRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+interface IPriwaReviewTargetPixel {
+  x: number;
+  y: number;
+}
+
+const PANEL_GAP_PX = 16;
+const MIN_VISIBLE_MAP_WIDTH_PX = 96;
+
+export const getPriwaReviewTargetPixel = (
+  mapRect: IPriwaReviewRect,
+  queueRect: IPriwaReviewRect | null,
+  treePanelRect: IPriwaReviewRect | null,
+): IPriwaReviewTargetPixel => {
+  const visibleLeft = queueRect
+    ? Math.max(mapRect.left, queueRect.right + PANEL_GAP_PX)
+    : mapRect.left;
+  const visibleRight = treePanelRect
+    ? Math.min(mapRect.right, treePanelRect.left - PANEL_GAP_PX)
+    : mapRect.right;
+  const hasUsefulGap = visibleRight - visibleLeft >= MIN_VISIBLE_MAP_WIDTH_PX;
+  const targetX = hasUsefulGap
+    ? (visibleLeft + visibleRight) / 2
+    : (mapRect.left + mapRect.right) / 2;
+
+  return {
+    x: targetX - mapRect.left,
+    y: (mapRect.top + mapRect.bottom) / 2 - mapRect.top,
+  };
+};
+
+export const getPriwaReviewMapCenter = (
+  coordinate: number[],
+  mapSize: number[],
+  targetPixel: IPriwaReviewTargetPixel,
+  resolution: number,
+): [number, number] => [
+  coordinate[0] - (targetPixel.x - mapSize[0] / 2) * resolution,
+  coordinate[1] + (targetPixel.y - mapSize[1] / 2) * resolution,
+];

--- a/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import type { IPriwaReviewItem } from "./priwaReviewWorkspace";
 import {
   filterPriwaReviewItems,
+  filterForPriwaReviewItem,
   findPriwaReviewItemByGroup,
   findPriwaReviewItemByMosaic,
   findPriwaReviewItemByPoint,
   resolvePriwaReviewSelection,
+  resolvePriwaFilteredReviewSelection,
 } from "./priwaReviewQueue";
 
 const openGroup = {
@@ -83,6 +85,31 @@ describe("PRIWA review queue", () => {
     expect(filterPriwaReviewItems(items, "open")).toEqual([openGroup, upload]);
     expect(filterPriwaReviewItems(items, "complete")).toEqual([completeGroup]);
     expect(filterPriwaReviewItems(items, "uploads")).toEqual([upload]);
+  });
+
+  it("selects the queue filter that can show an externally selected item", () => {
+    expect(filterForPriwaReviewItem(openGroup)).toBe("open");
+    expect(filterForPriwaReviewItem(completeGroup)).toBe("complete");
+    expect(filterForPriwaReviewItem(upload)).toBe("uploads");
+  });
+
+  it("lets a completed map selection escape the active open filter", () => {
+    expect(
+      resolvePriwaFilteredReviewSelection(
+        items,
+        "open",
+        completeGroup.key,
+        true,
+      ),
+    ).toBe(completeGroup);
+    expect(
+      resolvePriwaFilteredReviewSelection(
+        items,
+        "open",
+        completeGroup.key,
+        false,
+      ),
+    ).toBe(openGroup);
   });
 
   it("maps map features back to their canonical review item", () => {

--- a/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
@@ -9,6 +9,7 @@ import {
   findPriwaReviewItemByPoint,
   resolvePriwaReviewSelection,
   resolvePriwaFilteredReviewSelection,
+  shouldClosePriwaReviewTree,
 } from "./priwaReviewQueue";
 
 const openGroup = {
@@ -117,5 +118,11 @@ describe("PRIWA review queue", () => {
     expect(findPriwaReviewItemByMosaic(items, "flight-2")).toBe(completeGroup);
     expect(findPriwaReviewItemByGroup(items, "group-1")).toBe(completeGroup);
     expect(findPriwaReviewItemByPoint(items, "tree-1")).toBe(openGroup);
+  });
+
+  it("moves an open tree editor out of the embedded panel when the queue advances", () => {
+    expect(shouldClosePriwaReviewTree(openGroup, "tree-1")).toBe(false);
+    expect(shouldClosePriwaReviewTree(completeGroup, "tree-1")).toBe(true);
+    expect(shouldClosePriwaReviewTree(upload, "tree-1")).toBe(true);
   });
 });

--- a/frontend/src/components/PriwaField/priwaReviewQueue.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.ts
@@ -73,3 +73,11 @@ export const findPriwaReviewItemByPoint = (
     (item) =>
       item.kind !== "unassigned-upload" && item.treeIds.includes(pointId),
   ) ?? null;
+
+export const shouldClosePriwaReviewTree = (
+  item: IPriwaReviewItem,
+  selectedTreeId: string | null,
+) =>
+  !!selectedTreeId &&
+  (item.kind === "unassigned-upload" ||
+    !item.treeIds.includes(selectedTreeId));

--- a/frontend/src/components/PriwaField/priwaReviewQueue.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.ts
@@ -18,6 +18,30 @@ export const filterPriwaReviewItems = (
         : item.kind === "unassigned-upload",
   );
 
+export const filterForPriwaReviewItem = (
+  item: IPriwaReviewItem,
+): PriwaReviewFilter => {
+  if (item.kind === "unassigned-upload") return "uploads";
+  return isOpenPriwaReviewItem(item) ? "open" : "complete";
+};
+
+export const resolvePriwaFilteredReviewSelection = (
+  items: IPriwaReviewItem[],
+  filter: PriwaReviewFilter,
+  selectedKey: string | null,
+  preferExternalSelection: boolean,
+) => {
+  const visibleItems = filterPriwaReviewItems(items, filter);
+  return (
+    visibleItems.find((item) => item.key === selectedKey) ??
+    (preferExternalSelection
+      ? items.find((item) => item.key === selectedKey)
+      : null) ??
+    visibleItems[0] ??
+    null
+  );
+};
+
 export const resolvePriwaReviewSelection = (
   items: IPriwaReviewItem[],
   selectedKey: string | null,

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
@@ -5,6 +5,7 @@ import type { IPriwaMosaic } from "./usePriwaMosaics";
 import {
   buildPriwaReviewWorkspace,
   reviewItemDatasetIds,
+  setPriwaDatasetAssignment,
 } from "./priwaReviewWorkspace";
 
 const point = (id: string, lon: number, date = "2026-06-12"): IPriwaPoint => ({
@@ -27,6 +28,28 @@ const point = (id: string, lon: number, date = "2026-06-12"): IPriwaPoint => ({
   capturedAt: `${date}T10:00:00Z`,
   coordinateSource: "qr",
   gps: "ja",
+});
+
+describe("setPriwaDatasetAssignment", () => {
+  it("adds an assignment once without replacing adjacent flights", () => {
+    expect(setPriwaDatasetAssignment(["flight-1"], "flight-2", true)).toEqual([
+      "flight-1",
+      "flight-2",
+    ]);
+    expect(
+      setPriwaDatasetAssignment(["flight-1", "flight-2"], "flight-2", true),
+    ).toEqual(["flight-1", "flight-2"]);
+  });
+
+  it("removes only the selected assignment", () => {
+    expect(
+      setPriwaDatasetAssignment(
+        ["flight-1", "flight-2", "flight-3"],
+        "flight-2",
+        false,
+      ),
+    ).toEqual(["flight-1", "flight-3"]);
+  });
 });
 
 const mosaic = (

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
@@ -102,6 +102,22 @@ describe("buildPriwaReviewWorkspace", () => {
     });
   });
 
+  it("suggests every overlapping flight inside the date window", () => {
+    const items = buildPriwaReviewWorkspace(
+      [point("1", 8.15)],
+      [
+        { ...mosaic("flight-near"), captureDate: "2026-06-13" },
+        { ...mosaic("flight-far"), captureDate: "2026-06-17" },
+      ],
+      [group(["1"])],
+    );
+
+    expect(items[0]).toMatchObject({
+      key: "group:group-1",
+      suggestedDatasetIds: ["flight-near", "flight-far"],
+    });
+  });
+
   it("marks a confirmed reviewed group complete", () => {
     const items = buildPriwaReviewWorkspace(
       [point("1", 8.15)],

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
@@ -4,6 +4,7 @@ import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
 import {
   buildPriwaReviewWorkspace,
+  reconcilePriwaDatasetAssignments,
   reviewItemDatasetIds,
   setPriwaDatasetAssignment,
 } from "./priwaReviewWorkspace";
@@ -49,6 +50,26 @@ describe("setPriwaDatasetAssignment", () => {
         false,
       ),
     ).toEqual(["flight-1", "flight-3"]);
+  });
+});
+
+describe("reconcilePriwaDatasetAssignments", () => {
+  it("drops a classified flight after a workspace rerender", () => {
+    expect(
+      reconcilePriwaDatasetAssignments(
+        ["flight-1", "flight-2"],
+        ["flight-1"],
+      ),
+    ).toEqual(["flight-1"]);
+  });
+
+  it("does not reselect flights the reviewer explicitly deselected", () => {
+    expect(
+      reconcilePriwaDatasetAssignments(
+        ["flight-1"],
+        ["flight-1", "flight-2"],
+      ),
+    ).toEqual(["flight-1"]);
   });
 });
 

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
@@ -6,6 +6,7 @@ import type {
 } from "./types";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
 import { buildPriwaMosaicMatchIndex } from "./usePriwaMosaicMatches";
+import { matchPriwaPointsToMosaicCandidates } from "./priwaMosaicMatching";
 
 export type PriwaReviewStatus =
   | "group_suggestion"
@@ -79,12 +80,23 @@ export const buildPriwaReviewWorkspace = (
 ): IPriwaReviewItem[] => {
   const mosaicsById = new Map(mosaics.map((mosaic) => [mosaic.id, mosaic]));
   const rawMatches = buildPriwaMosaicMatchIndex(points, mosaics);
+  const candidateMosaics = [
+    ...rawMatches.matchedMosaics.map(({ mosaic }) => mosaic),
+    ...rawMatches.unmatchedMosaics.map(({ mosaic }) => mosaic),
+  ];
+  const candidateDatasetIdsByPointId = new Map<string, string[]>();
+  matchPriwaPointsToMosaicCandidates(points, candidateMosaics).forEach(
+    ({ pointId, mosaicId }) => {
+      const datasetIds = candidateDatasetIdsByPointId.get(pointId) ?? [];
+      datasetIds.push(mosaicId);
+      candidateDatasetIdsByPointId.set(pointId, datasetIds);
+    },
+  );
   const candidateDatasetIdsForTrees = (treeIds: string[]) =>
     unique(
-      treeIds.flatMap((treeId) => {
-        const datasetId = rawMatches.mosaicIdByPointId[treeId];
-        return datasetId ? [datasetId] : [];
-      }),
+      treeIds.flatMap(
+        (treeId) => candidateDatasetIdsByPointId.get(treeId) ?? [],
+      ),
     );
 
   const savedItems: IPriwaGroupReviewItem[] = groups.map((group) => {
@@ -159,10 +171,6 @@ export const buildPriwaReviewWorkspace = (
       reason,
     ]),
   );
-  const candidateMosaics = [
-    ...rawMatches.matchedMosaics.map(({ mosaic }) => mosaic),
-    ...rawMatches.unmatchedMosaics.map(({ mosaic }) => mosaic),
-  ];
   const uploadItems: IPriwaUploadReviewItem[] = candidateMosaics
     .filter((mosaic) => !claimedDatasetIds.has(mosaic.id))
     .map((mosaic) => ({

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
@@ -225,3 +225,11 @@ export const setPriwaDatasetAssignment = (
   isAssigned
     ? [...new Set([...datasetIds, datasetId])]
     : datasetIds.filter((candidateId) => candidateId !== datasetId);
+
+export const reconcilePriwaDatasetAssignments = (
+  selectedDatasetIds: string[],
+  candidateDatasetIds: string[],
+) => {
+  const candidateIds = new Set(candidateDatasetIds);
+  return selectedDatasetIds.filter((datasetId) => candidateIds.has(datasetId));
+};

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
@@ -208,3 +208,12 @@ export const reviewItemDatasetIds = (item: IPriwaReviewItem) =>
   item.kind === "unassigned-upload"
     ? [item.mosaic.id]
     : [...new Set([...item.assignedDatasetIds, ...item.suggestedDatasetIds])];
+
+export const setPriwaDatasetAssignment = (
+  datasetIds: string[],
+  datasetId: string,
+  isAssigned: boolean,
+) =>
+  isAssigned
+    ? [...new Set([...datasetIds, datasetId])]
+    : datasetIds.filter((candidateId) => candidateId !== datasetId);

--- a/frontend/src/components/PriwaField/usePriwaFlightReview.ts
+++ b/frontend/src/components/PriwaField/usePriwaFlightReview.ts
@@ -1,5 +1,5 @@
 import { message } from "antd";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { groupsForPriwaMosaicMatching } from "./priwaBefallsgruppenState";
 import { reconcilePriwaMosaicVisibility } from "./priwaFlightReviewState";
@@ -38,7 +38,6 @@ export function usePriwaFlightReview({
     new Set(),
   );
   const [selectedMosaicId, setSelectedMosaicId] = useState<string | null>(null);
-  const knownMosaicIdsRef = useRef<Set<string>>(new Set());
   const mosaicMatchGroups = useMemo(
     () =>
       groupsForPriwaMosaicMatching(groups, isLoadingGroups, groupsErrorMessage),
@@ -77,23 +76,13 @@ export function usePriwaFlightReview({
   }, [reviewMosaics, selectedMosaicId]);
 
   useEffect(() => {
-    const nextKnownIds = new Set(reviewMosaics.map((mosaic) => mosaic.id));
-    const matchedIds = new Set(
-      matches.matchedMosaics.map(({ mosaic }) => mosaic.id),
-    );
-    const previousKnownIds = knownMosaicIdsRef.current;
-
     setEnabledMosaicIds((currentIds) =>
       reconcilePriwaMosaicVisibility(
         currentIds,
-        previousKnownIds,
         reviewMosaics.map((mosaic) => mosaic.id),
-        matchedIds,
       ),
     );
-
-    knownMosaicIdsRef.current = nextKnownIds;
-  }, [matches.matchedMosaics, reviewMosaics]);
+  }, [reviewMosaics]);
 
   const setMosaicVisibility = useCallback(
     (mosaicId: string, checked: boolean) => {

--- a/frontend/src/components/PriwaField/usePriwaFlightReview.ts
+++ b/frontend/src/components/PriwaField/usePriwaFlightReview.ts
@@ -104,9 +104,9 @@ export function usePriwaFlightReview({
   const selectMatchedMosaicForPoint = useCallback(
     (point: IPriwaPoint) => {
       const mosaicId = matches.mosaicIdByPointId[point.id];
-      if (mosaicId) setSelectedMosaicId(mosaicId);
+      if (mosaicId) showOnlyMosaics([mosaicId]);
     },
-    [matches.mosaicIdByPointId],
+    [matches.mosaicIdByPointId, showOnlyMosaics],
   );
 
   const setFlightType = useCallback(

--- a/frontend/src/components/PriwaField/usePriwaReviewController.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewController.ts
@@ -105,17 +105,24 @@ export function usePriwaReviewController({
       : null;
   const isWorkspaceLoading = isLoadingPoints || isLoadingGroups || isCogLoading;
 
-  const selectReviewItem = useCallback(
+  const activateReviewItem = useCallback(
     (item: IPriwaReviewItem) => {
       setSelectedReviewKey(item.key);
       showOnlyMosaics(reviewItemDatasetIds(item));
+    },
+    [showOnlyMosaics],
+  );
+
+  const selectReviewItem = useCallback(
+    (item: IPriwaReviewItem) => {
+      activateReviewItem(item);
       if (item.kind === "unassigned-upload") {
         zoomToMosaicFootprint(item.mosaic);
       } else {
         zoomToTrees(item.treeIds);
       }
     },
-    [showOnlyMosaics, zoomToMosaicFootprint, zoomToTrees],
+    [activateReviewItem, zoomToMosaicFootprint, zoomToTrees],
   );
 
   useEffect(() => {
@@ -158,9 +165,9 @@ export function usePriwaReviewController({
   const selectReviewItemFromPoint = useCallback(
     (point: IPriwaPoint) => {
       const item = findPriwaReviewItemByPoint(reviewItems, point.id);
-      if (item) selectReviewItem(item);
+      if (item) activateReviewItem(item);
     },
-    [reviewItems, selectReviewItem],
+    [activateReviewItem, reviewItems],
   );
 
   const saveGroup = useCallback(

--- a/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
@@ -1,13 +1,13 @@
 import type { MutableRefObject } from "react";
 import { useEffect, useRef } from "react";
-import { Map } from "ol";
+import { Map as OlMap } from "ol";
 import TileLayerWebGL from "ol/layer/WebGLTile.js";
 
 import {
   createPriwaBefallsgruppeFeature,
   createPriwaBefallsgruppeLayer,
 } from "./createPriwaBefallsgruppeLayer";
-import { createPriwaCogLayers } from "./createPriwaCogLayer";
+import { createPriwaCogLayer } from "./createPriwaCogLayer";
 import {
   createPriwaMosaicFootprintFeature,
   createPriwaMosaicFootprintLayer,
@@ -28,7 +28,7 @@ type PriwaMosaicFootprintSource = NonNullable<
 >;
 
 interface UsePriwaReviewMapLayersOptions {
-  mapRef: MutableRefObject<Map | null>;
+  mapRef: MutableRefObject<OlMap | null>;
   groupLayerRef: MutableRefObject<PriwaBefallsgruppeLayer | null>;
   mosaicFootprintLayerRef: MutableRefObject<PriwaMosaicFootprintLayer | null>;
   groups: IPriwaBefallsgruppe[];
@@ -97,7 +97,9 @@ export function usePriwaReviewMapLayers({
   selectedMosaicId,
   selectedGroupId,
 }: UsePriwaReviewMapLayersOptions) {
-  const cogLayersRef = useRef<TileLayerWebGL[]>([]);
+  const cogLayersRef = useRef<
+    globalThis.Map<string, { cogUrl: string; layer: TileLayerWebGL }>
+  >(new globalThis.Map());
 
   useEffect(() => {
     const source = groupLayerRef.current?.getSource();
@@ -129,17 +131,48 @@ export function usePriwaReviewMapLayers({
     const map = mapRef.current;
     if (!map) return;
 
-    cogLayersRef.current.forEach((layer) => map.removeLayer(layer));
-    const cogLayers = createPriwaCogLayers(enabledMosaics);
-    cogLayersRef.current = cogLayers;
-    cogLayers.forEach((layer, index) => {
-      layer.setZIndex(20 + (enabledMosaics.length - index) / 100);
-      map.getLayers().insertAt(2 + index, layer);
+    const enabledMosaicIds = new Set(
+      enabledMosaics.map((mosaic) => mosaic.id),
+    );
+    cogLayersRef.current.forEach(({ layer }, mosaicId) => {
+      if (enabledMosaicIds.has(mosaicId)) return;
+      map.removeLayer(layer);
+      layer.dispose();
+      cogLayersRef.current.delete(mosaicId);
     });
 
-    return () => {
-      cogLayers.forEach((layer) => map.removeLayer(layer));
-      if (cogLayersRef.current === cogLayers) cogLayersRef.current = [];
-    };
+    enabledMosaics.forEach((mosaic, index) => {
+      const current = cogLayersRef.current.get(mosaic.id);
+      let layer = current?.layer;
+      if (current && current.cogUrl !== mosaic.cogUrl) {
+        map.removeLayer(current.layer);
+        current.layer.dispose();
+        cogLayersRef.current.delete(mosaic.id);
+        layer = undefined;
+      }
+
+      if (!layer) {
+        layer = createPriwaCogLayer(mosaic);
+        cogLayersRef.current.set(mosaic.id, {
+          cogUrl: mosaic.cogUrl,
+          layer,
+        });
+        map.addLayer(layer);
+      }
+
+      layer.setZIndex(20 + (enabledMosaics.length - index) / 100);
+    });
   }, [enabledMosaics, mapRef]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const cogLayers = cogLayersRef.current;
+    return () => {
+      cogLayers.forEach(({ layer }) => {
+        map?.removeLayer(layer);
+        layer.dispose();
+      });
+      cogLayers.clear();
+    };
+  }, [mapRef]);
 }


### PR DESCRIPTION
## Briefing
This update separates the mobile field workflow from the desktop review workflow while keeping both on the same PRIWA map. Drone teams get faster, clearer capture controls; reviewers get explicit multi-flight comparison, an adjacent tree inspector, and a resizable data table.

## Why
Pilot and reviewer feedback showed that tree numbers, coordinate provenance, flight comparison, and the relationship between groups, flights, and individual trees were difficult to understand. The old tree editor also covered the Befallsgruppe context during desktop review.

## What changed
- restores compact mobile map controls, visible tree numbers and coordinate-source labels, a full-screen capture form, and expanded field sections
- replaces the base-layer popover with a direct aerial/topographic toggle and removes obsolete status hints
- fetches all eligible flights and separates each flight assignment from its map visibility
- adds a synchronized desktop tree inspector with map/list highlighting and embeds the complete edit form beside the Befallsgruppe panel
- keeps tree-detail selection stationary, reserves map movement for the explicit aim action, and strengthens COG boundary contrast
- adds an always-reachable sticky horizontal table scrollbar and a draggable/keyboard-accessible desktop width handle
- avoids unnecessary startup COG loads and preserves unchanged COG layers when comparing flights
- shortens the upload action to avoid overflow

## Validation
- npm --prefix frontend test (261 tests)
- npm --prefix frontend run lint
- npm --prefix frontend run build
- scripts/lint-ast-grep.sh
- npm --prefix frontend run test:e2e:local:priwa:write (2 workflows)
- production-connected browser checks for multi-flight visibility, assignment state, table resizing, tree selection from list and map, adjacent summary/edit layout, and console errors

## Risk and limitations
Flight assignment remains explicit and persists only when the reviewer accepts or changes the group; the eye control changes map visibility only. On desktop widths below 1200 px, tree details use the existing right-hand review panel instead of adding a third column. No production data was modified during validation.

