### PR TITLE
docs(workflow): standardize PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Briefing
+
+<!-- In two to four sentences, state the outcome, why it matters, who or what is affected, and any material limitation or remaining gate. -->
+
+## What changed
+
+<!-- Use two to five outcome-level bullets. Describe behavior and boundaries, not a file inventory or work diary. -->
+
+## Validation
+
+<!-- List only checks actually performed, with observed results and the relevant environment. If something was not run, say so and explain why. -->
+
+## Risk and limitations
+
+<!-- State user-visible, compatibility, data, migration, deployment, or operational implications. For low-risk changes, one concrete sentence is sufficient. -->
+
+## Tracking
+
+<!-- Use `Fixes ISSUE-ID` only when merging fully completes the issue. Otherwise use `Related to ISSUE-ID`. Delete this section when no issue is tracked. -->
+
+<!-- Add a `Reviewer guide` only when review order, a design decision, screenshots, exact copy, or a high-risk area needs special attention. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,8 @@ scripts/qa/validate-isolated-env.sh
 - Use Conventional Commit format: `type(scope): short summary`.
 - Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`.
 - Good example: `fix(frontend): align tree and deadwood cover labels`.
-- PR bodies should be concise and changelog-friendly: what changed, why, who it helps,
-  validation done, and any user-visible risk.
+- Use [`.github/pull_request_template.md`](.github/pull_request_template.md) for PR descriptions and keep the body synchronized with the final diff and validation evidence.
+- Add the applicable release-grouping labels from [`.github/release.yml`](.github/release.yml).
 
 ## Local-Only Access
 


### PR DESCRIPTION
## Briefing

This adds a reviewer-first PR description template and points repository agents to it. Agent-authored PRs will begin with a short outcome briefing and separate verified changes, validation, risks, and tracking so reviewers can assess them quickly. This is documentation-only and does not change runtime behavior.

## What changed

- add a reusable GitHub PR template with concise, evidence-based sections
- replace the compressed PR-body rule with a direct reference to the canonical template
- retain DeadTrees title rules and make release-label use explicit

## Validation

- `git diff --cached --check`
- verified all required template headings are present
- verified the shared template is byte-identical across the three target repositories

## Risk and limitations

Low: documentation-only. Existing title, CI, review, deployment, and release workflow requirements remain in place.