### PR TITLE
fix(processor): filter non-nadir ODM images

### DIFF
--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -63,6 +63,7 @@ services:
       DEV_MODE: "false"
       ODM_AUTO_BOUNDARY: "true"
       ODM_SKY_REMOVAL: "true"
+      ODM_MAX_NADIR_DEVIATION_DEGREES: "10"
       # Service role key for accessing auth.users (user email lookup)
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
       # Linear integration for processing failure notifications

--- a/processor/src/process_odm.py
+++ b/processor/src/process_odm.py
@@ -31,10 +31,44 @@ from processor.src.utils.debug_artifacts import (
 	build_container_forensics,
 	write_debug_bundle,
 )
-from shared.exif_utils import extract_comprehensive_exif
+from shared.exif_utils import extract_camera_nadir_deviation_degrees, extract_comprehensive_exif
 
 # RTK file extensions as specified in requirements
 RTK_EXTENSIONS = {'.RTK', '.MRK', '.RTL', '.RTB', '.RPOS', '.RTS', '.IMU'}
+ORIENTATION_THRESHOLD_TOLERANCE_DEGREES = 0.1
+
+
+def _filter_images_by_camera_orientation(
+	image_files: list[Path], max_nadir_deviation_degrees: float
+) -> tuple[list[Path], list[tuple[Path, float, str]], list[Path]]:
+	"""Keep nadir images and images whose camera pitch metadata is unavailable.
+
+	Camera metadata conventions differ by manufacturer. The shared orientation
+	reader normalizes supported schemas to degrees away from nadir. Unknown
+	metadata remains eligible so unsupported and non-drone imagery is not
+	automatically rejected.
+	"""
+	if not 0 <= max_nadir_deviation_degrees <= 90:
+		raise ValueError('Maximum nadir deviation must be between 0 and 90 degrees')
+
+	kept: list[Path] = []
+	excluded: list[tuple[Path, float, str]] = []
+	unknown: list[Path] = []
+
+	for image_file in image_files:
+		orientation = extract_camera_nadir_deviation_degrees(image_file)
+		if orientation is None:
+			kept.append(image_file)
+			unknown.append(image_file)
+			continue
+
+		deviation_from_nadir, source_tag, _ = orientation
+		if deviation_from_nadir <= max_nadir_deviation_degrees + ORIENTATION_THRESHOLD_TOLERANCE_DEGREES:
+			kept.append(image_file)
+		else:
+			excluded.append((image_file, deviation_from_nadir, source_tag))
+
+	return kept, excluded, unknown
 
 
 def _build_odm_command() -> tuple[list[str], str, str]:
@@ -619,7 +653,43 @@ def _run_odm_container(images_dir: Path, output_dir: Path, token: str, dataset_i
 			)
 
 	logger.info(
-		f'Preparing to copy {len(valid_image_files)} valid images to shared volume (filtered out {len(image_files) - len(valid_image_files)} potentially corrupt images)',
+		f'Image-size validation kept {len(valid_image_files)} images and filtered out '
+		f'{len(image_files) - len(valid_image_files)} potentially corrupt images',
+		LogContext(category=LogCategory.ODM, token=token, dataset_id=dataset_id),
+	)
+
+	valid_image_files, orientation_excluded, orientation_unknown = _filter_images_by_camera_orientation(
+		valid_image_files,
+		max_nadir_deviation_degrees=settings.ODM_MAX_NADIR_DEVIATION_DEGREES,
+	)
+
+	logger.info(
+		f'Camera-orientation filter kept {len(valid_image_files)} images, '
+		f'excluded {len(orientation_excluded)} images outside '
+		f'nadir +/- {settings.ODM_MAX_NADIR_DEVIATION_DEGREES:g} degrees '
+		f'(with {ORIENTATION_THRESHOLD_TOLERANCE_DEGREES:g} degree metadata tolerance), and retained '
+		f'{len(orientation_unknown)} images without supported camera-orientation metadata',
+		LogContext(category=LogCategory.ODM, token=token, dataset_id=dataset_id),
+	)
+
+	if orientation_excluded:
+		excluded_sample = ', '.join(
+			f'{path.name} ({deviation:g} deg off nadir via {source_tag})'
+			for path, deviation, source_tag in orientation_excluded[:10]
+		)
+		logger.warning(
+			f'Excluded non-nadir ODM images: {excluded_sample}'
+			f'{" ..." if len(orientation_excluded) > 10 else ""}',
+			LogContext(category=LogCategory.ODM, token=token, dataset_id=dataset_id),
+		)
+
+	if not valid_image_files:
+		raise Exception(
+			f'No images remain within nadir +/- {settings.ODM_MAX_NADIR_DEVIATION_DEGREES:g} degrees'
+		)
+
+	logger.info(
+		f'Preparing to copy {len(valid_image_files)} orientation-eligible images to the shared ODM volume',
 		LogContext(category=LogCategory.ODM, token=token, dataset_id=dataset_id),
 	)
 

--- a/processor/tests/test_process_odm.py
+++ b/processor/tests/test_process_odm.py
@@ -22,7 +22,9 @@ from processor.src.process_odm import (
 	_analyze_extracted_files,
 	_extract_exif_from_images,
 	_build_odm_command,
+	_filter_images_by_camera_orientation,
 )
+from shared.exif_utils import extract_camera_nadir_deviation_degrees
 from processor.src.utils.ssh import push_file_to_storage_server, check_file_exists_on_storage
 
 
@@ -152,6 +154,96 @@ def test_build_odm_command_skips_auto_boundary_when_disabled(monkeypatch):
 	command, _, _ = _build_odm_command()
 
 	assert '--auto-boundary' not in command
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+	('xmp', 'expected_orientation'),
+	[
+		(
+			b'<rdf:Description drone-dji:GimbalPitchDegree="-90.00" />',
+			(0.0, 'GimbalPitchDegree', -90.0),
+		),
+		(
+			b'<drone-parrot:CameraPitchDegree>-82.0</drone-parrot:CameraPitchDegree>',
+			(8.0, 'CameraPitchDegree', -82.0),
+		),
+		(b'<rdf:Description Camera:Pitch="+7.5" />', (7.5, 'Camera:Pitch', 7.5)),
+		(
+			b'<skydio:CameraOrientationNED>0.2, -84.0, 146.5</skydio:CameraOrientationNED>',
+			(6.0, 'CameraOrientationNED', -84.0),
+		),
+	],
+)
+def test_extract_camera_nadir_deviation_supports_multiple_schemas(tmp_path, xmp, expected_orientation):
+	"""Vendor and cross-vendor XMP conventions should normalize to off-nadir degrees."""
+	image_path = tmp_path / 'drone.jpg'
+	image_path.write_bytes(b'\xff\xd8' + xmp + b'\xff\xd9')
+
+	assert extract_camera_nadir_deviation_degrees(image_path) == expected_orientation
+
+
+@pytest.mark.unit
+def test_extract_camera_nadir_deviation_ignores_vehicle_pitch(tmp_path):
+	"""Aircraft attitude must not be mistaken for the camera viewing direction."""
+	image_path = tmp_path / 'drone.jpg'
+	image_path.write_bytes(b'<rdf:Description drone-dji:FlightPitchDegree="0.5" />')
+
+	assert extract_camera_nadir_deviation_degrees(image_path) is None
+
+
+@pytest.mark.unit
+def test_extract_camera_nadir_deviation_scans_late_dng_xmp(tmp_path):
+	"""Orientation XMP should be found even when a TIFF/DNG container stores it late."""
+	image_path = tmp_path / 'drone.dng'
+	image_path.write_bytes(
+		b'II*\x00'
+		+ b'\x00' * (1024 * 1024)
+		+ b'<drone-parrot:CameraPitchDegree>-85.0</drone-parrot:CameraPitchDegree>'
+	)
+
+	assert extract_camera_nadir_deviation_degrees(image_path) == (5.0, 'CameraPitchDegree', -85.0)
+
+
+@pytest.mark.unit
+def test_filter_images_by_camera_orientation_keeps_only_nadir_candidates(tmp_path):
+	"""The ODM input set should reject oblique images but retain unknown metadata."""
+	image_xmp = {
+		'nadir-negative.jpg': ('GimbalPitchDegree', '-90.0'),
+		'nadir-positive.jpg': ('CameraPitchDegree', '+90.0'),
+		'boundary.jpg': ('Camera:Pitch', '+10.0'),
+		'rounded-boundary.jpg': ('GimbalPitchDegree', '-79.97'),
+		'oblique.jpg': ('Camera:Pitch', '+45.0'),
+	}
+	paths = []
+	for filename, (tag, pitch) in image_xmp.items():
+		path = tmp_path / filename
+		path.write_bytes(
+			b'\xff\xd8<rdf:Description '
+			+ tag.encode()
+			+ b'="'
+			+ pitch.encode()
+			+ b'" />\xff\xd9'
+		)
+		paths.append(path)
+
+	unknown_path = tmp_path / 'unknown.jpg'
+	unknown_path.write_bytes(b'\xff\xd8no pitch metadata\xff\xd9')
+	paths.append(unknown_path)
+
+	kept, excluded, unknown = _filter_images_by_camera_orientation(paths, max_nadir_deviation_degrees=10.0)
+
+	assert {path.name for path in kept} == {
+		'nadir-negative.jpg',
+		'nadir-positive.jpg',
+		'boundary.jpg',
+		'rounded-boundary.jpg',
+		'unknown.jpg',
+	}
+	assert [(path.name, deviation, source) for path, deviation, source in excluded] == [
+		('oblique.jpg', 45.0, 'Camera:Pitch')
+	]
+	assert unknown == [unknown_path]
 
 
 @pytest.fixture

--- a/shared/exif_utils.py
+++ b/shared/exif_utils.py
@@ -8,6 +8,7 @@ with particular focus on acquisition date and comprehensive metadata extraction.
 from pathlib import Path
 from typing import Dict, Any, Optional
 from datetime import datetime
+import re
 
 try:
 	from PIL import Image
@@ -21,6 +22,82 @@ from shared.logging import LogCategory, LogContext, UnifiedLogger, SupabaseHandl
 # Create logger instance
 logger = UnifiedLogger(__name__)
 logger.add_supabase_handler(SupabaseHandler())
+
+
+_METADATA_SCAN_CHUNK_BYTES = 1024 * 1024
+_METADATA_SCAN_OVERLAP_BYTES = 4096
+_ORIENTATION_XMP_PATTERN = re.compile(
+	r'(?:\b(?P<attr_name>(?:(?:[\w.-]+:)?(?:GimbalPitchDegree|CameraPitchDegree|CameraOrientationNED)|Camera:Pitch))'
+	r'\s*=\s*["\']\s*(?P<attr_value>[^"\']+))|'
+	r'(?:<(?P<element_name>(?:(?:[\w.-]+:)?(?:GimbalPitchDegree|CameraPitchDegree|CameraOrientationNED)|Camera:Pitch))'
+	r'\b[^>]*>\s*(?P<element_value>[^<]+))'.encode(),
+	re.IGNORECASE,
+)
+_ORIENTATION_NUMBER_PATTERN = re.compile(rb'[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?')
+
+
+def _normalise_camera_orientation(name: bytes, value: bytes) -> Optional[tuple[float, str, float]]:
+	"""Convert a supported metadata convention to off-nadir degrees."""
+	qualified_name = name.decode('ascii', errors='ignore')
+	local_name = qualified_name.rsplit(':', 1)[-1]
+	numbers = _ORIENTATION_NUMBER_PATTERN.findall(value)
+
+	if local_name.lower() == 'cameraorientationned':
+		# Skydio documents this field as roll, pitch, yaw in NED coordinates.
+		if len(numbers) < 3:
+			return None
+		raw_pitch = float(numbers[1])
+		return abs(abs(raw_pitch) - 90.0), 'CameraOrientationNED', raw_pitch
+
+	if not numbers:
+		return None
+
+	raw_pitch = float(numbers[0])
+	if qualified_name.lower() == 'camera:pitch':
+		# The cross-vendor Pix4D camera convention defines 0 degrees as nadir.
+		return abs(raw_pitch), 'Camera:Pitch', raw_pitch
+
+	if local_name.lower() in {'gimbalpitchdegree', 'camerapitchdegree'}:
+		# DJI, Autel and Parrot NED-style fields define nadir as +/- 90 degrees.
+		return abs(abs(raw_pitch) - 90.0), local_name, raw_pitch
+
+	return None
+
+
+def extract_camera_nadir_deviation_degrees(image_path: Path) -> Optional[tuple[float, str, float]]:
+	"""Read supported XMP camera orientations and normalize them to off-nadir degrees.
+
+	The parser is container-independent and scans the file in bounded chunks, so
+	it works with XMP embedded in formats such as JPEG, TIFF and DNG. Ambiguous
+	aircraft-body pitch fields are intentionally ignored.
+
+	Returns:
+		``(off_nadir_degrees, source_tag, raw_pitch)`` or ``None`` when no
+		supported camera-orientation metadata is present.
+	"""
+	fallback_orientation = None
+	overlap = b''
+
+	try:
+		with image_path.open('rb') as image_file:
+			while chunk := image_file.read(_METADATA_SCAN_CHUNK_BYTES):
+				metadata_window = overlap + chunk
+				for match in _ORIENTATION_XMP_PATTERN.finditer(metadata_window):
+					name = match.group('attr_name') or match.group('element_name')
+					value = match.group('attr_value') or match.group('element_value')
+					orientation = _normalise_camera_orientation(name, value)
+					if orientation is None:
+						continue
+
+					if orientation[1] != 'Camera:Pitch':
+						return orientation
+					fallback_orientation = orientation
+
+				overlap = metadata_window[-_METADATA_SCAN_OVERLAP_BYTES:]
+	except (OSError, ValueError):
+		return None
+
+	return fallback_orientation
 
 
 def _sanitize_text_for_db(text: str) -> str:

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -149,6 +149,7 @@ class Settings(BaseSettings):
 	ODM_AUTO_BOUNDARY: bool = False
 	ODM_SKY_REMOVAL: bool = False
 	ODM_BG_REMOVAL: bool = False
+	ODM_MAX_NADIR_DEVIATION_DEGREES: float = 10.0
 
 	# Linear integration for processing failure notifications
 	LINEAR_ENABLED: bool = False


### PR DESCRIPTION
## Briefing

ODM currently accepts every uploaded RGB image, so manually captured oblique and ground-level photos can enter the fast-orthophoto reconstruction and degrade the resulting mosaic. This change filters images by normalized camera orientation before they are copied into the ODM volume, while preserving compatibility with imagery that has no recognized orientation metadata.

## What changed

- Read embedded XMP orientation metadata from JPEG, TIFF, and DNG files in bounded chunks.
- Normalize DJI/Autel `GimbalPitchDegree`, Parrot `CameraPitchDegree`, Skydio `CameraOrientationNED`, and cross-vendor `Camera:Pitch` conventions to degrees off nadir.
- Keep images within the configurable 10 degree nadir threshold, including a 0.1 degree metadata tolerance for boundary rounding.
- Retain and report images with unknown orientation instead of rejecting unsupported cameras.
- Ignore ambiguous aircraft-body attitude such as `FlightPitchDegree`.
- Log kept, excluded, and unknown counts plus a bounded sample of exclusions.

## Why

The PRIWA flight behind dataset 10917 contained 350 nadir images, 32 images at -45 degrees, and one ground-level image at -2.3 degrees. The mixed input produced visible orthomosaic artifacts. OpenDroneMap recommends imagery 5-10 degrees off nadir for 2D and 2.5D products: https://docs.opendronemap.org/flying/

## Validation

- `python -m pytest -q -m unit processor/tests`: 155 passed, 116 deselected.
- `scripts/lint-python.sh`: passed.
- `scripts/lint-ast-grep.sh`: passed.
- Real PRIWA DJI samples: retained the -90 degree image; excluded -45 and -2.3 degree images.
- Four real Autel Evo II Pro RTK survey images from the OpenDroneMap Helenenschacht dataset were retained, including the -79.97 degree boundary case.
- Synthetic schema tests cover Parrot, Skydio, cross-vendor PIX4D, late DNG XMP, missing metadata, and aircraft-pitch rejection.

## Risk and limitations

Images without supported camera-orientation metadata remain eligible and are reported in processor logs. This avoids breaking conventional aerial imagery, but those images cannot be angle-filtered without a reliable orientation source. A full ODM reconstruction was not run locally; the change is covered at the deterministic input-selection boundary.