### PR TITLE
feat(priwa): improve field review and data tools

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Route, Routes, useLocation } from "react-router-dom";
-import { ConfigProvider, Layout } from "antd";
+import { App as AntdApp, ConfigProvider, Layout } from "antd";
 import { useEffect } from "react";
 import { trackPageView, initializePostHog } from "./utils/analytics";
 import { AOIProvider } from "./contexts/AOIContext";
@@ -59,9 +59,9 @@ function LayoutWrapper() {
   return (
     <div>
       <Layout
+        className={shouldUseFullHeight ? "dt-full-height-layout" : undefined}
         style={{
           margin: "0 auto",
-          height: shouldUseFullHeight ? "100dvh" : "auto",
           backgroundColor: "var(--dt-surface-base)",
         }}
       >
@@ -192,11 +192,13 @@ function AppWithTracking() {
 export default function App() {
   return (
     <ConfigProvider theme={antdTheme}>
-      <AOIProvider>
-        <AuditNavigationProvider>
-          <AppWithTracking />
-        </AuditNavigationProvider>
-      </AOIProvider>
+      <AntdApp>
+        <AOIProvider>
+          <AuditNavigationProvider>
+            <AppWithTracking />
+          </AuditNavigationProvider>
+        </AOIProvider>
+      </AntdApp>
     </ConfigProvider>
   );
 }

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -294,13 +294,12 @@ export default function PriwaFieldMap({
     [confirmedMobileMosaics, isMobile, matchedMosaics],
   );
   const mapEnabledMosaics = useMemo(
-    () =>
-      isMobile
-        ? enabledMosaics.filter(
-            (mosaic) => mosaic.flightType === "umfeldbefliegung",
-          )
-        : enabledMosaics,
+    () => (isMobile ? [] : enabledMosaics),
     [enabledMosaics, isMobile],
+  );
+  const mapEnabledMosaicIds = useMemo(
+    () => (isMobile ? new Set<string>() : enabledMosaicIds),
+    [enabledMosaicIds, isMobile],
   );
 
   const openPointForEditing = useCallback(
@@ -520,7 +519,7 @@ export default function PriwaFieldMap({
     footprintMosaics,
     reviewMosaics,
     enabledMosaics: mapEnabledMosaics,
-    enabledMosaicIds,
+    enabledMosaicIds: mapEnabledMosaicIds,
     showMosaicFootprints: !isMobile || areMobileFlightBoundariesVisible,
     selectedMosaicId: isMobile ? null : selectedMosaicId,
     selectedGroupId: isMobile ? null : selectedGroupId,
@@ -805,13 +804,11 @@ export default function PriwaFieldMap({
               points={points}
               groups={groups}
               mosaics={confirmedMobileMosaics}
-              enabledMosaicIds={enabledMosaicIds}
               areFlightBoundariesVisible={areMobileFlightBoundariesVisible}
               isFlightSheetOpen={isMobileFlightSheetOpen}
               focusedFlightId={focusedMobileFlightId}
               onEditPoint={openPointForEditing}
               onZoomToPoint={focusPointOnMap}
-              onSetMosaicVisibility={setMosaicVisibility}
               onZoomToMosaic={zoomToMosaicFootprint}
               onFlightBoundariesVisibilityChange={
                 setMobileFlightBoundariesVisible

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -169,6 +169,12 @@ export default function PriwaFieldMap({
   const [focusedPointId, setFocusedPointId] = useState<string | null>(null);
   const [reviewPointId, setReviewPointId] = useState<string | null>(null);
   const [baseLayer, setBaseLayer] = useState<PriwaBaseLayer>("aerial");
+  const [areMobileFlightBoundariesVisible, setMobileFlightBoundariesVisible] =
+    useState(true);
+  const [isMobileFlightSheetOpen, setMobileFlightSheetOpen] = useState(false);
+  const [focusedMobileFlightId, setFocusedMobileFlightId] = useState<
+    string | null
+  >(null);
   const isMobile = useIsMobile();
   const userLocation = useUserLocationLayer(mapRef);
   const {
@@ -273,10 +279,28 @@ export default function PriwaFieldMap({
     createGroup,
     createGroupForFlight,
   } = review;
+  const confirmedMobileMosaics = useMemo(
+    () =>
+      reviewMosaics.filter(
+        (mosaic) => mosaic.flightType === "umfeldbefliegung",
+      ),
+    [reviewMosaics],
+  );
   const footprintMosaics = useMemo(
     () =>
-      isMobile ? reviewMosaics : matchedMosaics.map(({ mosaic }) => mosaic),
-    [isMobile, matchedMosaics, reviewMosaics],
+      isMobile
+        ? confirmedMobileMosaics
+        : matchedMosaics.map(({ mosaic }) => mosaic),
+    [confirmedMobileMosaics, isMobile, matchedMosaics],
+  );
+  const mapEnabledMosaics = useMemo(
+    () =>
+      isMobile
+        ? enabledMosaics.filter(
+            (mosaic) => mosaic.flightType === "umfeldbefliegung",
+          )
+        : enabledMosaics,
+    [enabledMosaics, isMobile],
   );
 
   const openPointForEditing = useCallback(
@@ -408,7 +432,10 @@ export default function PriwaFieldMap({
       );
 
       if (mosaicId) {
-        if (!window.matchMedia("(max-width: 767px)").matches) {
+        if (window.matchMedia("(max-width: 767px)").matches) {
+          setFocusedMobileFlightId(mosaicId);
+          setMobileFlightSheetOpen(true);
+        } else {
           selectReviewItemFromMosaicRef.current(mosaicId);
         }
         return;
@@ -492,8 +519,9 @@ export default function PriwaFieldMap({
     points,
     footprintMosaics,
     reviewMosaics,
-    enabledMosaics,
+    enabledMosaics: mapEnabledMosaics,
     enabledMosaicIds,
+    showMosaicFootprints: !isMobile || areMobileFlightBoundariesVisible,
     selectedMosaicId: isMobile ? null : selectedMosaicId,
     selectedGroupId: isMobile ? null : selectedGroupId,
   });
@@ -776,12 +804,19 @@ export default function PriwaFieldMap({
             <PriwaMobileFieldTools
               points={points}
               groups={groups}
-              mosaics={reviewMosaics}
+              mosaics={confirmedMobileMosaics}
               enabledMosaicIds={enabledMosaicIds}
+              areFlightBoundariesVisible={areMobileFlightBoundariesVisible}
+              isFlightSheetOpen={isMobileFlightSheetOpen}
+              focusedFlightId={focusedMobileFlightId}
               onEditPoint={openPointForEditing}
               onZoomToPoint={focusPointOnMap}
               onSetMosaicVisibility={setMosaicVisibility}
               onZoomToMosaic={zoomToMosaicFootprint}
+              onFlightBoundariesVisibilityChange={
+                setMobileFlightBoundariesVisible
+              }
+              onFlightSheetOpenChange={setMobileFlightSheetOpen}
             />
           )}
           {!isMobile && !isPointListOpen && !isDrawerOpen && (

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, FloatButton, Tooltip, message } from "antd";
+import { Alert, App, Button, FloatButton, Tooltip } from "antd";
 import {
   AimOutlined,
   EnvironmentOutlined,
@@ -11,7 +11,7 @@ import { unByKey } from "ol/Observable";
 import { fromLonLat, toLonLat, transformExtent } from "ol/proj";
 import View from "ol/View";
 import { boundingExtent } from "ol/extent";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PointerEvent } from "react";
 
 import { createStandardMapControls } from "../../utils/basemaps";
@@ -19,6 +19,7 @@ import parseBBox from "../../utils/parseBBox";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { useUserLocationLayer } from "../../hooks/useUserLocationLayer";
 import { createLglDop20Layer } from "./createLglDop20Layer";
+import { PRIWA_COG_MAX_ZOOM } from "./createPriwaCogLayer";
 import { createPriwaTopographicLayer } from "./createPriwaTopographicLayer";
 import {
   createPriwaOfflineAreaFeature,
@@ -59,7 +60,6 @@ import type {
 } from "./types";
 
 const FIELD_CENTER: [number, number] = [8.18013, 48.45596];
-const EMPTY_MOSAIC_IDS = new Set<string>();
 
 interface PriwaFieldMapProps {
   points: IPriwaPoint[];
@@ -118,6 +118,7 @@ export default function PriwaFieldMap({
   isClassifyingFlight = false,
   onSyncNow,
 }: PriwaFieldMapProps) {
+  const { message } = App.useApp();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
   const isPlacingPointRef = useRef(false);
@@ -203,30 +204,34 @@ export default function PriwaFieldMap({
     [points],
   );
 
-  const zoomToMosaicFootprint = useCallback((mosaic: IPriwaMosaic) => {
-    if (!mosaic.bbox) {
-      message.warning(
-        "Für diesen Drohnenlayer ist keine Kartengrenze verfügbar.",
-      );
-      return;
-    }
+  const zoomToMosaicFootprint = useCallback(
+    (mosaic: IPriwaMosaic) => {
+      if (!mosaic.bbox) {
+        message.warning(
+          "Für diesen Drohnenlayer ist keine Kartengrenze verfügbar.",
+        );
+        return;
+      }
 
-    const bbox = parseBBox(mosaic.bbox);
-    if (!bbox) {
-      message.warning("Kartengrenze konnte nicht gelesen werden.");
-      return;
-    }
+      const bbox = parseBBox(mosaic.bbox);
+      if (!bbox) {
+        message.warning("Kartengrenze konnte nicht gelesen werden.");
+        return;
+      }
 
-    mapRef.current
-      ?.getView()
-      .fit(transformExtent(bbox, "EPSG:4326", "EPSG:3857"), {
-        duration: 500,
-        maxZoom: 19,
-        padding: [96, 96, 96, 96],
-      });
-  }, []);
+      mapRef.current
+        ?.getView()
+        .fit(transformExtent(bbox, "EPSG:4326", "EPSG:3857"), {
+          duration: 500,
+          maxZoom: 19,
+          padding: [96, 96, 96, 96],
+        });
+    },
+    [message],
+  );
 
   const review = usePriwaReviewController({
+    projectId,
     points,
     mosaics,
     groups,
@@ -268,6 +273,11 @@ export default function PriwaFieldMap({
     createGroup,
     createGroupForFlight,
   } = review;
+  const footprintMosaics = useMemo(
+    () =>
+      isMobile ? reviewMosaics : matchedMosaics.map(({ mosaic }) => mosaic),
+    [isMobile, matchedMosaics, reviewMosaics],
+  );
 
   const openPointForEditing = useCallback(
     (point: IPriwaPoint) => {
@@ -329,7 +339,7 @@ export default function PriwaFieldMap({
         center: fromLonLat(FIELD_CENTER),
         zoom: 19,
         minZoom: 8,
-        maxZoom: 21,
+        maxZoom: PRIWA_COG_MAX_ZOOM,
         projection: "EPSG:3857",
       }),
       interactions: defaultInteractions({
@@ -398,7 +408,10 @@ export default function PriwaFieldMap({
       );
 
       if (mosaicId) {
-        selectReviewItemFromMosaicRef.current(mosaicId);
+        if (!window.matchMedia("(max-width: 767px)").matches) {
+          selectReviewItemFromMosaicRef.current(mosaicId);
+        }
+        return;
       }
     });
 
@@ -477,10 +490,10 @@ export default function PriwaFieldMap({
     mosaicFootprintLayerRef,
     groups: isMobile ? [] : groups,
     points,
-    matchedMosaics: isMobile ? [] : matchedMosaics,
-    reviewMosaics: isMobile ? [] : reviewMosaics,
-    enabledMosaics: isMobile ? [] : enabledMosaics,
-    enabledMosaicIds: isMobile ? EMPTY_MOSAIC_IDS : enabledMosaicIds,
+    footprintMosaics,
+    reviewMosaics,
+    enabledMosaics,
+    enabledMosaicIds,
     selectedMosaicId: isMobile ? null : selectedMosaicId,
     selectedGroupId: isMobile ? null : selectedGroupId,
   });
@@ -671,7 +684,7 @@ export default function PriwaFieldMap({
       await onAddPoint(point);
       message.success("Käferbaum gespeichert");
     },
-    [onAddPoint],
+    [message, onAddPoint],
   );
 
   const handleUpdatePoint = useCallback(
@@ -679,7 +692,7 @@ export default function PriwaFieldMap({
       await onUpdatePoint(point);
       message.success("Käferbaum aktualisiert");
     },
-    [onUpdatePoint],
+    [message, onUpdatePoint],
   );
 
   const handleDeletePoint = useCallback(
@@ -689,7 +702,7 @@ export default function PriwaFieldMap({
       setDrawerOpen(false);
       setEditingPoint(null);
     },
-    [onDeletePoint],
+    [message, onDeletePoint],
   );
 
   const handleCacheBasemapArea = useCallback(async () => {
@@ -705,12 +718,12 @@ export default function PriwaFieldMap({
           : "Basiskarte konnte nicht offline gespeichert werden.",
       );
     }
-  }, [cacheCurrentMapArea]);
+  }, [cacheCurrentMapArea, message]);
 
   const handleClearBasemapArea = useCallback(async () => {
     await clearOfflineBasemapArea();
     message.success("Offline-Basiskartenbereich entfernt");
-  }, [clearOfflineBasemapArea]);
+  }, [clearOfflineBasemapArea, message]);
 
   const dataErrorMessage =
     errorMessage ?? groupsErrorMessage ?? cogErrorMessage;
@@ -763,8 +776,12 @@ export default function PriwaFieldMap({
             <PriwaMobileFieldTools
               points={points}
               groups={groups}
+              mosaics={reviewMosaics}
+              enabledMosaicIds={enabledMosaicIds}
               onEditPoint={openPointForEditing}
               onZoomToPoint={focusPointOnMap}
+              onSetMosaicVisibility={setMosaicVisibility}
+              onZoomToMosaic={zoomToMosaicFootprint}
             />
           )}
           {!isMobile && !isPointListOpen && !isDrawerOpen && (
@@ -837,6 +854,7 @@ export default function PriwaFieldMap({
         <PriwaPointListPanel
           points={points}
           groups={groups}
+          mosaics={mosaics}
           projectName={projectName}
           isLoading={isLoadingPoints}
           focusedPointId={focusedPointId}

--- a/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
@@ -5,19 +5,29 @@ import { useMemo, useState } from "react";
 import { indexPriwaBefallsgruppenByTreeId } from "./priwaBefallsgruppenState";
 import PriwaPointCompactList from "./PriwaPointCompactList";
 import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
+import PriwaMobileFlightSheet from "./PriwaMobileFlightSheet";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 interface PriwaMobileFieldToolsProps {
   points: IPriwaPoint[];
   groups: IPriwaBefallsgruppe[];
+  mosaics: IPriwaMosaic[];
+  enabledMosaicIds: Set<string>;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
+  onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
+  onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
 }
 
 export default function PriwaMobileFieldTools({
   points,
   groups,
+  mosaics,
+  enabledMosaicIds,
   onEditPoint,
   onZoomToPoint,
+  onSetMosaicVisibility,
+  onZoomToMosaic,
 }: PriwaMobileFieldToolsProps) {
   const [isTreeListOpen, setTreeListOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -54,6 +64,13 @@ export default function PriwaMobileFieldTools({
           aria-pressed={isTreeListOpen}
         />
       </Tooltip>
+
+      <PriwaMobileFlightSheet
+        mosaics={mosaics}
+        enabledMosaicIds={enabledMosaicIds}
+        onSetMosaicVisibility={onSetMosaicVisibility}
+        onZoomToMosaic={onZoomToMosaic}
+      />
 
       <Drawer
         title={`Käferbäume (${points.length})`}

--- a/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
@@ -13,10 +13,15 @@ interface PriwaMobileFieldToolsProps {
   groups: IPriwaBefallsgruppe[];
   mosaics: IPriwaMosaic[];
   enabledMosaicIds: Set<string>;
+  areFlightBoundariesVisible: boolean;
+  isFlightSheetOpen: boolean;
+  focusedFlightId: string | null;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
   onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
   onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
+  onFlightBoundariesVisibilityChange: (visible: boolean) => void;
+  onFlightSheetOpenChange: (open: boolean) => void;
 }
 
 export default function PriwaMobileFieldTools({
@@ -24,10 +29,15 @@ export default function PriwaMobileFieldTools({
   groups,
   mosaics,
   enabledMosaicIds,
+  areFlightBoundariesVisible,
+  isFlightSheetOpen,
+  focusedFlightId,
   onEditPoint,
   onZoomToPoint,
   onSetMosaicVisibility,
   onZoomToMosaic,
+  onFlightBoundariesVisibilityChange,
+  onFlightSheetOpenChange,
 }: PriwaMobileFieldToolsProps) {
   const [isTreeListOpen, setTreeListOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -68,8 +78,13 @@ export default function PriwaMobileFieldTools({
       <PriwaMobileFlightSheet
         mosaics={mosaics}
         enabledMosaicIds={enabledMosaicIds}
+        areBoundariesVisible={areFlightBoundariesVisible}
+        isOpen={isFlightSheetOpen}
+        focusedMosaicId={focusedFlightId}
         onSetMosaicVisibility={onSetMosaicVisibility}
         onZoomToMosaic={onZoomToMosaic}
+        onBoundariesVisibilityChange={onFlightBoundariesVisibilityChange}
+        onOpenChange={onFlightSheetOpenChange}
       />
 
       <Drawer

--- a/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFieldTools.tsx
@@ -12,13 +12,11 @@ interface PriwaMobileFieldToolsProps {
   points: IPriwaPoint[];
   groups: IPriwaBefallsgruppe[];
   mosaics: IPriwaMosaic[];
-  enabledMosaicIds: Set<string>;
   areFlightBoundariesVisible: boolean;
   isFlightSheetOpen: boolean;
   focusedFlightId: string | null;
   onEditPoint: (point: IPriwaPoint) => void;
   onZoomToPoint: (point: IPriwaPoint) => void;
-  onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
   onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
   onFlightBoundariesVisibilityChange: (visible: boolean) => void;
   onFlightSheetOpenChange: (open: boolean) => void;
@@ -28,13 +26,11 @@ export default function PriwaMobileFieldTools({
   points,
   groups,
   mosaics,
-  enabledMosaicIds,
   areFlightBoundariesVisible,
   isFlightSheetOpen,
   focusedFlightId,
   onEditPoint,
   onZoomToPoint,
-  onSetMosaicVisibility,
   onZoomToMosaic,
   onFlightBoundariesVisibilityChange,
   onFlightSheetOpenChange,
@@ -77,11 +73,9 @@ export default function PriwaMobileFieldTools({
 
       <PriwaMobileFlightSheet
         mosaics={mosaics}
-        enabledMosaicIds={enabledMosaicIds}
         areBoundariesVisible={areFlightBoundariesVisible}
         isOpen={isFlightSheetOpen}
         focusedMosaicId={focusedFlightId}
-        onSetMosaicVisibility={onSetMosaicVisibility}
         onZoomToMosaic={onZoomToMosaic}
         onBoundariesVisibilityChange={onFlightBoundariesVisibilityChange}
         onOpenChange={onFlightSheetOpenChange}

--- a/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
@@ -1,0 +1,136 @@
+import { AimOutlined, BorderOutlined } from "@ant-design/icons";
+import { Button, Drawer, Empty, Switch, Tag, Tooltip } from "antd";
+import { useState } from "react";
+
+import { formatPriwaReviewDate } from "./priwaReviewPresentation";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
+
+interface PriwaMobileFlightSheetProps {
+  mosaics: IPriwaMosaic[];
+  enabledMosaicIds: Set<string>;
+  onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
+  onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
+}
+
+export default function PriwaMobileFlightSheet({
+  mosaics,
+  enabledMosaicIds,
+  onSetMosaicVisibility,
+  onZoomToMosaic,
+}: PriwaMobileFlightSheetProps) {
+  const [isOpen, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip title="Befliegungen" placement="right">
+        <Button
+          className="pointer-events-auto shadow-md md:hidden"
+          shape="circle"
+          size="large"
+          icon={<BorderOutlined />}
+          onClick={() => setOpen(true)}
+          aria-label="Befliegungen öffnen"
+          aria-pressed={isOpen}
+        />
+      </Tooltip>
+
+      <Drawer
+        title={`Befliegungen (${mosaics.length})`}
+        placement="bottom"
+        height="72dvh"
+        open={isOpen}
+        onClose={() => setOpen(false)}
+        rootClassName="priwa-layer-sheet-root"
+        className="md:hidden"
+        styles={{
+          header: { padding: "12px 16px" },
+          body: {
+            padding: "0 0 calc(env(safe-area-inset-bottom, 0px) + 16px)",
+            overflow: "hidden",
+          },
+        }}
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="border-b border-slate-200 bg-cyan-50 px-4 py-3 text-xs text-cyan-950">
+            Die Kartengrenzen benötigen kaum Daten. Ein Luftbild wird erst
+            geladen, wenn du es einschaltest.
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-3">
+            {mosaics.length === 0 ? (
+              <Empty
+                className="py-12"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="Keine Befliegungen verfügbar"
+              />
+            ) : (
+              <div className="space-y-2">
+                {mosaics.map((mosaic) => (
+                  <div
+                    key={mosaic.id}
+                    className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div
+                          className="truncate text-sm font-semibold text-slate-900"
+                          title={mosaic.label}
+                        >
+                          {mosaic.label}
+                        </div>
+                        <div className="mt-0.5 text-xs text-slate-500">
+                          Aufnahme {formatPriwaReviewDate(mosaic.captureDate)}
+                        </div>
+                      </div>
+                      <Tag
+                        className="m-0 shrink-0"
+                        color={
+                          mosaic.flightType === "umfeldbefliegung"
+                            ? "green"
+                            : "gold"
+                        }
+                      >
+                        {mosaic.flightType === "umfeldbefliegung"
+                          ? "Bestätigt"
+                          : "Vorschlag"}
+                      </Tag>
+                    </div>
+
+                    <div className="mt-3 flex items-center justify-between gap-3">
+                      <Button
+                        size="small"
+                        icon={<AimOutlined />}
+                        disabled={!mosaic.bbox}
+                        onClick={() => {
+                          onZoomToMosaic(mosaic);
+                          setOpen(false);
+                        }}
+                      >
+                        Grenze zeigen
+                      </Button>
+                      <label className="flex items-center gap-2 text-xs font-medium text-slate-700">
+                        Luftbild
+                        <Switch
+                          size="small"
+                          checked={enabledMosaicIds.has(mosaic.id)}
+                          onChange={(checked) =>
+                            onSetMosaicVisibility(mosaic.id, checked)
+                          }
+                          aria-label={`Luftbild ${mosaic.label} anzeigen`}
+                        />
+                      </label>
+                    </div>
+                    {!mosaic.bbox && (
+                      <div className="mt-2 text-xs text-amber-700">
+                        Keine Kartengrenze verfügbar
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </Drawer>
+    </>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
@@ -7,11 +7,9 @@ import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 interface PriwaMobileFlightSheetProps {
   mosaics: IPriwaMosaic[];
-  enabledMosaicIds: Set<string>;
   areBoundariesVisible: boolean;
   isOpen: boolean;
   focusedMosaicId: string | null;
-  onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
   onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
   onBoundariesVisibilityChange: (visible: boolean) => void;
   onOpenChange: (open: boolean) => void;
@@ -19,11 +17,9 @@ interface PriwaMobileFlightSheetProps {
 
 export default function PriwaMobileFlightSheet({
   mosaics,
-  enabledMosaicIds,
   areBoundariesVisible,
   isOpen,
   focusedMosaicId,
-  onSetMosaicVisibility,
   onZoomToMosaic,
   onBoundariesVisibilityChange,
   onOpenChange,
@@ -81,7 +77,8 @@ export default function PriwaMobileFlightSheet({
               />
             </div>
             <p className="mt-1">
-              Ein Luftbild wird erst geladen, wenn du es einzeln einschaltest.
+              Auf Mobilgeräten werden nur die Grenzen bestätigt erfasster
+              Umfeldbefliegungen angezeigt.
             </p>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-3">
@@ -131,7 +128,7 @@ export default function PriwaMobileFlightSheet({
                       </Tag>
                     </div>
 
-                    <div className="mt-3 flex items-center justify-between gap-3">
+                    <div className="mt-3">
                       <Button
                         size="small"
                         icon={<AimOutlined />}
@@ -144,17 +141,6 @@ export default function PriwaMobileFlightSheet({
                       >
                         Grenze zeigen
                       </Button>
-                      <label className="flex items-center gap-2 text-xs font-medium text-slate-700">
-                        Luftbild
-                        <Switch
-                          size="small"
-                          checked={enabledMosaicIds.has(mosaic.id)}
-                          onChange={(checked) =>
-                            onSetMosaicVisibility(mosaic.id, checked)
-                          }
-                          aria-label={`Luftbild ${mosaic.label} anzeigen`}
-                        />
-                      </label>
                     </div>
                     {!mosaic.bbox && (
                       <div className="mt-2 text-xs text-amber-700">

--- a/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
+++ b/frontend/src/components/PriwaField/PriwaMobileFlightSheet.tsx
@@ -1,6 +1,6 @@
 import { AimOutlined, BorderOutlined } from "@ant-design/icons";
 import { Button, Drawer, Empty, Switch, Tag, Tooltip } from "antd";
-import { useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { formatPriwaReviewDate } from "./priwaReviewPresentation";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
@@ -8,17 +8,35 @@ import type { IPriwaMosaic } from "./usePriwaMosaics";
 interface PriwaMobileFlightSheetProps {
   mosaics: IPriwaMosaic[];
   enabledMosaicIds: Set<string>;
+  areBoundariesVisible: boolean;
+  isOpen: boolean;
+  focusedMosaicId: string | null;
   onSetMosaicVisibility: (mosaicId: string, visible: boolean) => void;
   onZoomToMosaic: (mosaic: IPriwaMosaic) => void;
+  onBoundariesVisibilityChange: (visible: boolean) => void;
+  onOpenChange: (open: boolean) => void;
 }
 
 export default function PriwaMobileFlightSheet({
   mosaics,
   enabledMosaicIds,
+  areBoundariesVisible,
+  isOpen,
+  focusedMosaicId,
   onSetMosaicVisibility,
   onZoomToMosaic,
+  onBoundariesVisibilityChange,
+  onOpenChange,
 }: PriwaMobileFlightSheetProps) {
-  const [isOpen, setOpen] = useState(false);
+  const focusedCardRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !focusedMosaicId) return;
+    const frame = window.requestAnimationFrame(() => {
+      focusedCardRef.current?.scrollIntoView({ block: "center" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusedMosaicId, isOpen]);
 
   return (
     <>
@@ -28,9 +46,10 @@ export default function PriwaMobileFlightSheet({
           shape="circle"
           size="large"
           icon={<BorderOutlined />}
-          onClick={() => setOpen(true)}
+          type={areBoundariesVisible ? "primary" : "default"}
+          onClick={() => onOpenChange(true)}
           aria-label="Befliegungen öffnen"
-          aria-pressed={isOpen}
+          aria-pressed={areBoundariesVisible}
         />
       </Tooltip>
 
@@ -39,7 +58,7 @@ export default function PriwaMobileFlightSheet({
         placement="bottom"
         height="72dvh"
         open={isOpen}
-        onClose={() => setOpen(false)}
+        onClose={() => onOpenChange(false)}
         rootClassName="priwa-layer-sheet-root"
         className="md:hidden"
         styles={{
@@ -52,8 +71,18 @@ export default function PriwaMobileFlightSheet({
       >
         <div className="flex h-full min-h-0 flex-col">
           <div className="border-b border-slate-200 bg-cyan-50 px-4 py-3 text-xs text-cyan-950">
-            Die Kartengrenzen benötigen kaum Daten. Ein Luftbild wird erst
-            geladen, wenn du es einschaltest.
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-medium">Befliegungsgrenzen anzeigen</span>
+              <Switch
+                size="small"
+                checked={areBoundariesVisible}
+                onChange={onBoundariesVisibilityChange}
+                aria-label="Alle Befliegungsgrenzen anzeigen"
+              />
+            </div>
+            <p className="mt-1">
+              Ein Luftbild wird erst geladen, wenn du es einzeln einschaltest.
+            </p>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-3">
             {mosaics.length === 0 ? (
@@ -67,7 +96,14 @@ export default function PriwaMobileFlightSheet({
                 {mosaics.map((mosaic) => (
                   <div
                     key={mosaic.id}
-                    className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+                    ref={
+                      mosaic.id === focusedMosaicId ? focusedCardRef : undefined
+                    }
+                    className={`rounded-lg border bg-white p-3 shadow-sm ${
+                      mosaic.id === focusedMosaicId
+                        ? "border-emerald-600 ring-2 ring-emerald-100"
+                        : "border-slate-200"
+                    }`}
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
@@ -101,8 +137,9 @@ export default function PriwaMobileFlightSheet({
                         icon={<AimOutlined />}
                         disabled={!mosaic.bbox}
                         onClick={() => {
+                          onBoundariesVisibilityChange(true);
                           onZoomToMosaic(mosaic);
-                          setOpen(false);
+                          onOpenChange(false);
                         }}
                       >
                         Grenze zeigen

--- a/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointDrawer.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  App,
   Button,
   Collapse,
   Drawer,
@@ -8,7 +9,6 @@ import {
   Modal,
   Select,
   Typography,
-  message,
 } from "antd";
 import {
   AimOutlined,
@@ -227,6 +227,7 @@ export default function PriwaPointDrawer({
   onZoomToPoint,
   presentation = "overlay",
 }: PriwaPointDrawerProps) {
+  const { message } = App.useApp();
   const isEmbedded = presentation === "embedded";
   const [form] = Form.useForm<IPriwaPointFormValues>();
   const [rawQrValue, setRawQrValue] = useState("");

--- a/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointListPanel.tsx
@@ -5,11 +5,20 @@ import type { CSSProperties } from "react";
 
 import PriwaPointCompactList from "./PriwaPointCompactList";
 import PriwaPointPanelResizeHandle from "./PriwaPointPanelResizeHandle";
+import PriwaPointSearchControl from "./PriwaPointSearchControl";
 import PriwaPointTable from "./PriwaPointTable";
-import { indexPriwaBefallsgruppenByTreeId } from "./priwaBefallsgruppenState";
+import {
+  indexPriwaBefallsgruppenByTreeId,
+  indexConfirmedPriwaFlightLabelsByTreeId,
+} from "./priwaBefallsgruppenState";
 import { downloadPriwaPointsCsv } from "./priwaPointCsv";
 import { isPriwaPointQaCandidate } from "./priwaPointQa";
+import {
+  filterPriwaPointsBySearch,
+  type PriwaPointSearchField,
+} from "./priwaPointTableData";
 import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 type PriwaPointFilter = "all" | "qa";
 type PriwaPointView = "list" | "table";
@@ -35,6 +44,7 @@ const loadInitialPointView = (): PriwaPointView => {
 interface PriwaPointListPanelProps {
   points: IPriwaPoint[];
   groups: IPriwaBefallsgruppe[];
+  mosaics: IPriwaMosaic[];
   projectName: string;
   isLoading?: boolean;
   focusedPointId?: string | null;
@@ -46,6 +56,7 @@ interface PriwaPointListPanelProps {
 export default function PriwaPointListPanel({
   points,
   groups,
+  mosaics,
   projectName,
   isLoading = false,
   focusedPointId = null,
@@ -54,12 +65,18 @@ export default function PriwaPointListPanel({
   onZoomToPoint,
 }: PriwaPointListPanelProps) {
   const [filter, setFilter] = useState<PriwaPointFilter>("all");
+  const [search, setSearch] = useState("");
+  const [searchField, setSearchField] = useState<PriwaPointSearchField>("all");
   const [view, setView] = useState<PriwaPointView>(loadInitialPointView);
   const panelRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const groupByTreeId = useMemo(
     () => indexPriwaBefallsgruppenByTreeId(groups),
     [groups],
+  );
+  const confirmedFlightLabelsByTreeId = useMemo(
+    () => indexConfirmedPriwaFlightLabelsByTreeId(groups, mosaics),
+    [groups, mosaics],
   );
   const qaPoints = useMemo(
     () => points.filter(isPriwaPointQaCandidate),
@@ -68,7 +85,24 @@ export default function PriwaPointListPanel({
   const exactCount = points.filter(
     (point) => point.coordinateSource === "qr",
   ).length;
-  const visiblePoints = filter === "qa" ? qaPoints : points;
+  const filteredPoints = filter === "qa" ? qaPoints : points;
+  const visiblePoints = useMemo(
+    () =>
+      filterPriwaPointsBySearch(
+        filteredPoints,
+        search,
+        searchField,
+        groupByTreeId,
+        confirmedFlightLabelsByTreeId,
+      ),
+    [
+      confirmedFlightLabelsByTreeId,
+      filteredPoints,
+      groupByTreeId,
+      search,
+      searchField,
+    ],
+  );
   const focusedPoint = useMemo(
     () => points.find((point) => point.id === focusedPointId) ?? null,
     [focusedPointId, points],
@@ -78,9 +112,11 @@ export default function PriwaPointListPanel({
   ).length;
   const emptyDescription = isLoading
     ? "Lade Punkte..."
-    : filter === "qa" && points.length > 0
-      ? "Keine QA-Punkte"
-      : "Keine Punkte";
+    : search.trim()
+      ? "Keine passenden Punkte"
+      : filter === "qa" && points.length > 0
+        ? "Keine QA-Punkte"
+        : "Keine Punkte";
 
   const changeView = (nextView: PriwaPointView) => {
     setView(nextView);
@@ -104,6 +140,8 @@ export default function PriwaPointListPanel({
     if (!focusedPointId) return;
 
     setFilter("all");
+    setSearch("");
+    setSearchField("all");
     setView("table");
   }, [focusedPointId]);
 
@@ -143,7 +181,13 @@ export default function PriwaPointListPanel({
             size="small"
             icon={<DownloadOutlined />}
             disabled={points.length === 0}
-            onClick={() => downloadPriwaPointsCsv(points, projectName)}
+            onClick={() =>
+              downloadPriwaPointsCsv(
+                points,
+                projectName,
+                confirmedFlightLabelsByTreeId,
+              )
+            }
           >
             CSV
           </Button>
@@ -174,7 +218,7 @@ export default function PriwaPointListPanel({
         </div>
       </div>
 
-      <div className="grid gap-2 border-b border-slate-200 px-3 py-2 md:grid-cols-2">
+      <div className="grid gap-2 border-b border-slate-200 px-3 py-2 md:grid-cols-3">
         <div>
           <div className="mb-1 text-xs font-medium text-slate-500">Ansicht</div>
           <Segmented<PriwaPointView>
@@ -203,6 +247,12 @@ export default function PriwaPointListPanel({
             ]}
           />
         </div>
+        <PriwaPointSearchControl
+          field={searchField}
+          search={search}
+          onFieldChange={setSearchField}
+          onSearchChange={setSearch}
+        />
       </div>
 
       {focusedPoint && (
@@ -236,6 +286,7 @@ export default function PriwaPointListPanel({
           <PriwaPointTable
             points={visiblePoints}
             groupByTreeId={groupByTreeId}
+            confirmedFlightLabelsByTreeId={confirmedFlightLabelsByTreeId}
             focusedPointId={focusedPointId}
             getScrollContainer={getTableScrollContainer}
             onEditPoint={onEditPoint}

--- a/frontend/src/components/PriwaField/PriwaPointSearchControl.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointSearchControl.tsx
@@ -1,0 +1,55 @@
+import { SearchOutlined } from "@ant-design/icons";
+import { Input, Select } from "antd";
+
+import type { PriwaPointSearchField } from "./priwaPointTableData";
+
+interface PriwaPointSearchControlProps {
+  field: PriwaPointSearchField;
+  search: string;
+  onFieldChange: (field: PriwaPointSearchField) => void;
+  onSearchChange: (search: string) => void;
+}
+
+export default function PriwaPointSearchControl({
+  field,
+  search,
+  onFieldChange,
+  onSearchChange,
+}: PriwaPointSearchControlProps) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium text-slate-500">Suche</div>
+      <div className="flex gap-1.5">
+        <Select<PriwaPointSearchField>
+          aria-label="Suchattribut auswählen"
+          className="w-36 shrink-0"
+          size="small"
+          value={field}
+          onChange={onFieldChange}
+          options={[
+            { label: "Alle Attribute", value: "all" },
+            { label: "Baumnr", value: "baumnr" },
+            { label: "Datum", value: "datum" },
+            { label: "Befallsgruppe", value: "group" },
+            { label: "Befliegungsdatei", value: "flight" },
+            { label: "Baumart", value: "baumart" },
+            { label: "Fund", value: "fund" },
+            { label: "Name", value: "name" },
+            { label: "Kommentar", value: "comment" },
+            { label: "Positionsquelle", value: "source" },
+          ]}
+        />
+        <Input
+          aria-label="Käferbäume durchsuchen"
+          allowClear
+          className="min-w-0"
+          size="small"
+          prefix={<SearchOutlined className="text-slate-400" />}
+          placeholder="Suchbegriff …"
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaPointTable.tsx
+++ b/frontend/src/components/PriwaField/PriwaPointTable.tsx
@@ -14,11 +14,13 @@ import {
   getPriwaPointTitle,
   isPriwaPointQaCandidate,
 } from "./priwaPointQa";
+import { comparePriwaTableText } from "./priwaPointTableData";
 import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
 
 interface PriwaPointTableProps {
   points: IPriwaPoint[];
   groupByTreeId: Record<string, IPriwaBefallsgruppe>;
+  confirmedFlightLabelsByTreeId: Record<string, string[]>;
   focusedPointId?: string | null;
   getScrollContainer: () => Window | HTMLElement;
   onEditPoint: (point: IPriwaPoint) => void;
@@ -28,6 +30,7 @@ interface PriwaPointTableProps {
 export default function PriwaPointTable({
   points,
   groupByTreeId,
+  confirmedFlightLabelsByTreeId,
   focusedPointId = null,
   getScrollContainer,
   onEditPoint,
@@ -62,13 +65,25 @@ export default function PriwaPointTable({
         title: "Baumnr",
         dataIndex: "baumnr",
         width: 110,
+        sorter: (left, right) =>
+          comparePriwaTableText(left.baumnr, right.baumnr),
         render: (_, point) => getPriwaPointTitle(point),
       },
-      { title: "Datum", dataIndex: "datum", width: 118 },
+      {
+        title: "Datum",
+        dataIndex: "datum",
+        width: 118,
+        sorter: (left, right) => left.datum.localeCompare(right.datum),
+      },
       {
         title: "Befallsgruppe",
         key: "befallsgruppe",
         width: 180,
+        sorter: (left, right) =>
+          comparePriwaTableText(
+            groupByTreeId[left.id]?.name,
+            groupByTreeId[right.id]?.name,
+          ),
         render: (_, point) => {
           const group = groupByTreeId[point.id];
           return group ? (
@@ -80,11 +95,43 @@ export default function PriwaPointTable({
           );
         },
       },
-      { title: "Baumart", dataIndex: "baumart", width: 150 },
+      {
+        title: "Bestätigte Befliegungsdateien",
+        key: "flightFilenames",
+        width: 280,
+        sorter: (left, right) =>
+          comparePriwaTableText(
+            confirmedFlightLabelsByTreeId[left.id]?.join(" | "),
+            confirmedFlightLabelsByTreeId[right.id]?.join(" | "),
+          ),
+        render: (_, point) => {
+          const labels = confirmedFlightLabelsByTreeId[point.id] ?? [];
+          const filenames = labels.join(" | ");
+          return filenames ? (
+            <span className="block max-w-[17rem] truncate" title={filenames}>
+              {filenames}
+            </span>
+          ) : (
+            <span className="text-slate-400">—</span>
+          );
+        },
+      },
+      {
+        title: "Baumart",
+        dataIndex: "baumart",
+        width: 150,
+        sorter: (left, right) =>
+          comparePriwaTableText(left.baumart, right.baumart),
+      },
       {
         title: "Fund",
         dataIndex: "fund",
         width: 150,
+        sorter: (left, right) =>
+          comparePriwaTableText(
+            getPriwaFundLabel(left),
+            getPriwaFundLabel(right),
+          ),
         render: (_, point) => getPriwaFundLabel(point),
       },
       { title: "Bohrmehl", dataIndex: "bm", width: 105 },
@@ -98,7 +145,12 @@ export default function PriwaPointTable({
       { title: "Nadelverfärbung", dataIndex: "nadel", width: 160 },
       { title: "Rindenverlust", dataIndex: "rinde", width: 125 },
       { title: "Nadelverlust", dataIndex: "kv", width: 125 },
-      { title: "Name", dataIndex: "name", width: 150 },
+      {
+        title: "Name",
+        dataIndex: "name",
+        width: 150,
+        sorter: (left, right) => comparePriwaTableText(left.name, right.name),
+      },
       {
         title: "Koordinaten",
         key: "coordinates",
@@ -141,7 +193,7 @@ export default function PriwaPointTable({
         ),
       },
     ],
-    [groupByTreeId, onEditPoint, onZoomToPoint],
+    [confirmedFlightLabelsByTreeId, groupByTreeId, onEditPoint, onZoomToPoint],
   );
 
   return (

--- a/frontend/src/components/PriwaField/createPriwaCogLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaCogLayer.ts
@@ -8,6 +8,8 @@ export interface IPriwaCogLayerSource {
   cogUrl: string;
 }
 
+export const PRIWA_COG_MAX_ZOOM = 23;
+
 export const resolvePriwaCogUrl = (cogUrl: string) => {
   try {
     return new URL(cogUrl).toString();
@@ -30,7 +32,7 @@ export const createPriwaCogLayer = (cog: IPriwaCogLayerSource) =>
       sourceOptions: COG_SOURCE_OPTIONS,
     }),
     opacity: 0.82,
-    maxZoom: 23,
+    maxZoom: PRIWA_COG_MAX_ZOOM,
     zIndex: 10,
     cacheSize: 4096,
     preload: 0,

--- a/frontend/src/components/PriwaField/priwaBefallsgruppenState.test.ts
+++ b/frontend/src/components/PriwaField/priwaBefallsgruppenState.test.ts
@@ -37,6 +37,30 @@ const mosaics: IPriwaMosaic[] = [
     additionalInformation: null,
     flightType: "umfeldbefliegung",
   },
+  {
+    id: "10513",
+    projectId: "project-1",
+    label: "pending-flight.zip",
+    cogUrl: "10513_cog.tif",
+    bbox: null,
+    captureDate: "2026-07-15",
+    createdAt: "2026-07-15T09:00:00.000Z",
+    authors: [],
+    additionalInformation: null,
+    flightType: null,
+  },
+  {
+    id: "10514",
+    projectId: "project-1",
+    label: "excluded-flight.zip",
+    cogUrl: "10514_cog.tif",
+    bbox: null,
+    captureDate: "2026-07-15",
+    createdAt: "2026-07-15T10:00:00.000Z",
+    authors: [],
+    additionalInformation: null,
+    flightType: "not_priwa",
+  },
 ];
 
 describe("PRIWA Befallsgruppen availability", () => {
@@ -67,7 +91,7 @@ describe("PRIWA Befallsgruppen availability", () => {
           {
             ...group,
             treeIds: ["tree-1", "tree-2"],
-            datasetIds: ["10512", "10512", "missing"],
+            datasetIds: ["10512", "10512", "10513", "10514", "missing"],
           },
         ],
         mosaics,

--- a/frontend/src/components/PriwaField/priwaBefallsgruppenState.test.ts
+++ b/frontend/src/components/PriwaField/priwaBefallsgruppenState.test.ts
@@ -4,9 +4,11 @@ import {
   arePriwaBefallsgruppenReady,
   groupsForPriwaMosaicMatching,
   indexPriwaBefallsgruppenByTreeId,
+  indexConfirmedPriwaFlightLabelsByTreeId,
   resolveInitialFlightGroupDraft,
 } from "./priwaBefallsgruppenState";
 import type { IPriwaBefallsgruppe } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 const group: IPriwaBefallsgruppe = {
   id: "group-1",
@@ -21,6 +23,21 @@ const group: IPriwaBefallsgruppe = {
   createdAt: "2026-07-16T08:00:00.000Z",
   updatedAt: "2026-07-16T08:00:00.000Z",
 };
+
+const mosaics: IPriwaMosaic[] = [
+  {
+    id: "10512",
+    projectId: "project-1",
+    label: "north-flight.zip",
+    cogUrl: "10512_cog.tif",
+    bbox: null,
+    captureDate: "2026-07-15",
+    createdAt: "2026-07-15T08:00:00.000Z",
+    authors: [],
+    additionalInformation: null,
+    flightType: "umfeldbefliegung",
+  },
+];
 
 describe("PRIWA Befallsgruppen availability", () => {
   it("allows confirmed-group behavior only after a successful load", () => {
@@ -40,6 +57,24 @@ describe("PRIWA Befallsgruppen availability", () => {
   it("indexes confirmed groups for tree table and list presentation", () => {
     expect(indexPriwaBefallsgruppenByTreeId([group])).toEqual({
       "tree-1": group,
+    });
+  });
+
+  it("indexes assigned flight filenames for every tree in a confirmed group", () => {
+    expect(
+      indexConfirmedPriwaFlightLabelsByTreeId(
+        [
+          {
+            ...group,
+            treeIds: ["tree-1", "tree-2"],
+            datasetIds: ["10512", "10512", "missing"],
+          },
+        ],
+        mosaics,
+      ),
+    ).toEqual({
+      "tree-1": ["north-flight.zip"],
+      "tree-2": ["north-flight.zip"],
     });
   });
 

--- a/frontend/src/components/PriwaField/priwaBefallsgruppenState.ts
+++ b/frontend/src/components/PriwaField/priwaBefallsgruppenState.ts
@@ -50,7 +50,7 @@ export const indexConfirmedPriwaFlightLabelsByTreeId = (
   groups.forEach((group) => {
     const labels = [...new Set(group.datasetIds)].flatMap((datasetId) => {
       const mosaic = mosaicById.get(datasetId);
-      return mosaic ? [mosaic.label] : [];
+      return mosaic?.flightType === "umfeldbefliegung" ? [mosaic.label] : [];
     });
     group.treeIds.forEach((treeId) => {
       labelsByTreeId[treeId] = labels;

--- a/frontend/src/components/PriwaField/priwaBefallsgruppenState.ts
+++ b/frontend/src/components/PriwaField/priwaBefallsgruppenState.ts
@@ -2,6 +2,7 @@ import type {
   IPriwaBefallsgruppe,
   IPriwaBefallsgruppeEditorDraft,
 } from "./types";
+import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 export const arePriwaBefallsgruppenReady = (
   isLoading: boolean,
@@ -38,3 +39,23 @@ export const indexPriwaBefallsgruppenByTreeId = (
       group.treeIds.map((treeId) => [treeId, group] as const),
     ),
   ) as Record<string, IPriwaBefallsgruppe>;
+
+export const indexConfirmedPriwaFlightLabelsByTreeId = (
+  groups: IPriwaBefallsgruppe[],
+  mosaics: IPriwaMosaic[],
+) => {
+  const mosaicById = new Map(mosaics.map((mosaic) => [mosaic.id, mosaic]));
+  const labelsByTreeId: Record<string, string[]> = {};
+
+  groups.forEach((group) => {
+    const labels = [...new Set(group.datasetIds)].flatMap((datasetId) => {
+      const mosaic = mosaicById.get(datasetId);
+      return mosaic ? [mosaic.label] : [];
+    });
+    group.treeIds.forEach((treeId) => {
+      labelsByTreeId[treeId] = labels;
+    });
+  });
+
+  return labelsByTreeId;
+};

--- a/frontend/src/components/PriwaField/priwaPointCsv.test.ts
+++ b/frontend/src/components/PriwaField/priwaPointCsv.test.ts
@@ -28,9 +28,13 @@ const basePoint: IPriwaPoint = {
 
 describe("priwaPointsToCsv", () => {
   it("exports PRIWA points with all field columns and escaped text", () => {
-    expect(priwaPointsToCsv([basePoint]).split("\n")).toEqual([
-      '"id","baumnr","fund","baumart","bohrmehl","bohrloch","harz","gruene_nadeln_am_boden","nadelverfaerbung","rindenverlust","nadelverlust","name","datum","latitude","longitude","coordinate_source","is_estimated_location","captured_at","kommentar","sync_status"',
-      '"point-1","B-17","ja","Fichte","ja","nein","nein","ja","fahlgrün/gelblich","bis25%","0%","Sigi Huber","2026-07-07","48.12345","8.54321","qr","false","2026-07-07T08:30:00.000Z","Nahe ""Rückeweg""","synced"',
+    expect(
+      priwaPointsToCsv([basePoint], {
+        "point-1": ['north "review", 1.zip', "south.zip"],
+      }).split("\n"),
+    ).toEqual([
+      '"id","baumnr","fund","baumart","bohrmehl","bohrloch","harz","gruene_nadeln_am_boden","nadelverfaerbung","rindenverlust","nadelverlust","name","datum","latitude","longitude","coordinate_source","is_estimated_location","captured_at","kommentar","sync_status","bestaetigte_befliegungsdateien"',
+      '"point-1","B-17","ja","Fichte","ja","nein","nein","ja","fahlgrün/gelblich","bis25%","0%","Sigi Huber","2026-07-07","48.12345","8.54321","qr","false","2026-07-07T08:30:00.000Z","Nahe ""Rückeweg""","synced","north ""review"", 1.zip | south.zip"',
     ]);
   });
 });

--- a/frontend/src/components/PriwaField/priwaPointCsv.ts
+++ b/frontend/src/components/PriwaField/priwaPointCsv.ts
@@ -21,6 +21,7 @@ const csvHeaders = [
   "captured_at",
   "kommentar",
   "sync_status",
+  "bestaetigte_befliegungsdateien",
 ];
 
 const escapeCsvCell = (value: string | number | boolean | null | undefined) => {
@@ -28,7 +29,10 @@ const escapeCsvCell = (value: string | number | boolean | null | undefined) => {
   return `"${normalized.replace(/"/g, '""')}"`;
 };
 
-export const priwaPointsToCsv = (points: IPriwaPoint[]) => {
+export const priwaPointsToCsv = (
+  points: IPriwaPoint[],
+  confirmedFlightLabelsByTreeId: Record<string, string[]>,
+) => {
   const rows = points.map((point) => [
     point.id,
     point.baumnr,
@@ -50,6 +54,7 @@ export const priwaPointsToCsv = (points: IPriwaPoint[]) => {
     point.capturedAt,
     point.kom,
     point.syncStatus ?? "synced",
+    (confirmedFlightLabelsByTreeId[point.id] ?? []).join(" | "),
   ]);
 
   return [
@@ -61,8 +66,9 @@ export const priwaPointsToCsv = (points: IPriwaPoint[]) => {
 export const downloadPriwaPointsCsv = (
   points: IPriwaPoint[],
   projectName: string,
+  confirmedFlightLabelsByTreeId: Record<string, string[]>,
 ) => {
-  const csv = priwaPointsToCsv(points);
+  const csv = priwaPointsToCsv(points, confirmedFlightLabelsByTreeId);
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");

--- a/frontend/src/components/PriwaField/priwaPointTableData.test.ts
+++ b/frontend/src/components/PriwaField/priwaPointTableData.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
+import {
+  comparePriwaTableText,
+  filterPriwaPointsBySearch,
+} from "./priwaPointTableData";
+
+const createPoint = (overrides: Partial<IPriwaPoint>): IPriwaPoint => ({
+  id: "tree-1",
+  baumnr: "4202",
+  fund: "ja",
+  baumart: "Fichte",
+  bm: "ja",
+  bohrloch: "ja",
+  harz: "nein",
+  grueneNadelnAmBoden: "nein",
+  nadel: "rot/braun",
+  rinde: "0%",
+  kv: "bis25%",
+  name: "Tobias Merz",
+  datum: "2026-06-17",
+  kom: "Am Forstweg",
+  capturedAt: "2026-06-17T10:00:00Z",
+  coordinateSource: "qr",
+  gps: "ja",
+  lat: 48.1,
+  lon: 8.2,
+  ...overrides,
+});
+
+const group: IPriwaBefallsgruppe = {
+  id: "group-1",
+  projectId: "priwa",
+  name: "Befallsgruppe Nord",
+  origin: "manual",
+  confidence: null,
+  suggestionReason: null,
+  algorithmVersion: null,
+  treeIds: ["tree-1"],
+  datasetIds: ["flight-1"],
+  createdAt: "2026-06-18T10:00:00Z",
+  updatedAt: "2026-06-18T10:00:00Z",
+};
+
+describe("filterPriwaPointsBySearch", () => {
+  const firstPoint = createPoint({});
+  const secondPoint = createPoint({
+    id: "tree-2",
+    baumnr: "56010",
+    name: "Fabian Bohnert",
+    kom: "Südhang",
+  });
+  const points = [firstPoint, secondPoint];
+  const groups = { "tree-1": group };
+  const flights = { "tree-1": ["DJI_20260618_Nord.zip"] };
+
+  it("matches tree data, confirmed groups, and flight filenames", () => {
+    expect(
+      filterPriwaPointsBySearch(points, "4202 Tobias", "all", groups, flights),
+    ).toEqual([firstPoint]);
+    expect(
+      filterPriwaPointsBySearch(
+        points,
+        "gruppe nord",
+        "group",
+        groups,
+        flights,
+      ),
+    ).toEqual([firstPoint]);
+    expect(
+      filterPriwaPointsBySearch(
+        points,
+        "DJI_20260618",
+        "flight",
+        groups,
+        flights,
+      ),
+    ).toEqual([firstPoint]);
+  });
+
+  it("restricts matches to the selected attribute", () => {
+    expect(
+      filterPriwaPointsBySearch(points, "Tobias", "name", groups, flights),
+    ).toEqual([firstPoint]);
+    expect(
+      filterPriwaPointsBySearch(points, "Fichte", "name", groups, flights),
+    ).toEqual([]);
+  });
+
+  it("returns all points for an empty search and none for an unknown term", () => {
+    expect(
+      filterPriwaPointsBySearch(points, "  ", "all", groups, flights),
+    ).toBe(points);
+    expect(
+      filterPriwaPointsBySearch(points, "unbekannt", "all", groups, flights),
+    ).toEqual([]);
+  });
+});
+
+describe("comparePriwaTableText", () => {
+  it("sorts tree numbers naturally and text without case sensitivity", () => {
+    expect(comparePriwaTableText("10", "2")).toBeGreaterThan(0);
+    expect(comparePriwaTableText("fichte", "Fichte")).toBe(0);
+  });
+});

--- a/frontend/src/components/PriwaField/priwaPointTableData.ts
+++ b/frontend/src/components/PriwaField/priwaPointTableData.ts
@@ -1,0 +1,83 @@
+import {
+  getPriwaFundLabel,
+  getPriwaPointSourceLabel,
+  getPriwaPointTitle,
+} from "./priwaPointQa";
+import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
+
+export type PriwaPointSearchField =
+  | "all"
+  | "baumnr"
+  | "datum"
+  | "group"
+  | "flight"
+  | "baumart"
+  | "fund"
+  | "name"
+  | "comment"
+  | "source";
+
+export const comparePriwaTableText = (
+  left: string | null | undefined,
+  right: string | null | undefined,
+) =>
+  (left ?? "").localeCompare(right ?? "", "de", {
+    numeric: true,
+    sensitivity: "base",
+  });
+
+export const filterPriwaPointsBySearch = (
+  points: IPriwaPoint[],
+  search: string,
+  field: PriwaPointSearchField,
+  groupByTreeId: Record<string, IPriwaBefallsgruppe>,
+  confirmedFlightLabelsByTreeId: Record<string, string[]>,
+) => {
+  const searchTerms = search
+    .trim()
+    .toLocaleLowerCase("de")
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (searchTerms.length === 0) return points;
+
+  return points.filter((point) => {
+    const valuesByField: Record<PriwaPointSearchField, unknown[]> = {
+      all: [
+        getPriwaPointTitle(point),
+        getPriwaPointSourceLabel(point),
+        getPriwaFundLabel(point),
+        point.datum,
+        point.baumart,
+        point.bm,
+        point.bohrloch,
+        point.harz,
+        point.grueneNadelnAmBoden,
+        point.nadel,
+        point.rinde,
+        point.kv,
+        point.name,
+        point.kom,
+        point.lat,
+        point.lon,
+        groupByTreeId[point.id]?.name,
+        ...(confirmedFlightLabelsByTreeId[point.id] ?? []),
+      ],
+      baumnr: [getPriwaPointTitle(point)],
+      datum: [point.datum],
+      group: [groupByTreeId[point.id]?.name],
+      flight: confirmedFlightLabelsByTreeId[point.id] ?? [],
+      baumart: [point.baumart],
+      fund: [getPriwaFundLabel(point)],
+      name: [point.name],
+      comment: [point.kom],
+      source: [getPriwaPointSourceLabel(point)],
+    };
+    const searchText = valuesByField[field]
+      .filter((value) => value !== null && value !== undefined)
+      .join(" ")
+      .toLocaleLowerCase("de");
+
+    return searchTerms.every((term) => searchText.includes(term));
+  });
+};

--- a/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.test.ts
@@ -7,6 +7,7 @@ import {
   findPriwaReviewItemByGroup,
   findPriwaReviewItemByMosaic,
   findPriwaReviewItemByPoint,
+  resolvePriwaReviewItemToActivate,
   resolvePriwaReviewSelection,
   resolvePriwaFilteredReviewSelection,
   shouldClosePriwaReviewTree,
@@ -80,6 +81,20 @@ describe("PRIWA review queue", () => {
     );
     expect(resolvePriwaReviewSelection(items, "removed")).toBe(openGroup);
     expect(resolvePriwaReviewSelection([], null)).toBeNull();
+  });
+
+  it("rehydrates a persisted selection exactly once", () => {
+    expect(
+      resolvePriwaReviewItemToActivate(items, completeGroup.key, null),
+    ).toBe(completeGroup);
+    expect(
+      resolvePriwaReviewItemToActivate(
+        items,
+        completeGroup.key,
+        completeGroup.key,
+      ),
+    ).toBeNull();
+    expect(resolvePriwaReviewItemToActivate(items, "removed", null)).toBeNull();
   });
 
   it("filters the queue without changing its source order", () => {

--- a/frontend/src/components/PriwaField/priwaReviewQueue.ts
+++ b/frontend/src/components/PriwaField/priwaReviewQueue.ts
@@ -51,6 +51,15 @@ export const resolvePriwaReviewSelection = (
   items[0] ??
   null;
 
+export const resolvePriwaReviewItemToActivate = (
+  items: IPriwaReviewItem[],
+  selectedKey: string | null,
+  activatedKey: string | null,
+) =>
+  selectedKey === activatedKey
+    ? null
+    : (items.find((item) => item.key === selectedKey) ?? null);
+
 export const findPriwaReviewItemByMosaic = (
   items: IPriwaReviewItem[],
   mosaicId: string,
@@ -79,5 +88,4 @@ export const shouldClosePriwaReviewTree = (
   selectedTreeId: string | null,
 ) =>
   !!selectedTreeId &&
-  (item.kind === "unassigned-upload" ||
-    !item.treeIds.includes(selectedTreeId));
+  (item.kind === "unassigned-upload" || !item.treeIds.includes(selectedTreeId));

--- a/frontend/src/components/PriwaField/usePriwaFlightReview.ts
+++ b/frontend/src/components/PriwaField/usePriwaFlightReview.ts
@@ -1,4 +1,4 @@
-import { message } from "antd";
+import { App } from "antd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { groupsForPriwaMosaicMatching } from "./priwaBefallsgruppenState";
@@ -14,6 +14,7 @@ interface UsePriwaFlightReviewOptions {
   isLoadingGroups: boolean;
   groupsErrorMessage: string | null;
   enableMosaics: boolean;
+  autoEnableMatchedMosaics: boolean;
   onSetFlightType: (input: {
     datasetId: string;
     flightType: PriwaFlightType;
@@ -31,9 +32,11 @@ export function usePriwaFlightReview({
   isLoadingGroups,
   groupsErrorMessage,
   enableMosaics,
+  autoEnableMatchedMosaics,
   onSetFlightType,
   onAssignFlightToGroup,
 }: UsePriwaFlightReviewOptions) {
+  const { message } = App.useApp();
   const [enabledMosaicIds, setEnabledMosaicIds] = useState<Set<string>>(
     new Set(),
   );
@@ -103,10 +106,11 @@ export function usePriwaFlightReview({
 
   const selectMatchedMosaicForPoint = useCallback(
     (point: IPriwaPoint) => {
+      if (!autoEnableMatchedMosaics) return;
       const mosaicId = matches.mosaicIdByPointId[point.id];
       if (mosaicId) showOnlyMosaics([mosaicId]);
     },
-    [matches.mosaicIdByPointId, showOnlyMosaics],
+    [autoEnableMatchedMosaics, matches.mosaicIdByPointId, showOnlyMosaics],
   );
 
   const setFlightType = useCallback(
@@ -128,7 +132,7 @@ export function usePriwaFlightReview({
         );
       }
     },
-    [onSetFlightType],
+    [message, onSetFlightType],
   );
 
   const assignMosaicToGroup = useCallback(
@@ -150,7 +154,7 @@ export function usePriwaFlightReview({
         );
       }
     },
-    [groups, onAssignFlightToGroup],
+    [groups, message, onAssignFlightToGroup],
   );
 
   return {

--- a/frontend/src/components/PriwaField/usePriwaReviewController.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewController.ts
@@ -1,4 +1,4 @@
-import { message } from "antd";
+import { App } from "antd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { arePriwaBefallsgruppenReady } from "./priwaBefallsgruppenState";
@@ -23,6 +23,7 @@ import { usePriwaFlightReview } from "./usePriwaFlightReview";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
 
 interface UsePriwaReviewControllerOptions {
+  projectId: string;
   points: IPriwaPoint[];
   mosaics: IPriwaMosaic[];
   groups: IPriwaBefallsgruppe[];
@@ -45,7 +46,19 @@ interface UsePriwaReviewControllerOptions {
   zoomToMosaicFootprint: (mosaic: IPriwaMosaic) => void;
 }
 
+const reviewSelectionStorageKey = (projectId: string) =>
+  `deadtrees-priwa-field:review-selection:${projectId}`;
+
+const readPersistedReviewSelection = (projectId: string) => {
+  try {
+    return window.sessionStorage.getItem(reviewSelectionStorageKey(projectId));
+  } catch {
+    return null;
+  }
+};
+
 export function usePriwaReviewController({
+  projectId,
   points,
   mosaics,
   groups,
@@ -61,8 +74,9 @@ export function usePriwaReviewController({
   zoomToTrees,
   zoomToMosaicFootprint,
 }: UsePriwaReviewControllerOptions) {
+  const { message } = App.useApp();
   const [selectedReviewKey, setSelectedReviewKey] = useState<string | null>(
-    null,
+    () => readPersistedReviewSelection(projectId),
   );
   const [groupEditorDraft, setGroupEditorDraft] =
     useState<IPriwaBefallsgruppeEditorDraft | null>(null);
@@ -72,7 +86,8 @@ export function usePriwaReviewController({
     groups,
     isLoadingGroups,
     groupsErrorMessage,
-    enableMosaics: !isMobile,
+    enableMosaics: true,
+    autoEnableMatchedMosaics: !isMobile,
     onSetFlightType,
     onAssignFlightToGroup,
   });
@@ -105,12 +120,33 @@ export function usePriwaReviewController({
       : null;
   const isWorkspaceLoading = isLoadingPoints || isLoadingGroups || isCogLoading;
 
+  const persistReviewSelection = useCallback(
+    (key: string | null) => {
+      setSelectedReviewKey(key);
+      try {
+        if (key) {
+          window.sessionStorage.setItem(
+            reviewSelectionStorageKey(projectId),
+            key,
+          );
+        } else {
+          window.sessionStorage.removeItem(
+            reviewSelectionStorageKey(projectId),
+          );
+        }
+      } catch {
+        // Selection persistence is a convenience; private browsing may disable it.
+      }
+    },
+    [projectId],
+  );
+
   const activateReviewItem = useCallback(
     (item: IPriwaReviewItem) => {
-      setSelectedReviewKey(item.key);
+      persistReviewSelection(item.key);
       showOnlyMosaics(reviewItemDatasetIds(item));
     },
-    [showOnlyMosaics],
+    [persistReviewSelection, showOnlyMosaics],
   );
 
   const selectReviewItem = useCallback(
@@ -139,11 +175,12 @@ export function usePriwaReviewController({
       selectedReviewKey,
     );
     if (nextItem) selectReviewItem(nextItem);
-    else setSelectedReviewKey(null);
+    else persistReviewSelection(null);
   }, [
     isMobile,
     isWorkspaceLoading,
     reviewItems,
+    persistReviewSelection,
     selectReviewItem,
     selectedReviewKey,
   ]);
@@ -178,8 +215,15 @@ export function usePriwaReviewController({
             "Befallsgruppen können erst nach erfolgreichem Laden bearbeitet werden.",
           );
         }
-        await onSaveGroup(input);
-        message.success("Befallsgruppe gespeichert");
+        const savedGroupId = await onSaveGroup(input);
+        if (typeof savedGroupId === "string") {
+          persistReviewSelection(`group:${savedGroupId}`);
+        }
+        message.success(
+          input.datasetIds.length > 0
+            ? "Befallsgruppe und Befliegung gespeichert"
+            : "Befallsgruppe gespeichert · Befliegung noch offen",
+        );
         setGroupEditorDraft(null);
       } catch (error) {
         message.error(
@@ -190,7 +234,7 @@ export function usePriwaReviewController({
         throw error;
       }
     },
-    [isGroupStateReady, onSaveGroup],
+    [isGroupStateReady, message, onSaveGroup, persistReviewSelection],
   );
 
   const deleteGroup = useCallback(
@@ -213,7 +257,7 @@ export function usePriwaReviewController({
         throw error;
       }
     },
-    [isGroupStateReady, onDeleteGroup],
+    [isGroupStateReady, message, onDeleteGroup],
   );
 
   const assignFlight = useCallback(
@@ -227,7 +271,7 @@ export function usePriwaReviewController({
       const mosaic = mosaics.find((candidate) => candidate.id === datasetId);
       if (mosaic) await assignMosaicToGroup(mosaic, groupId);
     },
-    [assignMosaicToGroup, isGroupStateReady, mosaics],
+    [assignMosaicToGroup, isGroupStateReady, message, mosaics],
   );
 
   const createGroupForFlight = useCallback(

--- a/frontend/src/components/PriwaField/usePriwaReviewController.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewController.ts
@@ -1,5 +1,5 @@
 import { App } from "antd";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { arePriwaBefallsgruppenReady } from "./priwaBefallsgruppenState";
 import {
@@ -11,6 +11,7 @@ import {
   findPriwaReviewItemByGroup,
   findPriwaReviewItemByMosaic,
   findPriwaReviewItemByPoint,
+  resolvePriwaReviewItemToActivate,
   resolvePriwaReviewSelection,
 } from "./priwaReviewQueue";
 import type {
@@ -78,6 +79,7 @@ export function usePriwaReviewController({
   const [selectedReviewKey, setSelectedReviewKey] = useState<string | null>(
     () => readPersistedReviewSelection(projectId),
   );
+  const activatedReviewKeyRef = useRef<string | null>(null);
   const [groupEditorDraft, setGroupEditorDraft] =
     useState<IPriwaBefallsgruppeEditorDraft | null>(null);
   const flightReview = usePriwaFlightReview({
@@ -143,6 +145,7 @@ export function usePriwaReviewController({
 
   const activateReviewItem = useCallback(
     (item: IPriwaReviewItem) => {
+      activatedReviewKeyRef.current = item.key;
       persistReviewSelection(item.key);
       showOnlyMosaics(reviewItemDatasetIds(item));
     },
@@ -163,10 +166,17 @@ export function usePriwaReviewController({
 
   useEffect(() => {
     if (isMobile || isWorkspaceLoading) return;
-    if (
-      selectedReviewKey &&
-      reviewItems.some((item) => item.key === selectedReviewKey)
-    ) {
+
+    const selectedItemToActivate = resolvePriwaReviewItemToActivate(
+      reviewItems,
+      selectedReviewKey,
+      activatedReviewKeyRef.current,
+    );
+    if (selectedItemToActivate) {
+      selectReviewItem(selectedItemToActivate);
+      return;
+    }
+    if (reviewItems.some((item) => item.key === selectedReviewKey)) {
       return;
     }
 
@@ -175,7 +185,10 @@ export function usePriwaReviewController({
       selectedReviewKey,
     );
     if (nextItem) selectReviewItem(nextItem);
-    else persistReviewSelection(null);
+    else {
+      activatedReviewKeyRef.current = null;
+      persistReviewSelection(null);
+    }
   }, [
     isMobile,
     isWorkspaceLoading,

--- a/frontend/src/components/PriwaField/usePriwaReviewMapLayers.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewMapLayers.test.ts
@@ -81,5 +81,15 @@ describe("PRIWA review map-layer synchronization", () => {
     expect(features).toHaveLength(1);
     expect(features[0].get("mosaicId")).toBe(mosaic.id);
     expect(features[0].getStyle()).toHaveLength(2);
+
+    syncPriwaMosaicFootprintLayer(
+      source,
+      [mosaic],
+      [mosaic],
+      new Set([mosaic.id]),
+      mosaic.id,
+      false,
+    );
+    expect(source.getFeatures()).toEqual([]);
   });
 });

--- a/frontend/src/components/PriwaField/usePriwaReviewMapLayers.test.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewMapLayers.test.ts
@@ -7,7 +7,6 @@ import {
   syncPriwaBefallsgruppeLayer,
   syncPriwaMosaicFootprintLayer,
 } from "./usePriwaReviewMapLayers";
-import type { IPriwaMatchedMosaic } from "./usePriwaMosaicMatches";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
 
 const point: IPriwaPoint = {
@@ -56,30 +55,23 @@ const mosaic: IPriwaMosaic = {
   additionalInformation: null,
   flightType: "umfeldbefliegung",
 };
-const match: IPriwaMatchedMosaic = {
-  mosaic,
-  points: [{ point, daysApart: 2, source: "confirmed" }],
-  minDaysApart: 2,
-  maxDaysApart: 2,
-};
-
 describe("PRIWA review map-layer synchronization", () => {
   it("replaces stale Befallsgruppe features with the current group state", () => {
     const source = createPriwaBefallsgruppeLayer().getSource()!;
     syncPriwaBefallsgruppeLayer(source, [group], [point]);
-    expect(source.getFeatures().map((feature) => feature.get("groupId"))).toEqual(
-      ["group-1"],
-    );
+    expect(
+      source.getFeatures().map((feature) => feature.get("groupId")),
+    ).toEqual(["group-1"]);
 
     syncPriwaBefallsgruppeLayer(source, [], [point]);
     expect(source.getFeatures()).toEqual([]);
   });
 
-  it("keeps matched footprints and applies selected and visibility state", () => {
+  it("keeps requested footprints and applies selected and visibility state", () => {
     const source = createPriwaMosaicFootprintLayer().getSource()!;
     syncPriwaMosaicFootprintLayer(
       source,
-      [match],
+      [mosaic],
       [mosaic],
       new Set([mosaic.id]),
       mosaic.id,

--- a/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
@@ -36,6 +36,7 @@ interface UsePriwaReviewMapLayersOptions {
   reviewMosaics: IPriwaMosaic[];
   enabledMosaics: IPriwaMosaic[];
   enabledMosaicIds: Set<string>;
+  showMosaicFootprints: boolean;
   selectedMosaicId: string | null;
   selectedGroupId: string | null;
 }
@@ -63,8 +64,10 @@ export const syncPriwaMosaicFootprintLayer = (
   reviewMosaics: IPriwaMosaic[],
   enabledMosaicIds: Set<string>,
   selectedMosaicId: string | null,
+  showMosaicFootprints = true,
 ) => {
   source.clear();
+  if (!showMosaicFootprints) return;
   const footprintIds = new Set(footprintMosaics.map((mosaic) => mosaic.id));
   reviewMosaics
     .filter(
@@ -93,6 +96,7 @@ export function usePriwaReviewMapLayers({
   reviewMosaics,
   enabledMosaics,
   enabledMosaicIds,
+  showMosaicFootprints,
   selectedMosaicId,
   selectedGroupId,
 }: UsePriwaReviewMapLayersOptions) {
@@ -116,6 +120,7 @@ export function usePriwaReviewMapLayers({
         reviewMosaics,
         enabledMosaicIds,
         selectedMosaicId,
+        showMosaicFootprints,
       );
     }
   }, [
@@ -124,6 +129,7 @@ export function usePriwaReviewMapLayers({
     mosaicFootprintLayerRef,
     reviewMosaics,
     selectedMosaicId,
+    showMosaicFootprints,
   ]);
 
   useEffect(() => {

--- a/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
+++ b/frontend/src/components/PriwaField/usePriwaReviewMapLayers.ts
@@ -14,7 +14,6 @@ import {
 } from "./createPriwaMosaicFootprintLayer";
 import type { IPriwaBefallsgruppe, IPriwaPoint } from "./types";
 import type { IPriwaMosaic } from "./usePriwaMosaics";
-import type { IPriwaMatchedMosaic } from "./usePriwaMosaicMatches";
 
 type PriwaBefallsgruppeLayer = ReturnType<typeof createPriwaBefallsgruppeLayer>;
 type PriwaMosaicFootprintLayer = ReturnType<
@@ -33,7 +32,7 @@ interface UsePriwaReviewMapLayersOptions {
   mosaicFootprintLayerRef: MutableRefObject<PriwaMosaicFootprintLayer | null>;
   groups: IPriwaBefallsgruppe[];
   points: IPriwaPoint[];
-  matchedMosaics: IPriwaMatchedMosaic[];
+  footprintMosaics: IPriwaMosaic[];
   reviewMosaics: IPriwaMosaic[];
   enabledMosaics: IPriwaMosaic[];
   enabledMosaicIds: Set<string>;
@@ -60,17 +59,17 @@ export const syncPriwaBefallsgruppeLayer = (
 
 export const syncPriwaMosaicFootprintLayer = (
   source: PriwaMosaicFootprintSource,
-  matchedMosaics: IPriwaMatchedMosaic[],
+  footprintMosaics: IPriwaMosaic[],
   reviewMosaics: IPriwaMosaic[],
   enabledMosaicIds: Set<string>,
   selectedMosaicId: string | null,
 ) => {
   source.clear();
-  const matchedIds = new Set(matchedMosaics.map(({ mosaic }) => mosaic.id));
+  const footprintIds = new Set(footprintMosaics.map((mosaic) => mosaic.id));
   reviewMosaics
     .filter(
       (mosaic) =>
-        matchedIds.has(mosaic.id) ||
+        footprintIds.has(mosaic.id) ||
         enabledMosaicIds.has(mosaic.id) ||
         mosaic.id === selectedMosaicId,
     )
@@ -90,7 +89,7 @@ export function usePriwaReviewMapLayers({
   mosaicFootprintLayerRef,
   groups,
   points,
-  matchedMosaics,
+  footprintMosaics,
   reviewMosaics,
   enabledMosaics,
   enabledMosaicIds,
@@ -113,7 +112,7 @@ export function usePriwaReviewMapLayers({
     if (source) {
       syncPriwaMosaicFootprintLayer(
         source,
-        matchedMosaics,
+        footprintMosaics,
         reviewMosaics,
         enabledMosaicIds,
         selectedMosaicId,
@@ -121,7 +120,7 @@ export function usePriwaReviewMapLayers({
     }
   }, [
     enabledMosaicIds,
-    matchedMosaics,
+    footprintMosaics,
     mosaicFootprintLayerRef,
     reviewMosaics,
     selectedMosaicId,
@@ -131,9 +130,7 @@ export function usePriwaReviewMapLayers({
     const map = mapRef.current;
     if (!map) return;
 
-    const enabledMosaicIds = new Set(
-      enabledMosaics.map((mosaic) => mosaic.id),
-    );
+    const enabledMosaicIds = new Set(enabledMosaics.map((mosaic) => mosaic.id));
     cogLayersRef.current.forEach(({ layer }, mosaicId) => {
       if (enabledMosaicIds.has(mosaicId)) return;
       map.removeLayer(layer);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,18 @@
 
 /* Theme variables are injected at runtime from src/theme/palette.ts */
 
+.dt-full-height-layout {
+  height: 100dvh;
+}
+
+/* WebKit can exclude the bottom safe area from dvh in installed web apps.
+ * Legacy vh includes that inset, keeping full-screen map routes edge-to-edge. */
+@media (display-mode: standalone) {
+  .dt-full-height-layout {
+    height: 100vh;
+  }
+}
+
 /* Shared OpenLayers controls for public maps */
 .dt-map-attribution-control {
   position: absolute;


### PR DESCRIPTION
## Briefing

This update consolidates the latest PRIWA feedback for field teams and desktop reviewers. It exposes confirmed flight coverage on mobile as lightweight metadata and boundaries only, improves tree review and export tools, and fixes review-state feedback that made successful saves appear lost after refresh.

## What changed

- show only accepted `umfeldbefliegung` records in the mobile flight sheet and map boundaries
- add a mobile master switch for confirmed flight boundaries and never load flight COGs on mobile
- open the focused flight sheet when a confirmed boundary is tapped
- add attribute-aware tree search, natural sorting, and confirmed flight filenames to the table and CSV
- raise PRIWA map zoom support and preserve the iPhone standalone full-height map
- preserve and fully rehydrate the selected review group across refreshes
- use Ant Design app-context messages to remove the static message warning

## User impact

Drone teams can orient themselves using accepted flight boundaries without spending bandwidth on orthophotos. Reviewers can inspect, filter, sort, and export confirmed group and flight context more directly, and saved review work no longer appears to vanish after refresh.

## Validation

- `npm --prefix frontend test -- --run` — 51 files, 280 tests passed
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- prod-connected browser smoke: saved group remained selected after refresh; persisted records were visible without another production write
- production read-only DB verification confirmed group persistence and current flight classifications

## Risk / limitations

Mobile shows confirmed flight metadata and boundaries only; flight COG imagery remains desktop-only. The existing Vite bundle-size warning remains unchanged.