### PR TITLE
fix(map): compact location search control

### DIFF
--- a/frontend/e2e/data-factory-readonly.spec.ts
+++ b/frontend/e2e/data-factory-readonly.spec.ts
@@ -504,6 +504,19 @@ test.describe("DeadTrees Data Factory read-only smoke", () => {
       .click({ timeout: 5_000 })
       .catch(() => undefined);
 
+    const locationSearch = page.getByTestId("location-search-control");
+    await expect(
+      locationSearch.getByPlaceholder("Search location..."),
+    ).toBeVisible();
+    await expect(
+      locationSearch.getByText("Location", { exact: true }),
+    ).toHaveCount(0);
+    const locationSearchBox = await locationSearch.boundingBox();
+    expect(locationSearchBox).not.toBeNull();
+    expect(locationSearchBox!.height).toBeLessThanOrEqual(60);
+    expect(locationSearchBox!.width).toBeGreaterThanOrEqual(260);
+    expect(locationSearchBox!.width).toBeLessThanOrEqual(320);
+
     const controls = page.getByTestId("deadtrees-layer-controls");
     await expect(controls).toBeVisible();
     await expect(

--- a/frontend/src/components/DeadwoodMap/LocationControls.tsx
+++ b/frontend/src/components/DeadwoodMap/LocationControls.tsx
@@ -1,6 +1,9 @@
-import { GeoapifyContext, GeoapifyGeocoderAutocomplete } from "@geoapify/react-geocoder-autocomplete";
+import {
+  GeoapifyContext,
+  GeoapifyGeocoderAutocomplete,
+} from "@geoapify/react-geocoder-autocomplete";
 import { Button } from "antd";
-import { EnvironmentOutlined } from "@ant-design/icons";
+import { EnvironmentOutlined, SearchOutlined } from "@ant-design/icons";
 import "@geoapify/geocoder-autocomplete/styles/round-borders.css";
 import "../DeadwoodMap/geocoder.css";
 import { useIsMobile } from "../../hooks/useIsMobile";
@@ -23,16 +26,18 @@ const LocationControls = ({
 
   return (
     <div
-      className={`location-controls pointer-events-auto flex w-full flex-col gap-2.5 ${isDrawerInline ? "" : "w-64 rounded-2xl border border-gray-200/60 bg-white/95 p-3.5 shadow-xl backdrop-blur-sm"}`}
+      className={`location-controls pointer-events-auto flex flex-col gap-2.5 ${isDrawerInline ? "location-controls--drawer" : "location-controls--floating"}`}
+      data-testid="location-search-control"
     >
-      {/* Address Search */}
-      {!isDrawerInline && <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500">Location</div>}
-      <GeoapifyContext apiKey={import.meta.env.VITE_GEOPIFY_KEY}>
-        <GeoapifyGeocoderAutocomplete
-          placeholder="Search location..."
-          placeSelect={(place) => place?.bbox && onPlaceSelect(place.bbox)}
-        />
-      </GeoapifyContext>
+      <div className="location-search-shell">
+        <SearchOutlined aria-hidden className="location-search-icon" />
+        <GeoapifyContext apiKey={import.meta.env.VITE_GEOPIFY_KEY}>
+          <GeoapifyGeocoderAutocomplete
+            placeholder="Search location..."
+            placeSelect={(place) => place?.bbox && onPlaceSelect(place.bbox)}
+          />
+        </GeoapifyContext>
+      </div>
       {isMobile && onLocateMe && (
         <Button
           icon={<EnvironmentOutlined />}

--- a/frontend/src/components/DeadwoodMap/geocoder.css
+++ b/frontend/src/components/DeadwoodMap/geocoder.css
@@ -1,8 +1,49 @@
 .geoapify-close-button {
-  color: gainsboro;
+  color: #6b7280;
 }
+
 .geoapify-close-button:hover {
-  color: white;
+  color: #14532d;
+}
+
+.location-controls--floating {
+  width: min(18rem, calc(100vw - 2rem));
+}
+
+.location-search-shell {
+  position: relative;
+  border: 1px solid rgb(255 255 255 / 75%);
+  border-radius: 14px;
+  background: rgb(255 255 255 / 96%);
+  box-shadow:
+    0 10px 30px rgb(15 23 42 / 14%),
+    0 2px 6px rgb(15 23 42 / 8%);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+  backdrop-filter: blur(10px);
+}
+
+.location-search-shell:focus-within {
+  border-color: rgb(22 101 52 / 55%);
+  box-shadow:
+    0 0 0 3px rgb(22 101 52 / 14%),
+    0 10px 30px rgb(15 23 42 / 14%);
+}
+
+.location-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 15px;
+  z-index: 2;
+  color: #4b5563;
+  font-size: 15px;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.location-search-shell .geocoder-container {
+  width: 100%;
 }
 
 .location-controls .geoapify-autocomplete-input,
@@ -21,6 +62,39 @@
 
 .location-controls .geoapify-autocomplete-input,
 .location-controls input[type="text"] {
-  min-height: 40px;
-  border-radius: 10px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 38px 0 42px;
+  border: 0;
+  border-radius: 13px;
+  background: transparent;
+  color: #1f2937;
+  outline: none;
+  line-height: 44px;
+}
+
+.location-controls .geoapify-autocomplete-input::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+.location-controls .geoapify-close-button {
+  right: 12px;
+}
+
+.location-controls .geoapify-autocomplete-items {
+  top: calc(100% + 8px);
+  border-color: rgb(229 231 235 / 90%);
+  border-radius: 14px;
+  box-shadow: 0 18px 40px rgb(15 23 42 / 18%);
+}
+
+.location-controls--drawer .location-search-shell {
+  box-shadow: none;
+}
+
+.location-controls--drawer {
+  width: 100%;
 }


### PR DESCRIPTION
## Briefing
The satellite map location finder used a large nested card that dominated the map. This follow-up replaces it with a compact floating search bar while preserving the existing Geoapify search and map navigation behavior.

## What changed
- Removed the separate uppercase location heading and nested card treatment
- Added a single 44 px search field with icon, focus state, and aligned suggestion menu
- Added an end-to-end size and structure regression check

## Validation
- `npm test` — 252 tests passed
- `npm run lint`
- `npm run build`
- `scripts/lint-ast-grep.sh`
- Targeted Playwright satellite-map journey
- Built-in Browser smoke at normal and compact desktop widths; Freiburg suggestions verified
- Codex autoreview: no actionable findings

## Risk
Visual-only change to the desktop map search control; mobile map behavior and geocoder selection logic are unchanged.