### PR TITLE
fix(processor): validate assets before activation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ PROCESSOR_TASK_BLACKLIST=
 # Gitignored host directory bind-mounted at /processor-control in the worker.
 # Relative paths are resolved from the repository root.
 PROCESSOR_CONTROL_DIR=./.local/processor-control
+# Host directory containing production models and metadata. Relative paths are
+# resolved from the repository root. Use an absolute shared path when deploys
+# run from a separate operator checkout.
+PROCESSOR_ASSETS_DIR=./assets
 # Per-host resource caps for the production processor container
 # (docker-compose.processor.yaml). On machines smaller than the defaults, lower
 # PROCESSOR_CPU_LIMIT to <= the host's CPU core count. Defaults: 30 CPUs / 96G.

--- a/docker-compose.processor.yaml
+++ b/docker-compose.processor.yaml
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./processor:/app/processor
       - ./shared:/app/shared
-      - ./assets:/app/assets
+      - ${PROCESSOR_ASSETS_DIR:-./assets}:/app/assets:ro
       # Processor->storage keypair. Override PROCESSOR_SSH_KEY_PATH in .env when
       # the default ~/.ssh lives on a filesystem the Docker daemon (root) cannot
       # read — e.g. an NFS home with root-squash; point it at a local-disk path.

--- a/docs/playbooks/processor-worker-setup.md
+++ b/docs/playbooks/processor-worker-setup.md
@@ -53,7 +53,7 @@ The production compose file expects these host resources to exist:
 
 - repository checkout mounted into the processor image during local build
 - `./processor` and `./shared`
-- `./assets`
+- `${PROCESSOR_ASSETS_DIR:-./assets}`, mounted read-only at `/app/assets`
 - `/data`
 - gitignored `.local/processor-control`, mounted at `/processor-control`
 - Docker socket for ODM and model helper containers
@@ -70,6 +70,12 @@ bind-mounts that small directory into the worker; processing output does not go
 there. Set `PROCESSOR_CONTROL_DIR` only when the host needs a different source
 path.
 
+When code is deployed from a separate operator checkout, set
+`PROCESSOR_ASSETS_DIR` in `.env` to the existing populated asset directory.
+The guarded auto-deploy runs `scripts/processor_asset_preflight.py` before it
+starts or resumes the worker. A missing model or metadata dataset leaves the
+worker drained and pauses automatic deployment.
+
 ## Bring-Up
 
 From the production checkout on the new worker host:
@@ -80,6 +86,7 @@ git fetch origin main
 git checkout main
 git pull --ff-only origin main
 mkdir -p .local/processor-control
+python3 scripts/processor_asset_preflight.py
 docker compose -f docker-compose.processor.yaml build processor tcd
 docker compose -f docker-compose.processor.yaml up -d processor
 ```

--- a/processor/src/deadwood_segmentation_v1_moehring/inference/deadwood_inference.py
+++ b/processor/src/deadwood_segmentation_v1_moehring/inference/deadwood_inference.py
@@ -21,8 +21,9 @@ from processor.src.utils.segmentation import (
 	mask_to_polygons_scanline,
 	reproject_polygons,
 )
+from shared.asset_manifest import DEADWOOD_V1_MODEL_CHECKPOINT_NAME
 
-DEADWOOD_MODEL_NAME = 'segformer_b5_full_epoch_100'
+DEADWOOD_MODEL_NAME = DEADWOOD_V1_MODEL_CHECKPOINT_NAME.removesuffix('.safetensors')
 DEADWOOD_PROBABILITY_THRESHOLD = 0.5
 DEADWOOD_MINIMUM_INFERENCE_RESOLUTION = 0.05
 DEADWOOD_BATCH_SIZE = 2

--- a/processor/src/deadwood_segmentation_v1_moehring/predict_deadwood.py
+++ b/processor/src/deadwood_segmentation_v1_moehring/predict_deadwood.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from shared.logger import logger
 from shared.logging import LogContext, LogCategory
-from shared.models import LabelDataEnum
+from shared.models import DEADWOOD_V1_MODEL_CHECKPOINT_NAME, LabelDataEnum
 from shared.labels import delete_model_prediction_labels
 from shared.db import login
 from shared.settings import settings
@@ -15,7 +15,7 @@ from ..utils.segmentation import polygons_to_multipolygon_geojson, reproject_pol
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 ASSETS_DIR = PROJECT_ROOT / 'assets'
 
-MODEL_PATH = str(ASSETS_DIR / 'models' / 'segformer_b5_full_epoch_100.safetensors')
+MODEL_PATH = str(ASSETS_DIR / 'models' / DEADWOOD_V1_MODEL_CHECKPOINT_NAME)
 MODULE_NAME = 'deadwood_segmentation_v1_moehring'
 CHECKPOINT_NAME = Path(MODEL_PATH).name
 MODEL_CONFIG = {

--- a/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
+++ b/processor/src/deadwood_treecover_combined_v2/inference/combined_inference.py
@@ -25,8 +25,6 @@ from processor.src.utils.segmentation import (
     reproject_polygons,
 )
 
-CHECKPOINT_NAME = 'ckpt_weighted_brownweight15_goldentestweight7.safetensors'
-
 # Class indices as defined in the training config (config/base_segformer.yml)
 CLASS_BACKGROUND = 0
 CLASS_TREECOVER = 1

--- a/scripts/lib/processor_runtime.sh
+++ b/scripts/lib/processor_runtime.sh
@@ -1,5 +1,10 @@
 PROCESSOR_DRAIN_WAIT_PID=""
 
+request_automation_drain() {
+	local reason="$1"
+	python3 "${STATUS_SCRIPT}" set-drain --reason "${reason}" --preserve-operator-drain >> "${LOG_FILE}" 2>&1
+}
+
 cleanup_processor_runtime_waiter() {
 	local wait_pid="${PROCESSOR_DRAIN_WAIT_PID:-}"
 	if [ -n "${wait_pid}" ] && kill -0 "${wait_pid}" 2>/dev/null; then

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import itertools
 import json
+import math
 import os
+import sqlite3
 import struct
 import sys
+from contextlib import closing
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +20,50 @@ from shared.operator_env import load_env_file
 
 
 MAX_SAFETENSORS_HEADER_BYTES = 16 * 1024 * 1024
+
+
+def valid_geopackage(path: Path, layer: str, required_columns: tuple[str, ...]) -> bool:
+	try:
+		with closing(sqlite3.connect(f'file:{path}?mode=ro', uri=True)) as database:
+			page_size = database.execute('PRAGMA page_size').fetchone()[0]
+			page_count = database.execute('PRAGMA page_count').fetchone()[0]
+			content = database.execute(
+				'SELECT table_name FROM gpkg_contents WHERE table_name = ?',
+				(layer,),
+			).fetchone()
+			columns = {row[1] for row in database.execute(f'PRAGMA table_info("{layer}")')}
+		return (
+			page_size > 0
+			and page_count > 0
+			and path.stat().st_size == page_size * page_count
+			and content == (layer,)
+			and set(required_columns).issubset(columns)
+		)
+	except (OSError, sqlite3.Error):
+		return False
+
+
+def valid_zarr_store(store: Path) -> bool:
+	try:
+		for name, (expected_shape, expected_chunks, omitted_chunks) in asset_manifest.PHENOLOGY_ARRAY_SPECS.items():
+			array_dir = store / name
+			metadata = json.loads((array_dir / '.zarray').read_text())
+			if tuple(metadata.get('shape', ())) != expected_shape or tuple(metadata.get('chunks', ())) != expected_chunks:
+				return False
+			separator = metadata.get('dimension_separator', '.')
+			if separator not in {'.', '/'}:
+				return False
+			chunk_ranges = [range(math.ceil(size / chunk)) for size, chunk in zip(expected_shape, expected_chunks)]
+			for coordinates in itertools.product(*chunk_ranges):
+				chunk_key = separator.join(map(str, coordinates))
+				if chunk_key in omitted_chunks:
+					continue
+				chunk = array_dir.joinpath(*map(str, coordinates)) if separator == '/' else array_dir / chunk_key
+				if not chunk.is_file() or chunk.stat().st_size == 0:
+					return False
+		return True
+	except (OSError, TypeError, ValueError, json.JSONDecodeError):
+		return False
 
 
 def valid_safetensors(path: Path, minimum_tensors: int, required_tensors: tuple[str, ...]) -> bool:
@@ -79,10 +127,19 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 	)
 	missing.extend(
 		assets_dir / relative
+		for relative, (layer, required_columns) in asset_manifest.GEOPACKAGE_SPECS.items()
+		if not valid_geopackage(assets_dir / relative, layer, required_columns)
+		and assets_dir / relative not in missing
+	)
+	missing.extend(
+		assets_dir / relative
 		for relative in asset_manifest.required_processor_asset_directories()
 		if not (assets_dir / relative).is_dir()
 		or not any(path.is_file() and not path.name.startswith('.') for path in (assets_dir / relative).iterdir())
 	)
+	phenology_store = assets_dir / asset_manifest.PHENOLOGY_ASSET_PATH
+	if phenology_store not in missing and not valid_zarr_store(phenology_store):
+		missing.append(phenology_store)
 	return missing
 
 

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -53,10 +53,24 @@ def valid_geopackage(path: Path, layer: str, required_columns: tuple[str, ...]) 
 
 def valid_zarr_store(store: Path, assets_dir: Path) -> bool:
 	try:
+		consolidated = json.loads((store / '.zmetadata').read_text())
+		if consolidated.get('zarr_consolidated_format') != 1 or not isinstance(consolidated.get('metadata'), dict):
+			return False
+		consolidated_metadata = consolidated['metadata']
+		if consolidated_metadata.get('.zgroup', {}).get('zarr_format') != 2:
+			return False
 		for name, (expected_shape, expected_chunks, omitted_chunks) in asset_manifest.PHENOLOGY_ARRAY_SPECS.items():
 			array_dir = store / name
 			metadata = json.loads((array_dir / '.zarray').read_text())
 			if tuple(metadata.get('shape', ())) != expected_shape or tuple(metadata.get('chunks', ())) != expected_chunks:
+				return False
+			if consolidated_metadata.get(f'{name}/.zarray') != metadata:
+				return False
+			array_attributes = consolidated_metadata.get(f'{name}/.zattrs')
+			if (
+				not isinstance(array_attributes, dict)
+				or len(array_attributes.get('_ARRAY_DIMENSIONS', ())) != len(expected_shape)
+			):
 				return False
 			separator = metadata.get('dimension_separator', '.')
 			if separator not in {'.', '/'}:
@@ -121,35 +135,42 @@ def resolve_assets_dir(repo_dir: Path) -> Path:
 	return assets_dir.resolve()
 
 
-def missing_assets(assets_dir: Path) -> list[Path]:
+def missing_assets(assets_dir: Path, task_blacklist: set[str] | frozenset[str] = frozenset()) -> list[Path]:
 	missing = [
 		assets_dir / relative
-		for relative in asset_manifest.required_processor_asset_files()
+		for relative in asset_manifest.required_processor_asset_files(task_blacklist)
 		if not contained_asset(assets_dir / relative, assets_dir)
 		or not (assets_dir / relative).is_file()
 		or (assets_dir / relative).stat().st_size == 0
 	]
 	missing.extend(
 		assets_dir / 'models' / name
-		for name, (minimum_tensors, required_tensors) in asset_manifest.processor_model_checkpoint_specs().items()
+		for name, (minimum_tensors, required_tensors) in asset_manifest.processor_model_checkpoint_specs(
+			task_blacklist
+		).items()
 		if not valid_safetensors(assets_dir / 'models' / name, minimum_tensors, required_tensors)
 		and assets_dir / 'models' / name not in missing
 	)
+	if asset_manifest.METADATA_TASK_TYPE not in task_blacklist:
+		missing.extend(
+			assets_dir / relative
+			for relative, (layer, required_columns) in asset_manifest.GEOPACKAGE_SPECS.items()
+			if not valid_geopackage(assets_dir / relative, layer, required_columns)
+			and assets_dir / relative not in missing
+		)
 	missing.extend(
 		assets_dir / relative
-		for relative, (layer, required_columns) in asset_manifest.GEOPACKAGE_SPECS.items()
-		if not valid_geopackage(assets_dir / relative, layer, required_columns)
-		and assets_dir / relative not in missing
-	)
-	missing.extend(
-		assets_dir / relative
-		for relative in asset_manifest.required_processor_asset_directories()
+		for relative in asset_manifest.required_processor_asset_directories(task_blacklist)
 		if not contained_asset(assets_dir / relative, assets_dir)
 		or not (assets_dir / relative).is_dir()
 		or not any(path.is_file() and not path.name.startswith('.') for path in (assets_dir / relative).iterdir())
 	)
 	phenology_store = assets_dir / asset_manifest.PHENOLOGY_ASSET_PATH
-	if phenology_store not in missing and not valid_zarr_store(phenology_store, assets_dir):
+	if (
+		asset_manifest.METADATA_TASK_TYPE not in task_blacklist
+		and phenology_store not in missing
+		and not valid_zarr_store(phenology_store, assets_dir)
+	):
 		missing.append(phenology_store)
 	return missing
 
@@ -157,7 +178,10 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 def main() -> int:
 	repo_dir = REPO_ROOT
 	assets_dir = resolve_assets_dir(repo_dir)
-	missing = missing_assets(assets_dir)
+	env_file = load_env_file(repo_dir / '.env')
+	configured_blacklist = os.environ.get('PROCESSOR_TASK_BLACKLIST', env_file.get('PROCESSOR_TASK_BLACKLIST', ''))
+	task_blacklist = {value.strip() for value in configured_blacklist.split(',') if value.strip()}
+	missing = missing_assets(assets_dir, task_blacklist)
 	if missing:
 		print(f'Processor asset preflight failed for {assets_dir}:', file=sys.stderr)
 		for path in missing:

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+from processor_runtime_control import load_env_file
+
 
 REQUIRED_FILES = (
 	'models/segformer_b5_full_epoch_100.safetensors',
@@ -17,25 +19,8 @@ REQUIRED_FILES = (
 REQUIRED_DIRECTORIES = ('pheno/modispheno_aggregated_normalized_filled.zarr',)
 
 
-def _env_file_value(path: Path, name: str) -> str | None:
-	if not path.exists():
-		return None
-	for raw_line in path.read_text().splitlines():
-		line = raw_line.strip()
-		if not line or line.startswith('#') or '=' not in line:
-			continue
-		key, value = line.split('=', 1)
-		if key.strip() != name:
-			continue
-		value = value.strip()
-		if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
-			value = value[1:-1]
-		return value
-	return None
-
-
 def resolve_assets_dir(repo_dir: Path) -> Path:
-	configured = os.environ.get('PROCESSOR_ASSETS_DIR') or _env_file_value(repo_dir / '.env', 'PROCESSOR_ASSETS_DIR')
+	configured = os.environ.get('PROCESSOR_ASSETS_DIR') or load_env_file(repo_dir / '.env').get('PROCESSOR_ASSETS_DIR')
 	assets_dir = Path(configured or 'assets').expanduser()
 	if not assets_dir.is_absolute():
 		assets_dir = repo_dir / assets_dir

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -22,6 +22,14 @@ from shared.operator_env import load_env_file
 MAX_SAFETENSORS_HEADER_BYTES = 16 * 1024 * 1024
 
 
+def contained_asset(path: Path, assets_dir: Path) -> bool:
+	try:
+		path.resolve().relative_to(assets_dir.resolve())
+		return True
+	except (OSError, ValueError):
+		return False
+
+
 def valid_geopackage(path: Path, layer: str, required_columns: tuple[str, ...]) -> bool:
 	try:
 		with closing(sqlite3.connect(f'file:{path}?mode=ro', uri=True)) as database:
@@ -43,7 +51,7 @@ def valid_geopackage(path: Path, layer: str, required_columns: tuple[str, ...]) 
 		return False
 
 
-def valid_zarr_store(store: Path) -> bool:
+def valid_zarr_store(store: Path, assets_dir: Path) -> bool:
 	try:
 		for name, (expected_shape, expected_chunks, omitted_chunks) in asset_manifest.PHENOLOGY_ARRAY_SPECS.items():
 			array_dir = store / name
@@ -59,7 +67,7 @@ def valid_zarr_store(store: Path) -> bool:
 				if chunk_key in omitted_chunks:
 					continue
 				chunk = array_dir.joinpath(*map(str, coordinates)) if separator == '/' else array_dir / chunk_key
-				if not chunk.is_file() or chunk.stat().st_size == 0:
+				if not contained_asset(chunk, assets_dir) or not chunk.is_file() or chunk.stat().st_size == 0:
 					return False
 		return True
 	except (OSError, TypeError, ValueError, json.JSONDecodeError):
@@ -117,7 +125,9 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 	missing = [
 		assets_dir / relative
 		for relative in asset_manifest.required_processor_asset_files()
-		if not (assets_dir / relative).is_file() or (assets_dir / relative).stat().st_size == 0
+		if not contained_asset(assets_dir / relative, assets_dir)
+		or not (assets_dir / relative).is_file()
+		or (assets_dir / relative).stat().st_size == 0
 	]
 	missing.extend(
 		assets_dir / 'models' / name
@@ -134,11 +144,12 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 	missing.extend(
 		assets_dir / relative
 		for relative in asset_manifest.required_processor_asset_directories()
-		if not (assets_dir / relative).is_dir()
+		if not contained_asset(assets_dir / relative, assets_dir)
+		or not (assets_dir / relative).is_dir()
 		or not any(path.is_file() and not path.name.startswith('.') for path in (assets_dir / relative).iterdir())
 	)
 	phenology_store = assets_dir / asset_manifest.PHENOLOGY_ASSET_PATH
-	if phenology_store not in missing and not valid_zarr_store(phenology_store):
+	if phenology_store not in missing and not valid_zarr_store(phenology_store, assets_dir):
 		missing.append(phenology_store)
 	return missing
 

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -178,6 +178,12 @@ def missing_assets(assets_dir: Path, task_blacklist: set[str] | frozenset[str] =
 def main() -> int:
 	repo_dir = REPO_ROOT
 	assets_dir = resolve_assets_dir(repo_dir)
+	if sys.argv[1:] == ['--print-assets-dir']:
+		print(assets_dir)
+		return 0
+	if len(sys.argv) > 1:
+		print('Usage: processor_asset_preflight.py [--print-assets-dir]', file=sys.stderr)
+		return 2
 	env_file = load_env_file(repo_dir / '.env')
 	configured_blacklist = os.environ.get('PROCESSOR_TASK_BLACKLIST', env_file.get('PROCESSOR_TASK_BLACKLIST', ''))
 	task_blacklist = {value.strip() for value in configured_blacklist.split(',') if value.strip()}

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -6,17 +6,11 @@ import os
 import sys
 from pathlib import Path
 
-from processor_runtime_control import load_env_file
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
 
-
-REQUIRED_FILES = (
-	'models/segformer_b5_full_epoch_100.safetensors',
-	'models/ckpt_weighted_brownweight15_goldentestweight7.safetensors',
-	'models/b1_50epoch_best_macro_f1.safetensors',
-	'gadm/gadm_410.gpkg',
-	'biom/terres_ecosystems.gpkg',
-)
-REQUIRED_DIRECTORIES = ('pheno/modispheno_aggregated_normalized_filled.zarr',)
+from shared import asset_manifest
+from shared.operator_env import load_env_file
 
 
 def resolve_assets_dir(repo_dir: Path) -> Path:
@@ -30,19 +24,19 @@ def resolve_assets_dir(repo_dir: Path) -> Path:
 def missing_assets(assets_dir: Path) -> list[Path]:
 	missing = [
 		assets_dir / relative
-		for relative in REQUIRED_FILES
+		for relative in asset_manifest.required_processor_asset_files()
 		if not (assets_dir / relative).is_file() or (assets_dir / relative).stat().st_size == 0
 	]
 	missing.extend(
 		assets_dir / relative
-		for relative in REQUIRED_DIRECTORIES
+		for relative in asset_manifest.required_processor_asset_directories()
 		if not (assets_dir / relative).is_dir() or not any((assets_dir / relative).iterdir())
 	)
 	return missing
 
 
 def main() -> int:
-	repo_dir = Path(__file__).resolve().parents[1]
+	repo_dir = REPO_ROOT
 	assets_dir = resolve_assets_dir(repo_dir)
 	missing = missing_assets(assets_dir)
 	if missing:

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -135,6 +135,10 @@ def resolve_assets_dir(repo_dir: Path) -> Path:
 	return assets_dir.resolve()
 
 
+def matching_mount(assets_dir: Path, mounted_assets: Path) -> bool:
+	return mounted_assets.resolve() == assets_dir.resolve()
+
+
 def missing_assets(assets_dir: Path, task_blacklist: set[str] | frozenset[str] = frozenset()) -> list[Path]:
 	missing = [
 		assets_dir / relative
@@ -181,8 +185,13 @@ def main() -> int:
 	if sys.argv[1:] == ['--print-assets-dir']:
 		print(assets_dir)
 		return 0
+	if len(sys.argv) == 3 and sys.argv[1] == '--mount-matches':
+		return 0 if matching_mount(assets_dir, Path(sys.argv[2])) else 1
 	if len(sys.argv) > 1:
-		print('Usage: processor_asset_preflight.py [--print-assets-dir]', file=sys.stderr)
+		print(
+			'Usage: processor_asset_preflight.py [--print-assets-dir | --mount-matches PATH]',
+			file=sys.stderr,
+		)
 		return 2
 	env_file = load_env_file(repo_dir / '.env')
 	configured_blacklist = os.environ.get('PROCESSOR_TASK_BLACKLIST', env_file.get('PROCESSOR_TASK_BLACKLIST', ''))

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import struct
 import sys
 from pathlib import Path
 
@@ -11,6 +13,45 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from shared import asset_manifest
 from shared.operator_env import load_env_file
+
+
+MAX_SAFETENSORS_HEADER_BYTES = 16 * 1024 * 1024
+
+
+def valid_safetensors(path: Path, minimum_tensors: int, required_tensors: tuple[str, ...]) -> bool:
+	try:
+		file_size = path.stat().st_size
+		with path.open('rb') as checkpoint:
+			header_size_raw = checkpoint.read(8)
+			if len(header_size_raw) != 8:
+				return False
+			header_size = struct.unpack('<Q', header_size_raw)[0]
+			if not 0 < header_size <= MAX_SAFETENSORS_HEADER_BYTES or 8 + header_size > file_size:
+				return False
+			header = json.loads(checkpoint.read(header_size))
+		if not isinstance(header, dict):
+			return False
+		tensors = {name: value for name, value in header.items() if name != '__metadata__'}
+		if len(tensors) < minimum_tensors or any(name not in tensors for name in required_tensors):
+			return False
+		payload_size = file_size - 8 - header_size
+		for tensor in tensors.values():
+			if not isinstance(tensor, dict) or not isinstance(tensor.get('dtype'), str):
+				return False
+			shape = tensor.get('shape')
+			if not isinstance(shape, list) or not all(isinstance(size, int) and size >= 0 for size in shape):
+				return False
+			offsets = tensor.get('data_offsets')
+			if (
+				not isinstance(offsets, list)
+				or len(offsets) != 2
+				or not all(isinstance(offset, int) for offset in offsets)
+				or not 0 <= offsets[0] <= offsets[1] <= payload_size
+			):
+				return False
+		return True
+	except (OSError, UnicodeDecodeError, json.JSONDecodeError, struct.error):
+		return False
 
 
 def resolve_assets_dir(repo_dir: Path) -> Path:
@@ -30,6 +71,12 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 		for relative in asset_manifest.required_processor_asset_files()
 		if not (assets_dir / relative).is_file() or (assets_dir / relative).stat().st_size == 0
 	]
+	missing.extend(
+		assets_dir / 'models' / name
+		for name, (minimum_tensors, required_tensors) in asset_manifest.processor_model_checkpoint_specs().items()
+		if not valid_safetensors(assets_dir / 'models' / name, minimum_tensors, required_tensors)
+		and assets_dir / 'models' / name not in missing
+	)
 	missing.extend(
 		assets_dir / relative
 		for relative in asset_manifest.required_processor_asset_directories()

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -30,7 +30,8 @@ def missing_assets(assets_dir: Path) -> list[Path]:
 	missing.extend(
 		assets_dir / relative
 		for relative in asset_manifest.required_processor_asset_directories()
-		if not (assets_dir / relative).is_dir() or not any((assets_dir / relative).iterdir())
+		if not (assets_dir / relative).is_dir()
+		or not any(path.is_file() and not path.name.startswith('.') for path in (assets_dir / relative).iterdir())
 	)
 	return missing
 

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -14,7 +14,10 @@ from shared.operator_env import load_env_file
 
 
 def resolve_assets_dir(repo_dir: Path) -> Path:
-	configured = os.environ.get('PROCESSOR_ASSETS_DIR') or load_env_file(repo_dir / '.env').get('PROCESSOR_ASSETS_DIR')
+	if 'PROCESSOR_ASSETS_DIR' in os.environ:
+		configured = os.environ['PROCESSOR_ASSETS_DIR']
+	else:
+		configured = load_env_file(repo_dir / '.env').get('PROCESSOR_ASSETS_DIR')
 	assets_dir = Path(configured or 'assets').expanduser()
 	if not assets_dir.is_absolute():
 		assets_dir = repo_dir / assets_dir

--- a/scripts/processor_asset_preflight.py
+++ b/scripts/processor_asset_preflight.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+REQUIRED_FILES = (
+	'models/segformer_b5_full_epoch_100.safetensors',
+	'models/ckpt_weighted_brownweight15_goldentestweight7.safetensors',
+	'models/b1_50epoch_best_macro_f1.safetensors',
+	'gadm/gadm_410.gpkg',
+	'biom/terres_ecosystems.gpkg',
+)
+REQUIRED_DIRECTORIES = ('pheno/modispheno_aggregated_normalized_filled.zarr',)
+
+
+def _env_file_value(path: Path, name: str) -> str | None:
+	if not path.exists():
+		return None
+	for raw_line in path.read_text().splitlines():
+		line = raw_line.strip()
+		if not line or line.startswith('#') or '=' not in line:
+			continue
+		key, value = line.split('=', 1)
+		if key.strip() != name:
+			continue
+		value = value.strip()
+		if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+			value = value[1:-1]
+		return value
+	return None
+
+
+def resolve_assets_dir(repo_dir: Path) -> Path:
+	configured = os.environ.get('PROCESSOR_ASSETS_DIR') or _env_file_value(repo_dir / '.env', 'PROCESSOR_ASSETS_DIR')
+	assets_dir = Path(configured or 'assets').expanduser()
+	if not assets_dir.is_absolute():
+		assets_dir = repo_dir / assets_dir
+	return assets_dir.resolve()
+
+
+def missing_assets(assets_dir: Path) -> list[Path]:
+	missing = [
+		assets_dir / relative
+		for relative in REQUIRED_FILES
+		if not (assets_dir / relative).is_file() or (assets_dir / relative).stat().st_size == 0
+	]
+	missing.extend(
+		assets_dir / relative
+		for relative in REQUIRED_DIRECTORIES
+		if not (assets_dir / relative).is_dir() or not any((assets_dir / relative).iterdir())
+	)
+	return missing
+
+
+def main() -> int:
+	repo_dir = Path(__file__).resolve().parents[1]
+	assets_dir = resolve_assets_dir(repo_dir)
+	missing = missing_assets(assets_dir)
+	if missing:
+		print(f'Processor asset preflight failed for {assets_dir}:', file=sys.stderr)
+		for path in missing:
+			print(f'- missing {path.relative_to(assets_dir)}', file=sys.stderr)
+		return 1
+	print(f'Processor assets ready at {assets_dir}')
+	return 0
+
+
+if __name__ == '__main__':
+	raise SystemExit(main())

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -10,6 +10,7 @@ ACTIVATED_SHA_FILE="${REPO_DIR}/.local/processor-activated-sha"
 PAUSE_FILE="${REPO_DIR}/.local/processor-deploy-paused"
 LOG_FILE="${REPO_DIR}/auto-deploy.log"
 STATUS_SCRIPT="${REPO_DIR}/scripts/processor_runtime_control.py"
+ASSET_PREFLIGHT_SCRIPT="${REPO_DIR}/scripts/processor_asset_preflight.py"
 COMPOSE_FILE="${REPO_DIR}/docker-compose.processor.yaml"
 BRANCH="${PROCESSOR_DEPLOY_BRANCH:-main}"
 DRAIN_TIMEOUT_SECONDS="${PROCESSOR_DRAIN_TIMEOUT_SECONDS:-43200}"
@@ -89,6 +90,13 @@ on_exit() {
 trap on_exit EXIT
 
 cd "${REPO_DIR}"
+
+if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
+	log "Refusing processor activation because required assets are missing"
+	python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
+	drain_set=1
+	exit 1
+fi
 
 if [ "${DEPLOY_PHASE}" = "activate" ]; then
 	remote_sha="${DEPLOY_TARGET_SHA}"

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -66,6 +66,42 @@ require_clean_checkout() {
 
 source "${SCRIPT_DIR}/lib/processor_runtime.sh"
 
+processor_asset_mount_matches() {
+	local container_id
+	local expected_assets
+	local mounted_assets
+
+	expected_assets="$(python3 "${ASSET_PREFLIGHT_SCRIPT}" --print-assets-dir)"
+	container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q processor 2>/dev/null || true)"
+	if [ -z "${container_id}" ]; then
+		return 1
+	fi
+	mounted_assets="$(
+		docker inspect "${container_id}" \
+			--format '{{range .Mounts}}{{if eq .Destination "/app/assets"}}{{.Source}}{{end}}{{end}}' \
+			2>/dev/null || true
+	)"
+	[ -n "${mounted_assets}" ] && [ "${mounted_assets}" = "${expected_assets}" ]
+}
+
+recreate_processor_for_assets() {
+	drain_set=1
+	wait_for_drain_with_recovery
+	python3 "${STATUS_SCRIPT}" clear-ack >> "${LOG_FILE}" 2>&1
+	PROCESSOR_RELEASE_SHA="${remote_sha}" \
+		docker compose -f "${COMPOSE_FILE}" up -d --force-recreate processor \
+		>> "${LOG_FILE}" 2>&1
+	python3 "${STATUS_SCRIPT}" wait-for-idle \
+		--expected-release-sha "${remote_sha}" \
+		--timeout-seconds "${STARTUP_TIMEOUT_SECONDS}" \
+		--poll-seconds "${READINESS_POLL_SECONDS}" >> "${LOG_FILE}" 2>&1
+	wait_for_processor_running
+	inspect_processor_runtime
+	python3 "${STATUS_SCRIPT}" record-worker-id >> "${LOG_FILE}" 2>&1
+	python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
+	drain_set=0
+}
+
 if [ "${PROCESSOR_RUNTIME_LOCK_HELD:-0}" != "1" ]; then
 	exec 9<>"${LOCK_FILE}"
 	if ! flock -n 9; then
@@ -148,24 +184,22 @@ else
 			fi
 			exit 1
 		fi
-		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
+		if ! processor_asset_mount_matches; then
+			log "Recreating processor because the configured asset mount changed"
+			if request_automation_drain "required processor assets missing"; then
+				recreate_processor_for_assets
+				log "Recreated processor with the configured asset mount"
+			elif [ "$?" -eq 3 ]; then
+				log "Preserved existing operator drain while the configured asset mount changed"
+			else
+				exit 1
+			fi
+		elif python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
 			wait_for_processor_running
 			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
 			log "Completed interrupted activation for ${remote_sha}"
 		elif python3 "${STATUS_SCRIPT}" asset-recovery-pending >> "${LOG_FILE}" 2>&1; then
-			drain_set=1
-			wait_for_drain_with_recovery
-			python3 "${STATUS_SCRIPT}" clear-ack >> "${LOG_FILE}" 2>&1
-			PROCESSOR_RELEASE_SHA="${remote_sha}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate processor >> "${LOG_FILE}" 2>&1
-			python3 "${STATUS_SCRIPT}" wait-for-idle \
-				--expected-release-sha "${remote_sha}" \
-				--timeout-seconds "${STARTUP_TIMEOUT_SECONDS}" \
-				--poll-seconds "${READINESS_POLL_SECONDS}" >> "${LOG_FILE}" 2>&1
-			wait_for_processor_running
-			inspect_processor_runtime
-			python3 "${STATUS_SCRIPT}" record-worker-id >> "${LOG_FILE}" 2>&1
-			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
-			drain_set=0
+			recreate_processor_for_assets
 			log "Recovered processor after restoring required assets"
 		else
 			log "No changes"

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -137,7 +137,8 @@ else
 			drain_set=1
 			exit 1
 		fi
-		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
+		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1 || \
+			python3 "${STATUS_SCRIPT}" asset-recovery-ready >> "${LOG_FILE}" 2>&1; then
 			wait_for_processor_running
 			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
 			log "Completed interrupted activation for ${remote_sha}"

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -101,7 +101,13 @@ if [ "${DEPLOY_PHASE}" = "activate" ]; then
 	fi
 	if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
 		log "Refusing processor activation because required assets are missing"
-		python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
+		if request_automation_drain "required processor assets missing"; then
+			:
+		elif [ "$?" -eq 3 ]; then
+			log "Preserved existing operator drain while refusing activation"
+		else
+			exit 1
+		fi
 		exit 1
 	fi
 	# Continue below with the target release's freshly loaded activation logic.
@@ -133,8 +139,13 @@ else
 	if [ "${local_sha}" = "${remote_sha}" ] && [ "${activated_sha}" = "${remote_sha}" ]; then
 		if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
 			log "Draining active release because required processor assets are missing"
-			python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
-			drain_set=1
+			if request_automation_drain "required processor assets missing"; then
+				drain_set=1
+			elif [ "$?" -eq 3 ]; then
+				log "Preserved existing operator drain while required assets are missing"
+			else
+				exit 1
+			fi
 			exit 1
 		fi
 		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
@@ -164,7 +175,14 @@ else
 
 	log "Preparing deploy from ${local_sha} to ${remote_sha}"
 
-	python3 "${STATUS_SCRIPT}" set-drain --reason "auto-deploy ${remote_sha}" >> "${LOG_FILE}" 2>&1
+	if request_automation_drain "auto-deploy ${remote_sha}"; then
+		:
+	elif [ "$?" -eq 3 ]; then
+		log "Skipping deploy because an operator drain is active"
+		exit 0
+	else
+		exit 1
+	fi
 	drain_set=1
 	wait_for_drain_with_recovery
 

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -137,11 +137,25 @@ else
 			drain_set=1
 			exit 1
 		fi
-		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1 || \
-			python3 "${STATUS_SCRIPT}" asset-recovery-ready >> "${LOG_FILE}" 2>&1; then
+		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
 			wait_for_processor_running
 			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
 			log "Completed interrupted activation for ${remote_sha}"
+		elif python3 "${STATUS_SCRIPT}" asset-recovery-pending >> "${LOG_FILE}" 2>&1; then
+			drain_set=1
+			wait_for_drain_with_recovery
+			python3 "${STATUS_SCRIPT}" clear-ack >> "${LOG_FILE}" 2>&1
+			PROCESSOR_RELEASE_SHA="${remote_sha}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate processor >> "${LOG_FILE}" 2>&1
+			python3 "${STATUS_SCRIPT}" wait-for-idle \
+				--expected-release-sha "${remote_sha}" \
+				--timeout-seconds "${STARTUP_TIMEOUT_SECONDS}" \
+				--poll-seconds "${READINESS_POLL_SECONDS}" >> "${LOG_FILE}" 2>&1
+			wait_for_processor_running
+			inspect_processor_runtime
+			python3 "${STATUS_SCRIPT}" record-worker-id >> "${LOG_FILE}" 2>&1
+			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1
+			drain_set=0
+			log "Recovered processor after restoring required assets"
 		else
 			log "No changes"
 		fi

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -91,19 +91,17 @@ trap on_exit EXIT
 
 cd "${REPO_DIR}"
 
-if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
-	log "Refusing processor activation because required assets are missing"
-	python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
-	drain_set=1
-	exit 1
-fi
-
 if [ "${DEPLOY_PHASE}" = "activate" ]; then
 	remote_sha="${DEPLOY_TARGET_SHA}"
 	drain_set=1
 	deployed_sha="$(git rev-parse HEAD)"
 	if [ -z "${remote_sha}" ] || [ "${deployed_sha}" != "${remote_sha}" ]; then
 		log "Refusing activation because HEAD ${deployed_sha} does not match target ${remote_sha:-missing}"
+		exit 1
+	fi
+	if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
+		log "Refusing processor activation because required assets are missing"
+		python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
 		exit 1
 	fi
 	# Continue below with the target release's freshly loaded activation logic.
@@ -133,6 +131,12 @@ else
 	activated_sha="$(cat "${ACTIVATED_SHA_FILE}" 2>/dev/null || true)"
 
 	if [ "${local_sha}" = "${remote_sha}" ] && [ "${activated_sha}" = "${remote_sha}" ]; then
+		if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
+			log "Draining active release because required processor assets are missing"
+			python3 "${STATUS_SCRIPT}" set-drain --reason "required processor assets missing" >> "${LOG_FILE}" 2>&1
+			drain_set=1
+			exit 1
+		fi
 		if python3 "${STATUS_SCRIPT}" activation-ready --release-sha "${remote_sha}" >> "${LOG_FILE}" 2>&1; then
 			wait_for_processor_running
 			python3 "${STATUS_SCRIPT}" clear-drain >> "${LOG_FILE}" 2>&1

--- a/scripts/processor_auto_deploy.sh
+++ b/scripts/processor_auto_deploy.sh
@@ -68,10 +68,8 @@ source "${SCRIPT_DIR}/lib/processor_runtime.sh"
 
 processor_asset_mount_matches() {
 	local container_id
-	local expected_assets
 	local mounted_assets
 
-	expected_assets="$(python3 "${ASSET_PREFLIGHT_SCRIPT}" --print-assets-dir)"
 	container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q processor 2>/dev/null || true)"
 	if [ -z "${container_id}" ]; then
 		return 1
@@ -81,7 +79,7 @@ processor_asset_mount_matches() {
 			--format '{{range .Mounts}}{{if eq .Destination "/app/assets"}}{{.Source}}{{end}}{{end}}' \
 			2>/dev/null || true
 	)"
-	[ -n "${mounted_assets}" ] && [ "${mounted_assets}" = "${expected_assets}" ]
+	[ -n "${mounted_assets}" ] && python3 "${ASSET_PREFLIGHT_SCRIPT}" --mount-matches "${mounted_assets}"
 }
 
 recreate_processor_for_assets() {

--- a/scripts/processor_docker_maintenance.sh
+++ b/scripts/processor_docker_maintenance.sh
@@ -9,6 +9,7 @@ LOCK_FILE="${LOCK_DIR}/processor-runtime.lock"
 ACTIVATED_SHA_FILE="${REPO_DIR}/.local/processor-activated-sha"
 LOG_FILE="${REPO_DIR}/processor-maintenance.log"
 STATUS_SCRIPT="${REPO_DIR}/scripts/processor_runtime_control.py"
+ASSET_PREFLIGHT_SCRIPT="${REPO_DIR}/scripts/processor_asset_preflight.py"
 COMPOSE_FILE="${REPO_DIR}/docker-compose.processor.yaml"
 HOLD_DURATION="${PROCESSOR_SNAP_HOLD_DURATION:-168h}"
 SNAP_CONTROL="${PROCESSOR_SNAP_CONTROL:-/usr/local/sbin/deadtrees-processor-snap-control}"
@@ -107,6 +108,11 @@ require_activated_checkout
 python3 "${STATUS_SCRIPT}" set-drain --reason "docker-maintenance" >> "${LOG_FILE}" 2>&1
 drain_set=1
 wait_for_drain_with_recovery
+
+if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
+	log "Refusing Docker maintenance restart because required processor assets are missing"
+	exit 1
+fi
 
 docker compose -f "${COMPOSE_FILE}" stop processor >> "${LOG_FILE}" 2>&1
 sudo -n "${SNAP_CONTROL}" refresh >> "${LOG_FILE}" 2>&1

--- a/scripts/processor_docker_maintenance.sh
+++ b/scripts/processor_docker_maintenance.sh
@@ -105,7 +105,14 @@ fi
 require_clean_checkout
 require_activated_checkout
 
-python3 "${STATUS_SCRIPT}" set-drain --reason "docker-maintenance" >> "${LOG_FILE}" 2>&1
+if request_automation_drain "docker-maintenance"; then
+	:
+elif [ "$?" -eq 3 ]; then
+	log "Skipping Docker maintenance because an operator drain is active"
+	exit 0
+else
+	exit 1
+fi
 drain_set=1
 wait_for_drain_with_recovery
 

--- a/scripts/processor_docker_maintenance.sh
+++ b/scripts/processor_docker_maintenance.sh
@@ -118,6 +118,13 @@ wait_for_drain_with_recovery
 
 if ! python3 "${ASSET_PREFLIGHT_SCRIPT}" >> "${LOG_FILE}" 2>&1; then
 	log "Refusing Docker maintenance restart because required processor assets are missing"
+	if request_automation_drain "required processor assets missing"; then
+		:
+	elif [ "$?" -eq 3 ]; then
+		log "Preserved operator drain while aborting Docker maintenance"
+	else
+		exit 1
+	fi
 	exit 1
 fi
 

--- a/scripts/processor_runtime_control.py
+++ b/scripts/processor_runtime_control.py
@@ -15,6 +15,11 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from shared.operator_env import load_env_file
+
 QUEUE_TABLE = 'v2_queue'
 QUEUE_POSITION_TABLE = 'v2_queue_positions'
 DEFAULT_CONTROL_DIR = '.local/processor-control'
@@ -26,24 +31,6 @@ class AuthenticationExpiredError(RuntimeError):
 	pass
 
 
-def load_env_file(path: Path) -> dict[str, str]:
-	env: dict[str, str] = {}
-	if not path.exists():
-		return env
-
-	for raw_line in path.read_text().splitlines():
-		line = raw_line.strip()
-		if not line or line.startswith('#') or '=' not in line:
-			continue
-		key, value = line.split('=', 1)
-		value = value.strip()
-		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
-			value = value[1:-1]
-		env[key.strip()] = os.path.expandvars(value)
-	return env
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
 ENV = {
 	**load_env_file(REPO_ROOT / '.env'),
 	**os.environ,
@@ -357,6 +344,25 @@ def cmd_activation_ready(args: argparse.Namespace) -> int:
 	return 0
 
 
+def cmd_asset_recovery_ready(_: argparse.Namespace) -> int:
+	worker_id = _worker_id()
+	previous_worker_id = _activated_worker_id()
+	request, ack = _load_drain_state()
+	if request is None or request.get('reason') != 'required processor assets missing':
+		return 1
+	if not _ack_matches_request(request, ack, worker_id):
+		return 1
+	state = _fetch_queue_state(
+		worker_id,
+		previous_worker_id=previous_worker_id,
+		include_waiting_preview=False,
+	)
+	if state['active_for_worker'] or state['active_for_previous_worker'] or state['active_without_owner']:
+		return 1
+	print(json.dumps({'asset_recovery_ready': True}, indent=2))
+	return 0
+
+
 def cmd_wait_for_idle(args: argparse.Namespace) -> int:
 	worker_id = _worker_id()
 	previous_worker_id = _activated_worker_id()
@@ -483,6 +489,12 @@ def build_parser() -> argparse.ArgumentParser:
 	)
 	activation_ready.add_argument('--release-sha', required=True)
 	activation_ready.set_defaults(func=cmd_activation_ready)
+
+	asset_recovery_ready = subparsers.add_parser(
+		'asset-recovery-ready',
+		help='Verify a repaired asset-loss drain is safe to clear.',
+	)
+	asset_recovery_ready.set_defaults(func=cmd_asset_recovery_ready)
 
 	wait_for_idle = subparsers.add_parser(
 		'wait-for-idle',

--- a/scripts/processor_runtime_control.py
+++ b/scripts/processor_runtime_control.py
@@ -23,12 +23,17 @@ from shared.operator_env import load_env_file
 QUEUE_TABLE = 'v2_queue'
 QUEUE_POSITION_TABLE = 'v2_queue_positions'
 DEFAULT_CONTROL_DIR = '.local/processor-control'
+AUTOMATION_DRAIN_REASONS = {'docker-maintenance', 'required processor assets missing'}
 DEFAULT_ACTIVATED_WORKER_ID_FILE = '.local/processor-activated-worker-id'
 DEFAULT_PROCESSOR_USERNAME = 'processor@deadtrees.earth'
 
 
 class AuthenticationExpiredError(RuntimeError):
 	pass
+
+
+def _is_automation_drain_reason(reason: object) -> bool:
+	return isinstance(reason, str) and (reason in AUTOMATION_DRAIN_REASONS or reason.startswith('auto-deploy '))
 
 
 ENV = {
@@ -281,6 +286,11 @@ def cmd_record_worker_id(_: argparse.Namespace) -> int:
 
 
 def cmd_set_drain(args: argparse.Namespace) -> int:
+	if args.preserve_operator_drain:
+		existing_request, _ = _load_drain_state()
+		if existing_request is not None and not _is_automation_drain_reason(existing_request.get('reason')):
+			print(json.dumps({'preserved_drain_request': existing_request}, indent=2))
+			return 3
 	_clear_file(_drain_ack_path())
 	payload = {
 		'request_id': str(uuid.uuid4()),
@@ -458,6 +468,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 	set_drain = subparsers.add_parser('set-drain', help='Request a drain so this worker stops claiming new tasks.')
 	set_drain.add_argument('--reason', required=True, help='Short operator reason for the drain request.')
+	set_drain.add_argument(
+		'--preserve-operator-drain',
+		action='store_true',
+		help='Return 3 without changing a drain that was not created by processor automation.',
+	)
 	set_drain.set_defaults(func=cmd_set_drain)
 
 	clear_drain = subparsers.add_parser('clear-drain', help='Clear the drain request so the worker can resume.')

--- a/scripts/processor_runtime_control.py
+++ b/scripts/processor_runtime_control.py
@@ -344,22 +344,11 @@ def cmd_activation_ready(args: argparse.Namespace) -> int:
 	return 0
 
 
-def cmd_asset_recovery_ready(_: argparse.Namespace) -> int:
-	worker_id = _worker_id()
-	previous_worker_id = _activated_worker_id()
-	request, ack = _load_drain_state()
+def cmd_asset_recovery_pending(_: argparse.Namespace) -> int:
+	request, _ = _load_drain_state()
 	if request is None or request.get('reason') != 'required processor assets missing':
 		return 1
-	if not _ack_matches_request(request, ack, worker_id):
-		return 1
-	state = _fetch_queue_state(
-		worker_id,
-		previous_worker_id=previous_worker_id,
-		include_waiting_preview=False,
-	)
-	if state['active_for_worker'] or state['active_for_previous_worker'] or state['active_without_owner']:
-		return 1
-	print(json.dumps({'asset_recovery_ready': True}, indent=2))
+	print(json.dumps({'asset_recovery_pending': True}, indent=2))
 	return 0
 
 
@@ -490,11 +479,11 @@ def build_parser() -> argparse.ArgumentParser:
 	activation_ready.add_argument('--release-sha', required=True)
 	activation_ready.set_defaults(func=cmd_activation_ready)
 
-	asset_recovery_ready = subparsers.add_parser(
-		'asset-recovery-ready',
-		help='Verify a repaired asset-loss drain is safe to clear.',
+	asset_recovery_pending = subparsers.add_parser(
+		'asset-recovery-pending',
+		help='Verify that the current drain was caused by missing processor assets.',
 	)
-	asset_recovery_ready.set_defaults(func=cmd_asset_recovery_ready)
+	asset_recovery_pending.set_defaults(func=cmd_asset_recovery_pending)
 
 	wait_for_idle = subparsers.add_parser(
 		'wait-for-idle',

--- a/scripts/processor_runtime_control.py
+++ b/scripts/processor_runtime_control.py
@@ -26,7 +26,7 @@ class AuthenticationExpiredError(RuntimeError):
 	pass
 
 
-def _load_env_file(path: Path) -> dict[str, str]:
+def load_env_file(path: Path) -> dict[str, str]:
 	env: dict[str, str] = {}
 	if not path.exists():
 		return env
@@ -45,7 +45,7 @@ def _load_env_file(path: Path) -> dict[str, str]:
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ENV = {
-	**_load_env_file(REPO_ROOT / '.env'),
+	**load_env_file(REPO_ROOT / '.env'),
 	**os.environ,
 }
 

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -1,9 +1,11 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 from shared.asset_manifest import PHENOLOGY_ASSET_PATH
+from shared.operator_env import load_env_file
 from scripts.processor_asset_preflight import missing_assets
 
 
@@ -27,3 +29,17 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 
 			self.assertIn(store / '.zmetadata', missing)
 			self.assertIn(store / 'phenology', missing)
+
+	def test_env_loader_preserves_dollar_pairs_and_shell_precedence(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			env_file = Path(tmp_dir) / '.env'
+			env_file.write_text(
+				'ASSET_ROOT=/from-file\n'
+				'PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/assets\n'
+				'PROCESSOR_PASSWORD=prefix$$suffix\n'
+			)
+			with patch.dict(os.environ, {'ASSET_ROOT': '/from-shell'}):
+				env = load_env_file(env_file)
+
+			self.assertEqual(env['PROCESSOR_ASSETS_DIR'], '/from-shell/assets')
+			self.assertEqual(env['PROCESSOR_PASSWORD'], 'prefix$$suffix')

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -1,7 +1,9 @@
 import json
 import os
+import sqlite3
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest.mock import patch
 
@@ -102,6 +104,23 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 
 			self.assertIn(geopackage, missing)
 
+	def test_gadm_without_runtime_admin_columns_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			geopackage = assets_dir / GADM_ASSET_PATH
+			geopackage.parent.mkdir(parents=True)
+			with closing(sqlite3.connect(geopackage)) as database:
+				with database:
+					database.execute('CREATE TABLE gpkg_contents (table_name TEXT)')
+					database.execute("INSERT INTO gpkg_contents VALUES ('gadm_410')")
+					database.execute(
+						'CREATE TABLE gadm_410 (geom TEXT, GID_0 TEXT, NAME_0 TEXT, CONTINENT TEXT)'
+					)
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(geopackage, missing)
+
 	def test_zarr_with_only_one_chunk_per_array_is_missing(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			assets_dir = Path(tmp_dir)
@@ -133,3 +152,11 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			missing = missing_assets(assets_dir)
 
 			self.assertIn(zgroup, missing)
+
+	def test_blacklisted_model_stage_does_not_require_its_checkpoint(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+
+			missing = missing_assets(assets_dir, {'aoi_v1'})
+
+			self.assertNotIn(assets_dir / 'models/b1_50epoch_best_macro_f1.safetensors', missing)

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from shared.asset_manifest import PHENOLOGY_ASSET_PATH
 from scripts.processor_asset_preflight import missing_assets
 
 
@@ -14,3 +15,15 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 				missing = missing_assets(assets_dir)
 
 			self.assertIn(assets_dir / 'models/replacement.safetensors', missing)
+
+	def test_nonempty_partial_phenology_store_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			store = assets_dir / PHENOLOGY_ASSET_PATH
+			store.mkdir(parents=True)
+			(store / '.fixture').write_text('partial\n')
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(store / '.zmetadata', missing)
+			self.assertIn(store / 'phenology', missing)

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.processor_asset_preflight import missing_assets
+
+
+class ProcessorAssetPreflightTest(unittest.TestCase):
+	def test_preflight_follows_canonical_model_checkpoint(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			with patch('shared.asset_manifest.DEADWOOD_V1_MODEL_CHECKPOINT_NAME', 'replacement.safetensors'):
+				missing = missing_assets(assets_dir)
+
+			self.assertIn(assets_dir / 'models/replacement.safetensors', missing)

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -59,6 +59,27 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 
 			self.assertEqual(assets_dir, (repo_dir / 'assets').resolve())
 
+	def test_compose_substitution_operators(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			env_file = Path(tmp_dir) / '.env'
+			env_file.write_text(
+				'EMPTY=\n'
+				'SET=/configured\n'
+				'DEFAULT_EMPTY=${EMPTY:-/default}\n'
+				'DEFAULT_UNSET=${UNSET-/default}\n'
+				'KEEP_EMPTY=${EMPTY-/default}\n'
+				'ALTERNATE=${SET:+/alternate}\n'
+				'ALTERNATE_EMPTY=${EMPTY+/alternate}\n'
+			)
+			with patch.dict(os.environ, {}, clear=True):
+				env = load_env_file(env_file)
+
+			self.assertEqual(env['DEFAULT_EMPTY'], '/default')
+			self.assertEqual(env['DEFAULT_UNSET'], '/default')
+			self.assertEqual(env['KEEP_EMPTY'], '')
+			self.assertEqual(env['ALTERNATE'], '/alternate')
+			self.assertEqual(env['ALTERNATE_EMPTY'], '/alternate')
+
 	def test_truncated_nonempty_checkpoint_is_missing(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			assets_dir = Path(tmp_dir)
@@ -97,3 +118,18 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			missing = missing_assets(assets_dir)
 
 			self.assertIn(store, missing)
+
+	def test_asset_symlink_outside_mounted_root_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			root = Path(tmp_dir)
+			assets_dir = root / 'assets'
+			assets_dir.mkdir()
+			external = root / 'external-zgroup'
+			external.write_text('{}')
+			zgroup = assets_dir / PHENOLOGY_ASSET_PATH / '.zgroup'
+			zgroup.parent.mkdir(parents=True)
+			zgroup.symlink_to(external)
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(zgroup, missing)

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 from shared.asset_manifest import GADM_ASSET_PATH, PHENOLOGY_ARRAY_SPECS, PHENOLOGY_ASSET_PATH
 from shared.operator_env import load_env_file
-from scripts.processor_asset_preflight import missing_assets, resolve_assets_dir
+from scripts.processor_asset_preflight import matching_mount, missing_assets, resolve_assets_dir
 
 
 class ProcessorAssetPreflightTest(unittest.TestCase):
@@ -154,6 +154,16 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			missing = missing_assets(assets_dir)
 
 			self.assertIn(zgroup, missing)
+
+	def test_equivalent_symlink_mount_matches_resolved_asset_root(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			root = Path(tmp_dir)
+			assets_dir = root / 'assets'
+			assets_dir.mkdir()
+			mounted_assets = root / 'configured-assets'
+			mounted_assets.symlink_to(assets_dir)
+
+			self.assertTrue(matching_mount(assets_dir, mounted_assets))
 
 	def test_blacklisted_model_stage_does_not_require_its_checkpoint(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -1,10 +1,11 @@
+import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from shared.asset_manifest import PHENOLOGY_ASSET_PATH
+from shared.asset_manifest import GADM_ASSET_PATH, PHENOLOGY_ARRAY_SPECS, PHENOLOGY_ASSET_PATH
 from shared.operator_env import load_env_file
 from scripts.processor_asset_preflight import missing_assets, resolve_assets_dir
 
@@ -38,6 +39,7 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 				'PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/assets\n'
 				'PROCESSOR_PASSWORD=prefix$$suffix\n'
 				"LITERAL_PATH='$ASSET_ROOT/assets'\n"
+				'COMMENTED_VALUE=secret # rotated\n'
 			)
 			with patch.dict(os.environ, {'ASSET_ROOT': '/from-shell'}):
 				env = load_env_file(env_file)
@@ -45,6 +47,7 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			self.assertEqual(env['PROCESSOR_ASSETS_DIR'], '/from-shell/assets')
 			self.assertEqual(env['PROCESSOR_PASSWORD'], 'prefix$$suffix')
 			self.assertEqual(env['LITERAL_PATH'], '$ASSET_ROOT/assets')
+			self.assertEqual(env['COMMENTED_VALUE'], 'secret')
 
 	def test_empty_shell_assets_override_uses_compose_default(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -66,3 +69,31 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			missing = missing_assets(assets_dir)
 
 			self.assertIn(checkpoint, missing)
+
+	def test_truncated_nonempty_geopackage_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			geopackage = assets_dir / GADM_ASSET_PATH
+			geopackage.parent.mkdir(parents=True)
+			geopackage.write_bytes(b'SQLite format 3\x00partial')
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(geopackage, missing)
+
+	def test_zarr_with_only_one_chunk_per_array_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			store = assets_dir / PHENOLOGY_ASSET_PATH
+			store.mkdir(parents=True)
+			(store / '.zgroup').write_text('{}')
+			(store / '.zmetadata').write_text('{}')
+			for name, (shape, chunks, _) in PHENOLOGY_ARRAY_SPECS.items():
+				array_dir = store / name
+				array_dir.mkdir()
+				(array_dir / '.zarray').write_text(json.dumps({'shape': shape, 'chunks': chunks}))
+				(array_dir / '.'.join('0' for _ in shape)).write_text('partial')
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(store, missing)

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from shared.asset_manifest import PHENOLOGY_ASSET_PATH
 from shared.operator_env import load_env_file
-from scripts.processor_asset_preflight import missing_assets
+from scripts.processor_asset_preflight import missing_assets, resolve_assets_dir
 
 
 class ProcessorAssetPreflightTest(unittest.TestCase):
@@ -43,3 +43,13 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 
 			self.assertEqual(env['PROCESSOR_ASSETS_DIR'], '/from-shell/assets')
 			self.assertEqual(env['PROCESSOR_PASSWORD'], 'prefix$$suffix')
+
+	def test_empty_shell_assets_override_uses_compose_default(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			repo_dir = Path(tmp_dir)
+			(repo_dir / '.env').write_text('PROCESSOR_ASSETS_DIR=/external/assets\n')
+
+			with patch.dict(os.environ, {'PROCESSOR_ASSETS_DIR': ''}):
+				assets_dir = resolve_assets_dir(repo_dir)
+
+			self.assertEqual(assets_dir, (repo_dir / 'assets').resolve())

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -41,6 +41,7 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 				'PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/assets\n'
 				'PROCESSOR_PASSWORD=prefix$$suffix\n'
 				"LITERAL_PATH='$ASSET_ROOT/assets'\n"
+				'ESCAPED_PASSWORD="secret\\tvalue\\\\path\\"quote"\n'
 				'COMMENTED_VALUE=secret # rotated\n'
 			)
 			with patch.dict(os.environ, {'ASSET_ROOT': '/from-shell'}):
@@ -49,6 +50,7 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 			self.assertEqual(env['PROCESSOR_ASSETS_DIR'], '/from-shell/assets')
 			self.assertEqual(env['PROCESSOR_PASSWORD'], 'prefix$$suffix')
 			self.assertEqual(env['LITERAL_PATH'], '$ASSET_ROOT/assets')
+			self.assertEqual(env['ESCAPED_PASSWORD'], 'secret\tvalue\\path"quote')
 			self.assertEqual(env['COMMENTED_VALUE'], 'secret')
 
 	def test_empty_shell_assets_override_uses_compose_default(self) -> None:

--- a/scripts/tests/test_processor_asset_preflight.py
+++ b/scripts/tests/test_processor_asset_preflight.py
@@ -37,12 +37,14 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 				'ASSET_ROOT=/from-file\n'
 				'PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/assets\n'
 				'PROCESSOR_PASSWORD=prefix$$suffix\n'
+				"LITERAL_PATH='$ASSET_ROOT/assets'\n"
 			)
 			with patch.dict(os.environ, {'ASSET_ROOT': '/from-shell'}):
 				env = load_env_file(env_file)
 
 			self.assertEqual(env['PROCESSOR_ASSETS_DIR'], '/from-shell/assets')
 			self.assertEqual(env['PROCESSOR_PASSWORD'], 'prefix$$suffix')
+			self.assertEqual(env['LITERAL_PATH'], '$ASSET_ROOT/assets')
 
 	def test_empty_shell_assets_override_uses_compose_default(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -53,3 +55,14 @@ class ProcessorAssetPreflightTest(unittest.TestCase):
 				assets_dir = resolve_assets_dir(repo_dir)
 
 			self.assertEqual(assets_dir, (repo_dir / 'assets').resolve())
+
+	def test_truncated_nonempty_checkpoint_is_missing(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			assets_dir = Path(tmp_dir)
+			checkpoint = assets_dir / 'models/segformer_b5_full_epoch_100.safetensors'
+			checkpoint.parent.mkdir(parents=True)
+			checkpoint.write_bytes(b'partial')
+
+			missing = missing_assets(assets_dir)
+
+			self.assertIn(checkpoint, missing)

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -7,6 +7,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from shared.asset_manifest import required_processor_asset_directories, required_processor_asset_files
+
 
 SCRIPT = Path(__file__).parents[1] / "processor_auto_deploy.sh"
 
@@ -56,6 +58,7 @@ class DeployHarness:
 		git(self.seed, "config", "user.email", "tests@deadtrees.example")
 		(self.seed / "scripts").mkdir()
 		(self.seed / "scripts" / "lib").mkdir()
+		(self.seed / "shared").mkdir()
 		(self.seed / "README.md").write_text("initial\n")
 		(self.seed / "docker-compose.processor.yaml").write_text("services: {}\n")
 		(self.seed / ".gitignore").write_text("/.local\n/assets\n.env\n__pycache__/\n")
@@ -63,6 +66,8 @@ class DeployHarness:
 		shutil.copy2(SCRIPT.parent / "lib" / "processor_runtime.sh", self.seed / "scripts" / "lib" / "processor_runtime.sh")
 		shutil.copy2(SCRIPT.parent / "processor_runtime_control.py", self.seed / "scripts" / "processor_runtime_control.py")
 		shutil.copy2(SCRIPT.parent / "processor_asset_preflight.py", self.seed / "scripts" / "processor_asset_preflight.py")
+		shutil.copy2(SCRIPT.parents[1] / "shared" / "operator_env.py", self.seed / "shared" / "operator_env.py")
+		shutil.copy2(SCRIPT.parents[1] / "shared" / "asset_manifest.py", self.seed / "shared" / "asset_manifest.py")
 		git(self.seed, "add", ".")
 		git(self.seed, "commit", "-m", "initial")
 		git(self.seed, "remote", "add", "origin", str(self.origin))
@@ -94,6 +99,9 @@ class DeployHarness:
 			"fi\n"
 			"if echo \"$@\" | grep -q activation-ready; then\n"
 			"  exit \"${PROCESSOR_TEST_ACTIVATION_READY:-1}\"\n"
+			"fi\n"
+			"if echo \"$@\" | grep -q asset-recovery-ready; then\n"
+			"  exit \"${PROCESSOR_TEST_ASSET_RECOVERY_READY:-1}\"\n"
 			"fi\n"
 			"if echo \"$@\" | grep -q worker-health; then\n"
 			"  if [ -e \"${PROCESSOR_TEST_UNHEALTHY_PATH:-}\" ]; then exit 1; fi\n"
@@ -159,15 +167,12 @@ class DeployHarness:
 
 	@staticmethod
 	def _write_asset_fixtures(repo: Path) -> None:
-		for relative in (
-			"models/segformer_b5_full_epoch_100.safetensors",
-			"models/ckpt_weighted_brownweight15_goldentestweight7.safetensors",
-			"models/b1_50epoch_best_macro_f1.safetensors",
-			"gadm/gadm_410.gpkg",
-			"biom/terres_ecosystems.gpkg",
-			"pheno/modispheno_aggregated_normalized_filled.zarr/.zgroup",
-		):
+		for relative in required_processor_asset_files():
 			path = repo / "assets" / relative
+			path.parent.mkdir(parents=True, exist_ok=True)
+			path.write_text("fixture\n")
+		for relative in required_processor_asset_directories():
+			path = repo / "assets" / relative / ".fixture"
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 
@@ -238,6 +243,24 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 				git(harness.worktree, "rev-parse", "HEAD").stdout.strip(),
 				git(harness.upstream, "rev-parse", "HEAD").stdout.strip(),
 			)
+
+	def test_restored_assets_clear_asset_loss_drain_after_resume(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			self.assertEqual(harness.run_deploy().returncode, 0)
+			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model.unlink()
+
+			self.assertNotEqual(harness.run_deploy().returncode, 0)
+			model.write_text("restored\n")
+			self.assertEqual(harness.run_deploy("--resume").returncode, 0)
+			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_READY"] = "0"
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertIn("asset-recovery-ready", harness.python_log.read_text())
+			self.assertIn("clear-drain", harness.python_log.read_text())
 
 	def test_target_release_runs_its_activation_logic_before_marking_active(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -1,15 +1,21 @@
+import itertools
 import json
+import math
 import os
 import shutil
+import sqlite3
 import stat
 import struct
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 
 from shared.asset_manifest import (
+	GEOPACKAGE_SPECS,
+	PHENOLOGY_ARRAY_SPECS,
 	processor_model_checkpoint_specs,
 	required_processor_asset_directories,
 	required_processor_asset_files,
@@ -187,12 +193,28 @@ class DeployHarness:
 					{name: {"dtype": "F32", "shape": [0], "data_offsets": [0, 0]} for name in names}
 				).encode()
 				path.write_bytes(struct.pack("<Q", len(header)) + header)
+			elif path.suffix == ".gpkg":
+				layer, required_columns = GEOPACKAGE_SPECS[relative]
+				with closing(sqlite3.connect(path)) as database:
+					with database:
+						database.execute("CREATE TABLE gpkg_contents (table_name TEXT)")
+						database.execute("INSERT INTO gpkg_contents VALUES (?)", (layer,))
+						columns = ", ".join(f'"{column}" TEXT' for column in required_columns)
+						database.execute(f'CREATE TABLE "{layer}" ({columns})')
+			elif path.name == ".zarray":
+				shape, chunks, _ = PHENOLOGY_ARRAY_SPECS[path.parent.name]
+				path.write_text(json.dumps({"shape": shape, "chunks": chunks}))
 			else:
 				path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
-			path = repo / "assets" / relative / "0"
-			path.parent.mkdir(parents=True, exist_ok=True)
-			path.write_text("fixture\n")
+			array_dir = repo / "assets" / relative
+			shape, chunks, omitted_chunks = PHENOLOGY_ARRAY_SPECS[array_dir.name]
+			for coordinates in itertools.product(*(range(math.ceil(size / chunk)) for size, chunk in zip(shape, chunks))):
+				path = array_dir / ".".join(map(str, coordinates))
+				if path.name in omitted_chunks:
+					continue
+				path.parent.mkdir(parents=True, exist_ok=True)
+				path.write_text("fixture\n")
 
 	def push_change(self, text: str) -> str:
 		(self.upstream / "README.md").write_text(text)

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -57,10 +58,11 @@ class DeployHarness:
 		(self.seed / "scripts" / "lib").mkdir()
 		(self.seed / "README.md").write_text("initial\n")
 		(self.seed / "docker-compose.processor.yaml").write_text("services: {}\n")
-		(self.seed / ".gitignore").write_text("/.local\n.env\n")
+		(self.seed / ".gitignore").write_text("/.local\n/assets\n.env\n")
 		shutil.copy2(SCRIPT, self.seed / "scripts" / "processor_auto_deploy.sh")
 		shutil.copy2(SCRIPT.parent / "lib" / "processor_runtime.sh", self.seed / "scripts" / "lib" / "processor_runtime.sh")
 		(self.seed / "scripts" / "processor_runtime_control.py").write_text("# test stub\n")
+		shutil.copy2(SCRIPT.parent / "processor_asset_preflight.py", self.seed / "scripts" / "processor_asset_preflight.py")
 		git(self.seed, "add", ".")
 		git(self.seed, "commit", "-m", "initial")
 		git(self.seed, "remote", "add", "origin", str(self.origin))
@@ -71,12 +73,14 @@ class DeployHarness:
 		for repo in (self.worktree, self.upstream):
 			git(repo, "config", "user.name", "DeadTrees Tests")
 			git(repo, "config", "user.email", "tests@deadtrees.example")
+			self._write_asset_fixtures(repo)
 
 		self.bin_dir.mkdir()
 		make_executable(
 			self.bin_dir / "python3",
 			"#!/bin/sh\n"
 			f"echo \"$@\" >> {self.python_log}\n"
+			f"if echo \"$@\" | grep -q processor_asset_preflight.py; then exec {sys.executable} \"$@\"; fi\n"
 			"if echo \"$@\" | grep -q wait-for-idle; then\n"
 			f"  if ( : <&9 ) 2>/dev/null; then echo \"inherited $*\" >> {self.waiter_fd_log}; else echo \"closed $*\" >> {self.waiter_fd_log}; fi\n"
 			"fi\n"
@@ -153,6 +157,20 @@ class DeployHarness:
 		self.env["PROCESSOR_STARTUP_TIMEOUT_SECONDS"] = "2"
 		self.env["PROCESSOR_TEST_UNHEALTHY_PATH"] = str(self.unhealthy_marker)
 
+	@staticmethod
+	def _write_asset_fixtures(repo: Path) -> None:
+		for relative in (
+			"models/segformer_b5_full_epoch_100.safetensors",
+			"models/ckpt_weighted_brownweight15_goldentestweight7.safetensors",
+			"models/b1_50epoch_best_macro_f1.safetensors",
+			"gadm/gadm_410.gpkg",
+			"biom/terres_ecosystems.gpkg",
+			"pheno/modispheno_aggregated_normalized_filled.zarr/.zgroup",
+		):
+			path = repo / "assets" / relative
+			path.parent.mkdir(parents=True, exist_ok=True)
+			path.write_text("fixture\n")
+
 	def push_change(self, text: str) -> str:
 		(self.upstream / "README.md").write_text(text)
 		git(self.upstream, "add", "README.md")
@@ -175,6 +193,33 @@ class DeployHarness:
 
 
 class ProcessorAutoDeployTest(unittest.TestCase):
+	def test_missing_assets_drains_and_pauses_before_docker_activation(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			(harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors").unlink()
+
+			result = harness.run_deploy()
+
+			self.assertNotEqual(result.returncode, 0)
+			self.assertTrue((harness.worktree / ".local" / "processor-deploy-paused").exists())
+			self.assertIn("set-drain --reason required processor assets missing", harness.python_log.read_text())
+			docker_log = harness.docker_log.read_text() if harness.docker_log.exists() else ""
+			self.assertNotIn(" build ", docker_log)
+			self.assertNotIn(" up ", docker_log)
+
+	def test_external_assets_directory_passes_preflight(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			external_assets = harness.tmp_path / "shared-assets"
+			shutil.copytree(harness.worktree / "assets", external_assets)
+			shutil.rmtree(harness.worktree / "assets")
+			(harness.worktree / ".env").write_text(f"PROCESSOR_ASSETS_DIR={external_assets}\n")
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertIn(" build ", harness.docker_log.read_text())
+
 	def test_target_release_runs_its_activation_logic_before_marking_active(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			harness = DeployHarness(Path(tmp_dir))
@@ -242,7 +287,7 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			result = harness.run_deploy()
 
 			self.assertNotEqual(result.returncode, 0)
-			self.assertFalse(harness.python_log.exists())
+			self.assertNotIn("set-drain", harness.python_log.read_text())
 			self.assertIn(
 				"Refusing deploy because HEAD contains local commits outside origin/main",
 				(harness.worktree / "auto-deploy.log").read_text(),

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -58,10 +58,10 @@ class DeployHarness:
 		(self.seed / "scripts" / "lib").mkdir()
 		(self.seed / "README.md").write_text("initial\n")
 		(self.seed / "docker-compose.processor.yaml").write_text("services: {}\n")
-		(self.seed / ".gitignore").write_text("/.local\n/assets\n.env\n")
+		(self.seed / ".gitignore").write_text("/.local\n/assets\n.env\n__pycache__/\n")
 		shutil.copy2(SCRIPT, self.seed / "scripts" / "processor_auto_deploy.sh")
 		shutil.copy2(SCRIPT.parent / "lib" / "processor_runtime.sh", self.seed / "scripts" / "lib" / "processor_runtime.sh")
-		(self.seed / "scripts" / "processor_runtime_control.py").write_text("# test stub\n")
+		shutil.copy2(SCRIPT.parent / "processor_runtime_control.py", self.seed / "scripts" / "processor_runtime_control.py")
 		shutil.copy2(SCRIPT.parent / "processor_asset_preflight.py", self.seed / "scripts" / "processor_asset_preflight.py")
 		git(self.seed, "add", ".")
 		git(self.seed, "commit", "-m", "initial")
@@ -213,12 +213,31 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			external_assets = harness.tmp_path / "shared-assets"
 			shutil.copytree(harness.worktree / "assets", external_assets)
 			shutil.rmtree(harness.worktree / "assets")
-			(harness.worktree / ".env").write_text(f"PROCESSOR_ASSETS_DIR={external_assets}\n")
+			harness.env["ASSET_ROOT"] = str(harness.tmp_path)
+			(harness.worktree / ".env").write_text("PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/shared-assets\n")
 
 			result = harness.run_deploy()
 
 			self.assertEqual(result.returncode, 0, result.stderr)
 			self.assertIn(" build ", harness.docker_log.read_text())
+
+	def test_target_release_can_remove_an_obsolete_asset_requirement(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			(harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors").unlink()
+			target_preflight = harness.upstream / "scripts" / "processor_asset_preflight.py"
+			target_preflight.write_text("raise SystemExit(0)\n")
+			git(harness.upstream, "add", "scripts/processor_asset_preflight.py")
+			git(harness.upstream, "commit", "-m", "remove obsolete asset requirement")
+			git(harness.upstream, "push", "origin", "main")
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertEqual(
+				git(harness.worktree, "rev-parse", "HEAD").stdout.strip(),
+				git(harness.upstream, "rev-parse", "HEAD").stdout.strip(),
+			)
 
 	def test_target_release_runs_its_activation_logic_before_marking_active(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -287,7 +306,8 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			result = harness.run_deploy()
 
 			self.assertNotEqual(result.returncode, 0)
-			self.assertNotIn("set-drain", harness.python_log.read_text())
+			python_log = harness.python_log.read_text() if harness.python_log.exists() else ""
+			self.assertNotIn("set-drain", python_log)
 			self.assertIn(
 				"Refusing deploy because HEAD contains local commits outside origin/main",
 				(harness.worktree / "auto-deploy.log").read_text(),

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -1,13 +1,19 @@
+import json
 import os
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from shared.asset_manifest import required_processor_asset_directories, required_processor_asset_files
+from shared.asset_manifest import (
+	processor_model_checkpoint_specs,
+	required_processor_asset_directories,
+	required_processor_asset_files,
+)
 
 
 SCRIPT = Path(__file__).parents[1] / "processor_auto_deploy.sh"
@@ -174,7 +180,15 @@ class DeployHarness:
 		for relative in required_processor_asset_files():
 			path = repo / "assets" / relative
 			path.parent.mkdir(parents=True, exist_ok=True)
-			path.write_text("fixture\n")
+			if path.suffix == ".safetensors":
+				minimum_tensors, required_tensors = processor_model_checkpoint_specs()[path.name]
+				names = [*required_tensors, *(f"fixture.{index}" for index in range(minimum_tensors))]
+				header = json.dumps(
+					{name: {"dtype": "F32", "shape": [0], "data_offsets": [0, 0]} for name in names}
+				).encode()
+				path.write_bytes(struct.pack("<Q", len(header)) + header)
+			else:
+				path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
 			path = repo / "assets" / relative / "0"
 			path.parent.mkdir(parents=True, exist_ok=True)
@@ -270,10 +284,11 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			harness = DeployHarness(Path(tmp_dir))
 			self.assertEqual(harness.run_deploy().returncode, 0)
 			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model_bytes = model.read_bytes()
 			model.unlink()
 
 			self.assertNotEqual(harness.run_deploy().returncode, 0)
-			model.write_text("restored\n")
+			model.write_bytes(model_bytes)
 			self.assertEqual(harness.run_deploy("--resume").returncode, 0)
 			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_PENDING"] = "0"
 
@@ -289,10 +304,11 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			harness = DeployHarness(Path(tmp_dir))
 			self.assertEqual(harness.run_deploy().returncode, 0)
 			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model_bytes = model.read_bytes()
 			model.unlink()
 
 			self.assertNotEqual(harness.run_deploy().returncode, 0)
-			model.write_text("restored\n")
+			model.write_bytes(model_bytes)
 			harness.docker_running.unlink()
 			self.assertEqual(harness.run_deploy("--resume").returncode, 0)
 			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_PENDING"] = "0"
@@ -310,13 +326,14 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			self.assertEqual(harness.run_deploy().returncode, 0)
 			harness.env["PROCESSOR_TEST_OPERATOR_DRAIN"] = "1"
 			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model_bytes = model.read_bytes()
 			model.unlink()
 			harness.docker_running.unlink()
 			up_count = harness.docker_log.read_text().count("up -d")
 			clear_count = harness.python_log.read_text().count("clear-drain")
 
 			self.assertNotEqual(harness.run_deploy().returncode, 0)
-			model.write_text("restored\n")
+			model.write_bytes(model_bytes)
 			result = harness.run_deploy()
 
 			self.assertEqual(result.returncode, 0, result.stderr)

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -100,8 +100,8 @@ class DeployHarness:
 			"if echo \"$@\" | grep -q activation-ready; then\n"
 			"  exit \"${PROCESSOR_TEST_ACTIVATION_READY:-1}\"\n"
 			"fi\n"
-			"if echo \"$@\" | grep -q asset-recovery-ready; then\n"
-			"  exit \"${PROCESSOR_TEST_ASSET_RECOVERY_READY:-1}\"\n"
+			"if echo \"$@\" | grep -q asset-recovery-pending; then\n"
+			"  exit \"${PROCESSOR_TEST_ASSET_RECOVERY_PENDING:-1}\"\n"
 			"fi\n"
 			"if echo \"$@\" | grep -q worker-health; then\n"
 			"  if [ -e \"${PROCESSOR_TEST_UNHEALTHY_PATH:-}\" ]; then exit 1; fi\n"
@@ -172,7 +172,7 @@ class DeployHarness:
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
-			path = repo / "assets" / relative / ".fixture"
+			path = repo / "assets" / relative / "0"
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 
@@ -226,6 +226,21 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			self.assertEqual(result.returncode, 0, result.stderr)
 			self.assertIn(" build ", harness.docker_log.read_text())
 
+	def test_external_assets_directory_expands_same_file_variable(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			external_assets = harness.tmp_path / "shared-assets"
+			shutil.copytree(harness.worktree / "assets", external_assets)
+			shutil.rmtree(harness.worktree / "assets")
+			(harness.worktree / ".env").write_text(
+				f"ASSET_ROOT={harness.tmp_path}\nPROCESSOR_ASSETS_DIR=${{ASSET_ROOT}}/shared-assets\n"
+			)
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertIn(" build ", harness.docker_log.read_text())
+
 	def test_target_release_can_remove_an_obsolete_asset_requirement(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			harness = DeployHarness(Path(tmp_dir))
@@ -254,12 +269,33 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			self.assertNotEqual(harness.run_deploy().returncode, 0)
 			model.write_text("restored\n")
 			self.assertEqual(harness.run_deploy("--resume").returncode, 0)
-			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_READY"] = "0"
+			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_PENDING"] = "0"
 
 			result = harness.run_deploy()
 
 			self.assertEqual(result.returncode, 0, result.stderr)
-			self.assertIn("asset-recovery-ready", harness.python_log.read_text())
+			self.assertIn("asset-recovery-pending", harness.python_log.read_text())
+			self.assertIn("clear-drain", harness.python_log.read_text())
+			self.assertIn("up -d --force-recreate processor", harness.docker_log.read_text())
+
+	def test_restored_assets_recover_when_worker_is_unavailable(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			self.assertEqual(harness.run_deploy().returncode, 0)
+			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model.unlink()
+
+			self.assertNotEqual(harness.run_deploy().returncode, 0)
+			model.write_text("restored\n")
+			harness.docker_running.unlink()
+			self.assertEqual(harness.run_deploy("--resume").returncode, 0)
+			harness.env["PROCESSOR_TEST_ASSET_RECOVERY_PENDING"] = "0"
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertIn("wait-for-idle --allow-unacknowledged-stopped-worker", harness.python_log.read_text())
+			self.assertIn("up -d --force-recreate processor", harness.docker_log.read_text())
 			self.assertIn("clear-drain", harness.python_log.read_text())
 
 	def test_target_release_runs_its_activation_logic_before_marking_active(self) -> None:

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -14,8 +14,10 @@ from contextlib import closing
 from pathlib import Path
 
 from shared.asset_manifest import (
+	AOI_V1_MODEL_CHECKPOINT_NAME,
 	GEOPACKAGE_SPECS,
 	PHENOLOGY_ARRAY_SPECS,
+	PHENOLOGY_ASSET_PATH,
 	processor_model_checkpoint_specs,
 	required_processor_asset_directories,
 	required_processor_asset_files,
@@ -206,6 +208,16 @@ class DeployHarness:
 				path.write_text(json.dumps({"shape": shape, "chunks": chunks}))
 			else:
 				path.write_text("fixture\n")
+		consolidated_metadata = {".zgroup": {"zarr_format": 2}, ".zattrs": {}}
+		for name, (shape, _, _) in PHENOLOGY_ARRAY_SPECS.items():
+			array_dir = repo / "assets" / "pheno/modispheno_aggregated_normalized_filled.zarr" / name
+			consolidated_metadata[f"{name}/.zarray"] = json.loads((array_dir / ".zarray").read_text())
+			consolidated_metadata[f"{name}/.zattrs"] = {
+				"_ARRAY_DIMENSIONS": [f"dimension_{index}" for index in range(len(shape))]
+			}
+		(repo / "assets/pheno/modispheno_aggregated_normalized_filled.zarr/.zmetadata").write_text(
+			json.dumps({"metadata": consolidated_metadata, "zarr_consolidated_format": 1})
+		)
 		for relative in required_processor_asset_directories():
 			array_dir = repo / "assets" / relative
 			shape, chunks, omitted_chunks = PHENOLOGY_ARRAY_SPECS[array_dir.name]
@@ -251,6 +263,27 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			docker_log = harness.docker_log.read_text() if harness.docker_log.exists() else ""
 			self.assertNotIn(" build ", docker_log)
 			self.assertNotIn(" up ", docker_log)
+
+	def test_corrupt_consolidated_zarr_metadata_blocks_activation(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			(harness.worktree / 'assets' / PHENOLOGY_ASSET_PATH / '.zmetadata').write_text('not-json')
+
+			result = harness.run_deploy()
+
+			self.assertNotEqual(result.returncode, 0)
+			self.assertIn("set-drain --reason required processor assets missing", harness.python_log.read_text())
+
+	def test_blacklisted_model_stage_does_not_block_activation(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			(harness.worktree / 'assets/models' / AOI_V1_MODEL_CHECKPOINT_NAME).unlink()
+			harness.env['PROCESSOR_TASK_BLACKLIST'] = 'aoi_v1'
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertIn(" build ", harness.docker_log.read_text())
 
 	def test_external_assets_directory_passes_preflight(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -59,6 +59,7 @@ class DeployHarness:
 		self.python_log = tmp_path / "python.log"
 		self.docker_log = tmp_path / "docker.log"
 		self.docker_running = tmp_path / "docker-running"
+		self.asset_mount = tmp_path / "docker-asset-mount"
 		self.inspect_failed_once = tmp_path / "inspect-failed-once"
 		self.build_failed_once = tmp_path / "build-failed-once"
 		self.activation_write_failed_once = tmp_path / "activation-write-failed-once"
@@ -93,6 +94,7 @@ class DeployHarness:
 			git(repo, "config", "user.name", "DeadTrees Tests")
 			git(repo, "config", "user.email", "tests@deadtrees.example")
 			self._write_asset_fixtures(repo)
+		self.asset_mount.write_text(str((self.worktree / "assets").resolve()))
 
 		self.bin_dir.mkdir()
 		make_executable(
@@ -150,6 +152,10 @@ class DeployHarness:
 			"  exit 0\n"
 			"fi\n"
 			"if [ \"$1\" = inspect ]; then\n"
+			"  if echo \"$*\" | grep -q '\\.Mounts'; then\n"
+			f"    cat {self.asset_mount}\n"
+			"    exit 0\n"
+			"  fi\n"
 			f"  if [ -n \"${{PROCESSOR_TEST_INSPECT_FAIL_ONCE:-}}\" ] && [ ! -e {self.inspect_failed_once} ]; then\n"
 			f"    touch {self.inspect_failed_once}\n"
 			"    exit 1\n"
@@ -162,6 +168,7 @@ class DeployHarness:
 			"fi\n"
 			"if [ \"$1\" = compose ] && echo \"$@\" | grep -q ' up '; then\n"
 			f"  touch {self.docker_running}\n"
+			f"  printf '%s' \"${{PROCESSOR_ASSETS_DIR:-{(self.worktree / 'assets').resolve()}}}\" > {self.asset_mount}\n"
 			"fi\n"
 			"if [ \"$1\" = compose ] && echo \"$@\" | grep -q ' build ' && "
 			f"[ -n \"${{PROCESSOR_TEST_BUILD_FAIL_ONCE:-}}\" ] && [ ! -e {self.build_failed_once} ]; then\n"
@@ -315,6 +322,22 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 
 			self.assertEqual(result.returncode, 0, result.stderr)
 			self.assertIn(" build ", harness.docker_log.read_text())
+
+	def test_no_change_asset_mount_migration_recreates_worker(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			self.assertEqual(harness.run_deploy().returncode, 0)
+			external_assets = harness.tmp_path / 'replacement-assets'
+			shutil.copytree(harness.worktree / 'assets', external_assets)
+			harness.env['PROCESSOR_ASSETS_DIR'] = str(external_assets)
+			before = harness.docker_log.read_text().count('up -d --force-recreate processor')
+
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertEqual(harness.docker_log.read_text().count('up -d --force-recreate processor'), before + 1)
+			self.assertEqual(harness.asset_mount.read_text(), str(external_assets))
+			self.assertIn('clear-drain', harness.python_log.read_text())
 
 	def test_target_release_can_remove_an_obsolete_asset_requirement(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/tests/test_processor_auto_deploy.py
+++ b/scripts/tests/test_processor_auto_deploy.py
@@ -97,6 +97,10 @@ class DeployHarness:
 			"if echo \"$@\" | grep -q clear-ack && [ -n \"${PROCESSOR_TEST_ACK_PATH:-}\" ]; then\n"
 			"  rm -f \"$PROCESSOR_TEST_ACK_PATH\"\n"
 			"fi\n"
+			"if echo \"$@\" | grep -q 'set-drain.*--preserve-operator-drain' && "
+			"[ -n \"${PROCESSOR_TEST_OPERATOR_DRAIN:-}\" ]; then\n"
+			"  exit 3\n"
+			"fi\n"
 			"if echo \"$@\" | grep -q activation-ready; then\n"
 			"  exit \"${PROCESSOR_TEST_ACTIVATION_READY:-1}\"\n"
 			"fi\n"
@@ -219,7 +223,9 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			shutil.copytree(harness.worktree / "assets", external_assets)
 			shutil.rmtree(harness.worktree / "assets")
 			harness.env["ASSET_ROOT"] = str(harness.tmp_path)
-			(harness.worktree / ".env").write_text("PROCESSOR_ASSETS_DIR=${ASSET_ROOT}/shared-assets\n")
+			(harness.worktree / ".env").write_text(
+				"ASSET_ROOT=/stale/path\nPROCESSOR_ASSETS_DIR=${ASSET_ROOT}/shared-assets\n"
+			)
 
 			result = harness.run_deploy()
 
@@ -297,6 +303,26 @@ class ProcessorAutoDeployTest(unittest.TestCase):
 			self.assertIn("wait-for-idle --allow-unacknowledged-stopped-worker", harness.python_log.read_text())
 			self.assertIn("up -d --force-recreate processor", harness.docker_log.read_text())
 			self.assertIn("clear-drain", harness.python_log.read_text())
+
+	def test_restored_assets_preserve_planned_shutdown(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = DeployHarness(Path(tmp_dir))
+			self.assertEqual(harness.run_deploy().returncode, 0)
+			harness.env["PROCESSOR_TEST_OPERATOR_DRAIN"] = "1"
+			model = harness.worktree / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors"
+			model.unlink()
+			harness.docker_running.unlink()
+			up_count = harness.docker_log.read_text().count("up -d")
+			clear_count = harness.python_log.read_text().count("clear-drain")
+
+			self.assertNotEqual(harness.run_deploy().returncode, 0)
+			model.write_text("restored\n")
+			result = harness.run_deploy()
+
+			self.assertEqual(result.returncode, 0, result.stderr)
+			self.assertEqual(harness.docker_log.read_text().count("up -d"), up_count)
+			self.assertEqual(harness.python_log.read_text().count("clear-drain"), clear_count)
+			self.assertFalse(harness.docker_running.exists())
 
 	def test_target_release_runs_its_activation_logic_before_marking_active(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -143,6 +143,10 @@ class ProcessorDockerMaintenanceTest(unittest.TestCase):
 
 			self.assertNotEqual(result.returncode, 0)
 			self.assertIn("set-drain --reason docker-maintenance", harness.python_log.read_text())
+			self.assertIn(
+				"set-drain --reason required processor assets missing --preserve-operator-drain",
+				harness.python_log.read_text(),
+			)
 			docker_log = harness.docker_log.read_text()
 			self.assertNotIn("stop processor", docker_log)
 			self.assertNotIn("up -d processor", docker_log)

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -118,7 +118,7 @@ class MaintenanceHarness:
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
-			path = self.repo / "assets" / relative / ".fixture"
+			path = self.repo / "assets" / relative / "0"
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -148,6 +148,16 @@ class MaintenanceHarness:
 				path.write_text(json.dumps({"shape": shape, "chunks": chunks}))
 			else:
 				path.write_text("fixture\n")
+		consolidated_metadata = {".zgroup": {"zarr_format": 2}, ".zattrs": {}}
+		for name, (shape, _, _) in PHENOLOGY_ARRAY_SPECS.items():
+			array_dir = self.repo / "assets" / "pheno/modispheno_aggregated_normalized_filled.zarr" / name
+			consolidated_metadata[f"{name}/.zarray"] = json.loads((array_dir / ".zarray").read_text())
+			consolidated_metadata[f"{name}/.zattrs"] = {
+				"_ARRAY_DIMENSIONS": [f"dimension_{index}" for index in range(len(shape))]
+			}
+		(self.repo / "assets/pheno/modispheno_aggregated_normalized_filled.zarr/.zmetadata").write_text(
+			json.dumps({"metadata": consolidated_metadata, "zarr_consolidated_format": 1})
+		)
 		for relative in required_processor_asset_directories():
 			array_dir = self.repo / "assets" / relative
 			shape, chunks, omitted_chunks = PHENOLOGY_ARRAY_SPECS[array_dir.name]

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -1,15 +1,21 @@
+import itertools
 import json
+import math
 import os
 import shutil
+import sqlite3
 import stat
 import struct
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 
 from shared.asset_manifest import (
+	GEOPACKAGE_SPECS,
+	PHENOLOGY_ARRAY_SPECS,
 	processor_model_checkpoint_specs,
 	required_processor_asset_directories,
 	required_processor_asset_files,
@@ -129,12 +135,28 @@ class MaintenanceHarness:
 					{name: {"dtype": "F32", "shape": [0], "data_offsets": [0, 0]} for name in names}
 				).encode()
 				path.write_bytes(struct.pack("<Q", len(header)) + header)
+			elif path.suffix == ".gpkg":
+				layer, required_columns = GEOPACKAGE_SPECS[relative]
+				with closing(sqlite3.connect(path)) as database:
+					with database:
+						database.execute("CREATE TABLE gpkg_contents (table_name TEXT)")
+						database.execute("INSERT INTO gpkg_contents VALUES (?)", (layer,))
+						columns = ", ".join(f'"{column}" TEXT' for column in required_columns)
+						database.execute(f'CREATE TABLE "{layer}" ({columns})')
+			elif path.name == ".zarray":
+				shape, chunks, _ = PHENOLOGY_ARRAY_SPECS[path.parent.name]
+				path.write_text(json.dumps({"shape": shape, "chunks": chunks}))
 			else:
 				path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
-			path = self.repo / "assets" / relative / "0"
-			path.parent.mkdir(parents=True, exist_ok=True)
-			path.write_text("fixture\n")
+			array_dir = self.repo / "assets" / relative
+			shape, chunks, omitted_chunks = PHENOLOGY_ARRAY_SPECS[array_dir.name]
+			for coordinates in itertools.product(*(range(math.ceil(size / chunk)) for size, chunk in zip(shape, chunks))):
+				path = array_dir / ".".join(map(str, coordinates))
+				if path.name in omitted_chunks:
+					continue
+				path.parent.mkdir(parents=True, exist_ok=True)
+				path.write_text("fixture\n")
 
 	def run(self, *args: str) -> subprocess.CompletedProcess[str]:
 		return run(

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -35,10 +35,11 @@ class MaintenanceHarness:
 		(self.repo / "scripts").mkdir()
 		(self.repo / "scripts" / "lib").mkdir()
 		(self.repo / "docker-compose.processor.yaml").write_text("services: {}\n")
-		(self.repo / ".gitignore").write_text("/.local\n")
+		(self.repo / ".gitignore").write_text("/.local\n/assets\n__pycache__/\n")
 		shutil.copy2(SCRIPT, self.repo / "scripts" / "processor_docker_maintenance.sh")
 		shutil.copy2(SCRIPT.parent / "lib" / "processor_runtime.sh", self.repo / "scripts" / "lib" / "processor_runtime.sh")
-		(self.repo / "scripts" / "processor_runtime_control.py").write_text("# test stub\n")
+		shutil.copy2(SCRIPT.parent / "processor_runtime_control.py", self.repo / "scripts" / "processor_runtime_control.py")
+		shutil.copy2(SCRIPT.parent / "processor_asset_preflight.py", self.repo / "scripts" / "processor_asset_preflight.py")
 		run("git", "init", "--initial-branch=main", cwd=self.repo)
 		run("git", "config", "user.name", "DeadTrees Tests", cwd=self.repo)
 		run("git", "config", "user.email", "tests@deadtrees.example", cwd=self.repo)
@@ -47,6 +48,7 @@ class MaintenanceHarness:
 		(self.repo / ".local").mkdir()
 		activated_sha = run("git", "rev-parse", "HEAD", cwd=self.repo).stdout.strip()
 		(self.repo / ".local" / "processor-activated-sha").write_text(f"{activated_sha}\n")
+		self._write_asset_fixtures()
 
 		self.bin_dir.mkdir()
 		make_executable(self.bin_dir / "flock", "#!/bin/sh\nexit 0\n")
@@ -65,6 +67,7 @@ class MaintenanceHarness:
 		make_executable(
 			self.bin_dir / "python3",
 			f"#!/bin/sh\necho \"$@\" >> {self.python_log}\n"
+			f"if echo \"$@\" | grep -q processor_asset_preflight.py; then exec {sys.executable} \"$@\"; fi\n"
 			"if echo \"$@\" | grep -q clear-ack && [ -n \"${PROCESSOR_TEST_ACK_PATH:-}\" ]; then\n"
 			"  rm -f \"$PROCESSOR_TEST_ACK_PATH\"\n"
 			"fi\n"
@@ -104,6 +107,19 @@ class MaintenanceHarness:
 		self.env["PROCESSOR_STARTUP_TIMEOUT_SECONDS"] = "2"
 		self.env["PROCESSOR_SNAP_CONTROL"] = str(self.bin_dir / "snap-control")
 
+	def _write_asset_fixtures(self) -> None:
+		for relative in (
+			"models/segformer_b5_full_epoch_100.safetensors",
+			"models/ckpt_weighted_brownweight15_goldentestweight7.safetensors",
+			"models/b1_50epoch_best_macro_f1.safetensors",
+			"gadm/gadm_410.gpkg",
+			"biom/terres_ecosystems.gpkg",
+			"pheno/modispheno_aggregated_normalized_filled.zarr/.zgroup",
+		):
+			path = self.repo / "assets" / relative
+			path.parent.mkdir(parents=True, exist_ok=True)
+			path.write_text("fixture\n")
+
 	def run(self, *args: str) -> subprocess.CompletedProcess[str]:
 		return run(
 			"bash",
@@ -116,6 +132,19 @@ class MaintenanceHarness:
 
 
 class ProcessorDockerMaintenanceTest(unittest.TestCase):
+	def test_missing_assets_leave_worker_drained_without_restart(self) -> None:
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			harness = MaintenanceHarness(Path(tmp_dir), processor_available=True)
+			(harness.repo / "assets" / "models" / "segformer_b5_full_epoch_100.safetensors").unlink()
+
+			result = harness.run()
+
+			self.assertNotEqual(result.returncode, 0)
+			self.assertIn("set-drain --reason docker-maintenance", harness.python_log.read_text())
+			docker_log = harness.docker_log.read_text()
+			self.assertNotIn("stop processor", docker_log)
+			self.assertNotIn("up -d processor", docker_log)
+
 	def test_snap_control_limits_root_action_to_validated_docker_operations(self) -> None:
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			tmp_path = Path(tmp_dir)

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -1,13 +1,19 @@
+import json
 import os
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from shared.asset_manifest import required_processor_asset_directories, required_processor_asset_files
+from shared.asset_manifest import (
+	processor_model_checkpoint_specs,
+	required_processor_asset_directories,
+	required_processor_asset_files,
+)
 
 
 SCRIPT = Path(__file__).parents[1] / "processor_docker_maintenance.sh"
@@ -116,7 +122,15 @@ class MaintenanceHarness:
 		for relative in required_processor_asset_files():
 			path = self.repo / "assets" / relative
 			path.parent.mkdir(parents=True, exist_ok=True)
-			path.write_text("fixture\n")
+			if path.suffix == ".safetensors":
+				minimum_tensors, required_tensors = processor_model_checkpoint_specs()[path.name]
+				names = [*required_tensors, *(f"fixture.{index}" for index in range(minimum_tensors))]
+				header = json.dumps(
+					{name: {"dtype": "F32", "shape": [0], "data_offsets": [0, 0]} for name in names}
+				).encode()
+				path.write_bytes(struct.pack("<Q", len(header)) + header)
+			else:
+				path.write_text("fixture\n")
 		for relative in required_processor_asset_directories():
 			path = self.repo / "assets" / relative / "0"
 			path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tests/test_processor_docker_maintenance.py
+++ b/scripts/tests/test_processor_docker_maintenance.py
@@ -7,6 +7,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from shared.asset_manifest import required_processor_asset_directories, required_processor_asset_files
+
 
 SCRIPT = Path(__file__).parents[1] / "processor_docker_maintenance.sh"
 SNAP_CONTROL_SCRIPT = Path(__file__).parents[1] / "processor_snap_control.sh"
@@ -34,12 +36,15 @@ class MaintenanceHarness:
 		self.repo.mkdir()
 		(self.repo / "scripts").mkdir()
 		(self.repo / "scripts" / "lib").mkdir()
+		(self.repo / "shared").mkdir()
 		(self.repo / "docker-compose.processor.yaml").write_text("services: {}\n")
 		(self.repo / ".gitignore").write_text("/.local\n/assets\n__pycache__/\n")
 		shutil.copy2(SCRIPT, self.repo / "scripts" / "processor_docker_maintenance.sh")
 		shutil.copy2(SCRIPT.parent / "lib" / "processor_runtime.sh", self.repo / "scripts" / "lib" / "processor_runtime.sh")
 		shutil.copy2(SCRIPT.parent / "processor_runtime_control.py", self.repo / "scripts" / "processor_runtime_control.py")
 		shutil.copy2(SCRIPT.parent / "processor_asset_preflight.py", self.repo / "scripts" / "processor_asset_preflight.py")
+		shutil.copy2(SCRIPT.parents[1] / "shared" / "operator_env.py", self.repo / "shared" / "operator_env.py")
+		shutil.copy2(SCRIPT.parents[1] / "shared" / "asset_manifest.py", self.repo / "shared" / "asset_manifest.py")
 		run("git", "init", "--initial-branch=main", cwd=self.repo)
 		run("git", "config", "user.name", "DeadTrees Tests", cwd=self.repo)
 		run("git", "config", "user.email", "tests@deadtrees.example", cwd=self.repo)
@@ -108,15 +113,12 @@ class MaintenanceHarness:
 		self.env["PROCESSOR_SNAP_CONTROL"] = str(self.bin_dir / "snap-control")
 
 	def _write_asset_fixtures(self) -> None:
-		for relative in (
-			"models/segformer_b5_full_epoch_100.safetensors",
-			"models/ckpt_weighted_brownweight15_goldentestweight7.safetensors",
-			"models/b1_50epoch_best_macro_f1.safetensors",
-			"gadm/gadm_410.gpkg",
-			"biom/terres_ecosystems.gpkg",
-			"pheno/modispheno_aggregated_normalized_filled.zarr/.zgroup",
-		):
+		for relative in required_processor_asset_files():
 			path = self.repo / "assets" / relative
+			path.parent.mkdir(parents=True, exist_ok=True)
+			path.write_text("fixture\n")
+		for relative in required_processor_asset_directories():
+			path = self.repo / "assets" / relative / ".fixture"
 			path.parent.mkdir(parents=True, exist_ok=True)
 			path.write_text("fixture\n")
 

--- a/scripts/tests/test_processor_runtime_control.py
+++ b/scripts/tests/test_processor_runtime_control.py
@@ -34,6 +34,23 @@ def test_ack_release_sha_must_match_when_expected():
 	assert not runtime_control._ack_matches_request(request, ack, 'worker-a', 'release-b')
 
 
+def test_asset_recovery_requires_matching_ack_and_no_active_rows(monkeypatch):
+	request = {'request_id': 'request-a', 'requested_at': 'now', 'reason': 'required processor assets missing'}
+	monkeypatch.setattr(runtime_control, '_worker_id', lambda: 'worker-a')
+	monkeypatch.setattr(runtime_control, '_activated_worker_id', lambda: None)
+	monkeypatch.setattr(runtime_control, '_load_drain_state', lambda: (request, _matching_ack()))
+	monkeypatch.setattr(runtime_control, '_fetch_queue_state', lambda worker_id, **kwargs: _state())
+
+	assert runtime_control.cmd_asset_recovery_ready(argparse.Namespace()) == 0
+
+	monkeypatch.setattr(
+		runtime_control,
+		'_fetch_queue_state',
+		lambda worker_id, **kwargs: _state(active_for_worker=[{'id': 123}]),
+	)
+	assert runtime_control.cmd_asset_recovery_ready(argparse.Namespace()) == 1
+
+
 def test_worker_health_rejects_even_malformed_persisted_marker(monkeypatch, tmp_path):
 	marker = tmp_path / 'loop-unhealthy.json'
 	marker.write_text('interrupted write')

--- a/scripts/tests/test_processor_runtime_control.py
+++ b/scripts/tests/test_processor_runtime_control.py
@@ -34,21 +34,13 @@ def test_ack_release_sha_must_match_when_expected():
 	assert not runtime_control._ack_matches_request(request, ack, 'worker-a', 'release-b')
 
 
-def test_asset_recovery_requires_matching_ack_and_no_active_rows(monkeypatch):
+def test_asset_recovery_pending_requires_asset_loss_drain(monkeypatch):
 	request = {'request_id': 'request-a', 'requested_at': 'now', 'reason': 'required processor assets missing'}
-	monkeypatch.setattr(runtime_control, '_worker_id', lambda: 'worker-a')
-	monkeypatch.setattr(runtime_control, '_activated_worker_id', lambda: None)
 	monkeypatch.setattr(runtime_control, '_load_drain_state', lambda: (request, _matching_ack()))
-	monkeypatch.setattr(runtime_control, '_fetch_queue_state', lambda worker_id, **kwargs: _state())
+	assert runtime_control.cmd_asset_recovery_pending(argparse.Namespace()) == 0
 
-	assert runtime_control.cmd_asset_recovery_ready(argparse.Namespace()) == 0
-
-	monkeypatch.setattr(
-		runtime_control,
-		'_fetch_queue_state',
-		lambda worker_id, **kwargs: _state(active_for_worker=[{'id': 123}]),
-	)
-	assert runtime_control.cmd_asset_recovery_ready(argparse.Namespace()) == 1
+	request['reason'] = 'auto-deploy release-a'
+	assert runtime_control.cmd_asset_recovery_pending(argparse.Namespace()) == 1
 
 
 def test_worker_health_rejects_even_malformed_persisted_marker(monkeypatch, tmp_path):

--- a/scripts/tests/test_processor_runtime_control.py
+++ b/scripts/tests/test_processor_runtime_control.py
@@ -43,6 +43,20 @@ def test_asset_recovery_pending_requires_asset_loss_drain(monkeypatch):
 	assert runtime_control.cmd_asset_recovery_pending(argparse.Namespace()) == 1
 
 
+def test_set_drain_preserves_operator_request(monkeypatch):
+	existing = {'request_id': 'operator-request', 'reason': 'planned-shutdown', 'requested_at': 'now'}
+	monkeypatch.setattr(runtime_control, '_load_drain_state', lambda: (existing, _matching_ack()))
+	monkeypatch.setattr(
+		runtime_control,
+		'_write_json',
+		lambda *args: (_ for _ in ()).throw(AssertionError('operator drain was replaced')),
+	)
+
+	args = argparse.Namespace(reason='required processor assets missing', preserve_operator_drain=True)
+
+	assert runtime_control.cmd_set_drain(args) == 3
+
+
 def test_worker_health_rejects_even_malformed_persisted_marker(monkeypatch, tmp_path):
 	marker = tmp_path / 'loop-unhealthy.json'
 	marker.write_text('interrupted write')

--- a/shared/asset_manifest.py
+++ b/shared/asset_manifest.py
@@ -8,7 +8,28 @@ AOI_V1_MODEL_CHECKPOINT_NAME = 'b1_50epoch_best_macro_f1.safetensors'
 GADM_ASSET_PATH = 'gadm/gadm_410.gpkg'
 BIOME_ASSET_PATH = 'biom/terres_ecosystems.gpkg'
 PHENOLOGY_ASSET_PATH = 'pheno/modispheno_aggregated_normalized_filled.zarr'
-PHENOLOGY_ARRAY_NAMES = ('day', 'nan_mask', 'phenology', 'x', 'y')
+GEOPACKAGE_SPECS = {
+	GADM_ASSET_PATH: ('gadm_410', ('geom', 'GID_0', 'NAME_0', 'CONTINENT')),
+	BIOME_ASSET_PATH: ('terres_ecosystems', ('geom', 'ECO_NAME', 'REALM', 'BIOME')),
+}
+PHENOLOGY_ARRAY_SPECS = {
+	'day': ((366,), (366,), ()),
+	'nan_mask': ((1680, 4320), (420, 1080), ()),
+	'phenology': (
+		(1680, 4320, 366),
+		(105, 540, 46),
+		(
+			'14.3.0', '14.3.1', '14.6.0', '14.6.1', '14.6.2', '14.6.7',
+			'15.1.0', '15.1.1', '15.1.2', '15.1.7', '15.2.0', '15.2.1',
+			'15.2.2', '15.2.7', '15.3.0', '15.3.1', '15.3.2', '15.3.7',
+			'15.4.0', '15.4.1', '15.4.2', '15.4.7', '15.5.0', '15.5.1',
+			'15.5.2', '15.5.6', '15.5.7', '15.6.0', '15.6.1', '15.6.2',
+			'15.6.7',
+		),
+	),
+	'x': ((4320,), (4320,), ()),
+	'y': ((1680,), (1680,), ()),
+}
 
 
 def processor_model_checkpoint_specs() -> dict[str, tuple[int, tuple[str, ...]]]:
@@ -22,13 +43,12 @@ def processor_model_checkpoint_specs() -> dict[str, tuple[int, tuple[str, ...]]]
 def required_processor_asset_files() -> tuple[str, ...]:
 	return (
 		*(f'models/{name}' for name in processor_model_checkpoint_specs()),
-		GADM_ASSET_PATH,
-		BIOME_ASSET_PATH,
+		*GEOPACKAGE_SPECS,
 		f'{PHENOLOGY_ASSET_PATH}/.zgroup',
 		f'{PHENOLOGY_ASSET_PATH}/.zmetadata',
-		*(f'{PHENOLOGY_ASSET_PATH}/{name}/.zarray' for name in PHENOLOGY_ARRAY_NAMES),
+		*(f'{PHENOLOGY_ASSET_PATH}/{name}/.zarray' for name in PHENOLOGY_ARRAY_SPECS),
 	)
 
 
 def required_processor_asset_directories() -> tuple[str, ...]:
-	return tuple(f'{PHENOLOGY_ASSET_PATH}/{name}' for name in PHENOLOGY_ARRAY_NAMES)
+	return tuple(f'{PHENOLOGY_ASSET_PATH}/{name}' for name in PHENOLOGY_ARRAY_SPECS)

--- a/shared/asset_manifest.py
+++ b/shared/asset_manifest.py
@@ -9,9 +9,10 @@ GADM_ASSET_PATH = 'gadm/gadm_410.gpkg'
 BIOME_ASSET_PATH = 'biom/terres_ecosystems.gpkg'
 PHENOLOGY_ASSET_PATH = 'pheno/modispheno_aggregated_normalized_filled.zarr'
 GEOPACKAGE_SPECS = {
-	GADM_ASSET_PATH: ('gadm_410', ('geom', 'GID_0', 'NAME_0', 'CONTINENT')),
+	GADM_ASSET_PATH: ('gadm_410', ('geom', 'GID_0', 'NAME_0', 'NAME_2', 'NAME_4', 'CONTINENT')),
 	BIOME_ASSET_PATH: ('terres_ecosystems', ('geom', 'ECO_NAME', 'REALM', 'BIOME')),
 }
+METADATA_TASK_TYPE = 'metadata'
 PHENOLOGY_ARRAY_SPECS = {
 	'day': ((366,), (366,), ()),
 	'nan_mask': ((1680, 4320), (420, 1080), ()),
@@ -32,23 +33,32 @@ PHENOLOGY_ARRAY_SPECS = {
 }
 
 
-def processor_model_checkpoint_specs() -> dict[str, tuple[int, tuple[str, ...]]]:
-	return {
+def processor_model_checkpoint_specs(
+	task_blacklist: set[str] | frozenset[str] = frozenset(),
+) -> dict[str, tuple[int, tuple[str, ...]]]:
+	specs = {
 		DEADWOOD_V1_MODEL_CHECKPOINT_NAME: (1000, ('_orig_mod.decoder.blocks.0.conv1.1.num_batches_tracked',)),
 		COMBINED_MODEL_CHECKPOINT_NAME: (600, ('model.decode_head.batch_norm.bias',)),
 		AOI_V1_MODEL_CHECKPOINT_NAME: (200, ('model.decode_head.batch_norm.bias',)),
 	}
+	tasks = {
+		DEADWOOD_V1_MODEL_CHECKPOINT_NAME: 'deadwood_v1',
+		COMBINED_MODEL_CHECKPOINT_NAME: 'deadwood_treecover_combined_v2',
+		AOI_V1_MODEL_CHECKPOINT_NAME: 'aoi_v1',
+	}
+	return {name: spec for name, spec in specs.items() if tasks[name] not in task_blacklist}
 
 
-def required_processor_asset_files() -> tuple[str, ...]:
-	return (
-		*(f'models/{name}' for name in processor_model_checkpoint_specs()),
-		*GEOPACKAGE_SPECS,
-		f'{PHENOLOGY_ASSET_PATH}/.zgroup',
-		f'{PHENOLOGY_ASSET_PATH}/.zmetadata',
-		*(f'{PHENOLOGY_ASSET_PATH}/{name}/.zarray' for name in PHENOLOGY_ARRAY_SPECS),
-	)
+def required_processor_asset_files(task_blacklist: set[str] | frozenset[str] = frozenset()) -> tuple[str, ...]:
+	files = [f'models/{name}' for name in processor_model_checkpoint_specs(task_blacklist)]
+	if METADATA_TASK_TYPE not in task_blacklist:
+		files.extend(GEOPACKAGE_SPECS)
+		files.extend((f'{PHENOLOGY_ASSET_PATH}/.zgroup', f'{PHENOLOGY_ASSET_PATH}/.zmetadata'))
+		files.extend(f'{PHENOLOGY_ASSET_PATH}/{name}/.zarray' for name in PHENOLOGY_ARRAY_SPECS)
+	return tuple(files)
 
 
-def required_processor_asset_directories() -> tuple[str, ...]:
+def required_processor_asset_directories(task_blacklist: set[str] | frozenset[str] = frozenset()) -> tuple[str, ...]:
+	if METADATA_TASK_TYPE in task_blacklist:
+		return ()
 	return tuple(f'{PHENOLOGY_ASSET_PATH}/{name}' for name in PHENOLOGY_ARRAY_SPECS)

--- a/shared/asset_manifest.py
+++ b/shared/asset_manifest.py
@@ -8,6 +8,7 @@ AOI_V1_MODEL_CHECKPOINT_NAME = 'b1_50epoch_best_macro_f1.safetensors'
 GADM_ASSET_PATH = 'gadm/gadm_410.gpkg'
 BIOME_ASSET_PATH = 'biom/terres_ecosystems.gpkg'
 PHENOLOGY_ASSET_PATH = 'pheno/modispheno_aggregated_normalized_filled.zarr'
+PHENOLOGY_ARRAY_NAMES = ('day', 'nan_mask', 'phenology', 'x', 'y')
 
 
 def required_processor_asset_files() -> tuple[str, ...]:
@@ -17,8 +18,11 @@ def required_processor_asset_files() -> tuple[str, ...]:
 		f'models/{AOI_V1_MODEL_CHECKPOINT_NAME}',
 		GADM_ASSET_PATH,
 		BIOME_ASSET_PATH,
+		f'{PHENOLOGY_ASSET_PATH}/.zgroup',
+		f'{PHENOLOGY_ASSET_PATH}/.zmetadata',
+		*(f'{PHENOLOGY_ASSET_PATH}/{name}/.zarray' for name in PHENOLOGY_ARRAY_NAMES),
 	)
 
 
 def required_processor_asset_directories() -> tuple[str, ...]:
-	return (PHENOLOGY_ASSET_PATH,)
+	return tuple(f'{PHENOLOGY_ASSET_PATH}/{name}' for name in PHENOLOGY_ARRAY_NAMES)

--- a/shared/asset_manifest.py
+++ b/shared/asset_manifest.py
@@ -11,11 +11,17 @@ PHENOLOGY_ASSET_PATH = 'pheno/modispheno_aggregated_normalized_filled.zarr'
 PHENOLOGY_ARRAY_NAMES = ('day', 'nan_mask', 'phenology', 'x', 'y')
 
 
+def processor_model_checkpoint_specs() -> dict[str, tuple[int, tuple[str, ...]]]:
+	return {
+		DEADWOOD_V1_MODEL_CHECKPOINT_NAME: (1000, ('_orig_mod.decoder.blocks.0.conv1.1.num_batches_tracked',)),
+		COMBINED_MODEL_CHECKPOINT_NAME: (600, ('model.decode_head.batch_norm.bias',)),
+		AOI_V1_MODEL_CHECKPOINT_NAME: (200, ('model.decode_head.batch_norm.bias',)),
+	}
+
+
 def required_processor_asset_files() -> tuple[str, ...]:
 	return (
-		f'models/{DEADWOOD_V1_MODEL_CHECKPOINT_NAME}',
-		f'models/{COMBINED_MODEL_CHECKPOINT_NAME}',
-		f'models/{AOI_V1_MODEL_CHECKPOINT_NAME}',
+		*(f'models/{name}' for name in processor_model_checkpoint_specs()),
 		GADM_ASSET_PATH,
 		BIOME_ASSET_PATH,
 		f'{PHENOLOGY_ASSET_PATH}/.zgroup',

--- a/shared/asset_manifest.py
+++ b/shared/asset_manifest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+DEADWOOD_V1_MODEL_CHECKPOINT_NAME = 'segformer_b5_full_epoch_100.safetensors'
+COMBINED_MODEL_CHECKPOINT_NAME = 'ckpt_weighted_brownweight15_goldentestweight7.safetensors'
+AOI_V1_MODEL_CHECKPOINT_NAME = 'b1_50epoch_best_macro_f1.safetensors'
+
+GADM_ASSET_PATH = 'gadm/gadm_410.gpkg'
+BIOME_ASSET_PATH = 'biom/terres_ecosystems.gpkg'
+PHENOLOGY_ASSET_PATH = 'pheno/modispheno_aggregated_normalized_filled.zarr'
+
+
+def required_processor_asset_files() -> tuple[str, ...]:
+	return (
+		f'models/{DEADWOOD_V1_MODEL_CHECKPOINT_NAME}',
+		f'models/{COMBINED_MODEL_CHECKPOINT_NAME}',
+		f'models/{AOI_V1_MODEL_CHECKPOINT_NAME}',
+		GADM_ASSET_PATH,
+		BIOME_ASSET_PATH,
+	)
+
+
+def required_processor_asset_directories() -> tuple[str, ...]:
+	return (PHENOLOGY_ASSET_PATH,)

--- a/shared/models.py
+++ b/shared/models.py
@@ -7,6 +7,11 @@ from pydantic_partial import PartialModelMixin
 from pydantic_settings import BaseSettings
 from rasterio.coords import BoundingBox
 
+from .asset_manifest import (
+	AOI_V1_MODEL_CHECKPOINT_NAME,
+	COMBINED_MODEL_CHECKPOINT_NAME,
+	DEADWOOD_V1_MODEL_CHECKPOINT_NAME,
+)
 from .settings import settings
 
 
@@ -37,7 +42,6 @@ class LabelDataEnum(str, Enum):
 
 
 COMBINED_MODEL_MODULE = 'deadwood_treecover_combined_v2'
-COMBINED_MODEL_CHECKPOINT_NAME = 'ckpt_weighted_brownweight15_goldentestweight7.safetensors'
 COMBINED_MODEL_CONFIG = {
 	'module': COMBINED_MODEL_MODULE,
 	'checkpoint_name': COMBINED_MODEL_CHECKPOINT_NAME,
@@ -45,7 +49,7 @@ COMBINED_MODEL_CONFIG = {
 
 DEADWOOD_V1_MODEL_CONFIG = {
 	'module': 'deadwood_segmentation_v1_moehring',
-	'checkpoint_name': 'segformer_b5_full_epoch_100.safetensors',
+	'checkpoint_name': DEADWOOD_V1_MODEL_CHECKPOINT_NAME,
 }
 
 TREECOVER_V1_MODEL_CONFIG = {
@@ -57,7 +61,6 @@ TREECOVER_V1_MODEL_CONFIG = {
 # polygon per orthomosaic that an auditor reviews/edits before the dataset is
 # audited. SegFormer-B1, binary inside/outside-AOI classification.
 AOI_V1_MODEL_MODULE = 'aoi_segmentation_v1'
-AOI_V1_MODEL_CHECKPOINT_NAME = 'b1_50epoch_best_macro_f1.safetensors'
 AOI_V1_MODEL_CONFIG = {
 	'module': AOI_V1_MODEL_MODULE,
 	'checkpoint_name': AOI_V1_MODEL_CHECKPOINT_NAME,

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from string import Template
 
 
 def load_env_file(path: Path) -> dict[str, str]:
@@ -17,5 +18,5 @@ def load_env_file(path: Path) -> dict[str, str]:
 		value = value.strip()
 		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
 			value = value[1:-1]
-		env[key.strip()] = os.path.expandvars(value)
+		env[key.strip()] = Template(value).safe_substitute({**os.environ, **env})
 	return env

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -5,13 +5,36 @@ import re
 from pathlib import Path
 
 
-ENV_REFERENCE = re.compile(r'(?<!\$)\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))')
+ENV_REFERENCE = re.compile(
+	r'(?<!\$)\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)'
+	r'(?:(?P<operator>:-|-|:\+|\+|:\?|\?)(?P<operand>[^{}]*))?\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))'
+)
 
 
 def _expand_references(value: str, variables: dict[str, str]) -> str:
 	def replace(match: re.Match[str]) -> str:
 		name = match.group('braced') or match.group('plain')
-		return variables.get(name, match.group(0))
+		operator = match.group('operator')
+		operand = match.group('operand') or ''
+		is_set = name in variables
+		value = variables.get(name, '')
+		is_nonempty = is_set and value != ''
+
+		if operator is None:
+			return value
+		if operator == ':-':
+			return value if is_nonempty else _expand_references(operand, variables)
+		if operator == '-':
+			return value if is_set else _expand_references(operand, variables)
+		if operator == ':+':
+			return _expand_references(operand, variables) if is_nonempty else ''
+		if operator == '+':
+			return _expand_references(operand, variables) if is_set else ''
+		if operator == ':?' and not is_nonempty:
+			raise ValueError(operand or f'{name} is required')
+		if operator == '?' and not is_set:
+			raise ValueError(operand or f'{name} is required')
+		return value
 
 	return ENV_REFERENCE.sub(replace, value)
 

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -9,6 +9,7 @@ ENV_REFERENCE = re.compile(
 	r'(?<!\$)\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)'
 	r'(?:(?P<operator>:-|-|:\+|\+|:\?|\?)(?P<operand>[^{}]*))?\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))'
 )
+DOUBLE_QUOTED_ESCAPES = {'n': '\n', 'r': '\r', 't': '\t', '\\': '\\', '"': '"'}
 
 
 def _expand_references(value: str, variables: dict[str, str]) -> str:
@@ -43,11 +44,23 @@ def _parse_value(raw_value: str) -> tuple[str, bool]:
 	value = raw_value.strip()
 	if value.startswith(("'", '"')):
 		quote = value[0]
+		parsed = []
 		escaped = False
-		for index, character in enumerate(value[1:], start=1):
-			if character == quote and not escaped:
-				return value[1:index], quote == "'"
-			escaped = character == '\\' and not escaped
+		for character in value[1:]:
+			if escaped:
+				if quote == '"':
+					parsed.append(DOUBLE_QUOTED_ESCAPES.get(character, f'\\{character}'))
+				else:
+					parsed.append("'" if character == "'" else f'\\{character}')
+				escaped = False
+			elif character == '\\':
+				escaped = True
+			elif character == quote:
+				return ''.join(parsed), quote == "'"
+			else:
+				parsed.append(character)
+		if escaped:
+			parsed.append('\\')
 		return value, False
 	value = re.split(r'\s+#', value, maxsplit=1)[0].rstrip()
 	return value, False

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -16,6 +16,20 @@ def _expand_references(value: str, variables: dict[str, str]) -> str:
 	return ENV_REFERENCE.sub(replace, value)
 
 
+def _parse_value(raw_value: str) -> tuple[str, bool]:
+	value = raw_value.strip()
+	if value.startswith(("'", '"')):
+		quote = value[0]
+		escaped = False
+		for index, character in enumerate(value[1:], start=1):
+			if character == quote and not escaped:
+				return value[1:index], quote == "'"
+			escaped = character == '\\' and not escaped
+		return value, False
+	value = re.split(r'\s+#', value, maxsplit=1)[0].rstrip()
+	return value, False
+
+
 def load_env_file(path: Path) -> dict[str, str]:
 	env: dict[str, str] = {}
 	if not path.exists():
@@ -25,10 +39,7 @@ def load_env_file(path: Path) -> dict[str, str]:
 		line = raw_line.strip()
 		if not line or line.startswith('#') or '=' not in line:
 			continue
-		key, value = line.split('=', 1)
-		value = value.strip()
-		single_quoted = bool(value and value[0] == value[-1] == "'")
-		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
-			value = value[1:-1]
+		key, raw_value = line.split('=', 1)
+		value, single_quoted = _parse_value(raw_value)
 		env[key.strip()] = value if single_quoted else _expand_references(value, {**env, **os.environ})
 	return env

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -27,7 +27,8 @@ def load_env_file(path: Path) -> dict[str, str]:
 			continue
 		key, value = line.split('=', 1)
 		value = value.strip()
+		single_quoted = bool(value and value[0] == value[-1] == "'")
 		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
 			value = value[1:-1]
-		env[key.strip()] = _expand_references(value, {**env, **os.environ})
+		env[key.strip()] = value if single_quoted else _expand_references(value, {**env, **os.environ})
 	return env

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -18,5 +18,5 @@ def load_env_file(path: Path) -> dict[str, str]:
 		value = value.strip()
 		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
 			value = value[1:-1]
-		env[key.strip()] = Template(value).safe_substitute({**os.environ, **env})
+		env[key.strip()] = Template(value).safe_substitute({**env, **os.environ})
 	return env

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
-from string import Template
+
+
+ENV_REFERENCE = re.compile(r'(?<!\$)\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))')
+
+
+def _expand_references(value: str, variables: dict[str, str]) -> str:
+	def replace(match: re.Match[str]) -> str:
+		name = match.group('braced') or match.group('plain')
+		return variables.get(name, match.group(0))
+
+	return ENV_REFERENCE.sub(replace, value)
 
 
 def load_env_file(path: Path) -> dict[str, str]:
@@ -18,5 +29,5 @@ def load_env_file(path: Path) -> dict[str, str]:
 		value = value.strip()
 		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
 			value = value[1:-1]
-		env[key.strip()] = Template(value).safe_substitute({**env, **os.environ})
+		env[key.strip()] = _expand_references(value, {**env, **os.environ})
 	return env

--- a/shared/operator_env.py
+++ b/shared/operator_env.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+	env: dict[str, str] = {}
+	if not path.exists():
+		return env
+
+	for raw_line in path.read_text().splitlines():
+		line = raw_line.strip()
+		if not line or line.startswith('#') or '=' not in line:
+			continue
+		key, value = line.split('=', 1)
+		value = value.strip()
+		if value and value[0] == value[-1] and value[0] in {'"', "'"}:
+			value = value[1:-1]
+		env[key.strip()] = os.path.expandvars(value)
+	return env

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -3,6 +3,8 @@ from dotenv import load_dotenv
 from pathlib import Path
 import os
 
+from .asset_manifest import BIOME_ASSET_PATH, GADM_ASSET_PATH, PHENOLOGY_ASSET_PATH
+
 # load an .env file if it exists
 load_dotenv()
 
@@ -60,10 +62,10 @@ class Settings(BaseSettings):
 	# Base paths and directories
 	BASE_DIR: str = str(BASE)
 	# Default to repo-local assets in dev/test; container deployments can still override via env.
-	GADM_DATA_PATH: str = str(ASSETS_DIR / 'gadm' / 'gadm_410.gpkg')
+	GADM_DATA_PATH: str = str(ASSETS_DIR / GADM_ASSET_PATH)
 	CONCURRENT_TASKS: int = 2
 
-	BIOME_DATA_PATH: str = str(ASSETS_DIR / 'biom' / 'terres_ecosystems.gpkg')
+	BIOME_DATA_PATH: str = str(ASSETS_DIR / BIOME_ASSET_PATH)
 
 	BIOME_DICT: dict[int, str] = {
 		1: 'Tropical and Subtropical Moist Broadleaf Forests',
@@ -82,7 +84,7 @@ class Settings(BaseSettings):
 		14: 'Mangroves',
 	}
 
-	PHENOLOGY_DATA_PATH: str = str(ASSETS_DIR / 'pheno' / 'modispheno_aggregated_normalized_filled.zarr')
+	PHENOLOGY_DATA_PATH: str = str(ASSETS_DIR / PHENOLOGY_ASSET_PATH)
 
 	# DTE maps (deadwood/forest cover COGs)
 	DTE_MAPS_PATH: str = '/data/assets/dte_maps'


### PR DESCRIPTION
## Briefing

Prevents a processor host from starting or resuming when required production models or metadata assets are missing. This closes the deployment gap that activated Helicon from a new operator checkout whose relative `assets/` bind mount was empty, causing repeated user-upload and backlog failures. The live Helicon host is repaired but remains drained pending this reviewed guard and a canary.

## What changed

- Defines one dependency-light, worker-capability-aware asset manifest consumed by runtime configuration and activation preflight, including bounded safetensors checks, GeoPackage schema/integrity checks, consolidated Zarr metadata plus a complete required chunk inventory, and mount-root containment.
- Guards both auto-deploy and Docker-maintenance restarts; missing assets transition either path into one recoverable asset-loss drain.
- Safely recreates an available or stopped worker under an automation-owned drain after assets are restored, while preserving planned operator shutdowns.
- Detects no-code-change asset mount configuration drift and recreates the worker through the same guarded drain and readiness path.
- Allows production hosts to mount an explicit read-only shared asset directory through `PROCESSOR_ASSETS_DIR` and documents the separate-checkout setup.

## Validation

- `python3 -m unittest scripts.tests.test_processor_auto_deploy scripts.tests.test_processor_docker_maintenance scripts.tests.test_processor_asset_preflight` - 42 tests passed locally, including missing/truncated/escaping-symlink asset containment, GeoPackage and consolidated/complete Zarr validation, task-blacklist capability filtering, resolved-path no-change mount migration, maintenance-to-asset recovery, stopped-worker recovery, operator-drain preservation, Compose-compatible env quoting/comments/substitutions/precedence, literal-dollar credentials, and target-release requirement changes.
- `python3 -m py_compile ...` for all changed Python runtime and preflight modules - passed locally.
- `bash -n scripts/processor_auto_deploy.sh scripts/processor_docker_maintenance.sh` and `git diff --check` - passed locally.
- Live Helicon containment: deploy timer stopped, worker drained, active task requeued, populated assets mounted, and all required paths verified inside the restarted drained container.

## Risk and limitations

This changes processor-host deployment and runtime asset configuration only. It does not requeue datasets already failed by the incident; requeueing remains a separate controlled operation after the Helicon canary.

## Tracking

Related to DT-723

## Reviewer guide

Please verify drain ownership, target-release activation ordering, available/stopped-worker asset recovery, Zarr validation, and that deploy and maintenance failure paths leave the worker drained.
