### PR TITLE
fix(priwa): keep late flight suggestions selected

### DIFF
--- a/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
+++ b/frontend/src/components/PriwaField/PriwaReviewGroupDetails.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import type { IPriwaBefallsgruppeSaveInput, IPriwaPoint } from "./types";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
 import {
-  reconcilePriwaDatasetAssignments,
+  resolvePriwaSuggestedAssignments,
   setPriwaDatasetAssignment,
   type IPriwaGroupReviewItem,
 } from "./priwaReviewWorkspace";
@@ -68,20 +68,25 @@ export default function PriwaReviewGroupDetails({
     const mosaic = mosaicsById.get(id);
     return mosaic ? [mosaic] : [];
   });
-  const [suggestedAssignmentIds, setSuggestedAssignmentIds] = useState(
+  const [suggestedAssignmentOverrideIds, setSuggestedAssignmentOverrideIds] =
+    useState<string[] | null>(null);
+  const eligibleSuggestedAssignmentIds = resolvePriwaSuggestedAssignments(
+    suggestedAssignmentOverrideIds,
     item.draft.datasetIds,
-  );
-  const eligibleSuggestedAssignmentIds = reconcilePriwaDatasetAssignments(
-    suggestedAssignmentIds,
     item.suggestedDatasetIds,
   );
 
   const setAssignment = (mosaic: IPriwaMosaic, isAssigned: boolean) => {
     if (item.kind === "suggested-group") {
-      setSuggestedAssignmentIds((currentIds) =>
-        reconcilePriwaDatasetAssignments(
-          setPriwaDatasetAssignment(currentIds, mosaic.id, isAssigned),
-          item.suggestedDatasetIds,
+      setSuggestedAssignmentOverrideIds((currentOverrideIds) =>
+        setPriwaDatasetAssignment(
+          resolvePriwaSuggestedAssignments(
+            currentOverrideIds,
+            item.draft.datasetIds,
+            item.suggestedDatasetIds,
+          ),
+          mosaic.id,
+          isAssigned,
         ),
       );
       return;

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.test.ts
@@ -5,6 +5,7 @@ import type { IPriwaMosaic } from "./usePriwaMosaics";
 import {
   buildPriwaReviewWorkspace,
   reconcilePriwaDatasetAssignments,
+  resolvePriwaSuggestedAssignments,
   reviewItemDatasetIds,
   setPriwaDatasetAssignment,
 } from "./priwaReviewWorkspace";
@@ -70,6 +71,25 @@ describe("reconcilePriwaDatasetAssignments", () => {
         ["flight-1", "flight-2"],
       ),
     ).toEqual(["flight-1"]);
+  });
+});
+
+describe("resolvePriwaSuggestedAssignments", () => {
+  it("selects a flight that arrives before the reviewer changes the draft", () => {
+    expect(resolvePriwaSuggestedAssignments(null, [], [])).toEqual([]);
+    expect(
+      resolvePriwaSuggestedAssignments(
+        null,
+        ["flight-1"],
+        ["flight-1"],
+      ),
+    ).toEqual(["flight-1"]);
+  });
+
+  it("preserves an explicit reviewer deselection across later rerenders", () => {
+    expect(
+      resolvePriwaSuggestedAssignments([], ["flight-1"], ["flight-1"]),
+    ).toEqual([]);
   });
 });
 

--- a/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
+++ b/frontend/src/components/PriwaField/priwaReviewWorkspace.ts
@@ -233,3 +233,13 @@ export const reconcilePriwaDatasetAssignments = (
   const candidateIds = new Set(candidateDatasetIds);
   return selectedDatasetIds.filter((datasetId) => candidateIds.has(datasetId));
 };
+
+export const resolvePriwaSuggestedAssignments = (
+  reviewerOverrideIds: string[] | null,
+  draftDatasetIds: string[],
+  candidateDatasetIds: string[],
+) =>
+  reconcilePriwaDatasetAssignments(
+    reviewerOverrideIds ?? draftDatasetIds,
+    candidateDatasetIds,
+  );


### PR DESCRIPTION
## Briefing

This fixes the PRIWA review race that could save an accepted Befallsgruppe without its late-loading flight assignment. Reviewers can now use **Vorschlag übernehmen** confidently even when flight candidates finish loading after the group panel first renders.

## Why

The panel previously copied the initial flight IDs into local state. When a flight candidate arrived later, it appeared in the UI but remained unchecked, so accepting the suggestion persisted the group with no linked flight and kept it under **Offen** instead of **Fertig**.

## What changed

- treat the absence of a reviewer override separately from an explicit checkbox selection
- allow late-arriving default flight assignments to flow through until the reviewer changes a checkbox
- preserve explicit reviewer selections and deselections across later rerenders
- add regression coverage for both the loading race and reviewer-input preservation

## Validation

- `npm --prefix frontend test -- --run` — 51 files, 283 tests passed
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `scripts/lint-ast-grep.sh`
- `git diff --check`

## Risk and limitations

The change is limited to suggested-group flight-selection state. Existing groups already saved without a linked flight remain open and are not modified by this PR. No production data was changed during implementation or validation.