### PR TITLE
feat(priwa): add versioned Warnkarte GeoPackage workflow

### DIFF
--- a/api/src/priwa/__init__.py
+++ b/api/src/priwa/__init__.py
@@ -1,0 +1,1 @@
+"""PRIWA-specific API business logic."""

--- a/api/src/priwa/warnkarte.py
+++ b/api/src/priwa/warnkarte.py
@@ -1,0 +1,375 @@
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import hashlib
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, BinaryIO
+
+import fiona
+from pyproj import CRS
+from shapely.geometry import shape
+from shapely.validation import explain_validity
+
+
+EXPECTED_CRS = 'EPSG:32632'
+EXPECTED_EPSG = 32632
+PROBABILITY_STEP = Decimal('0.1')
+PROBABILITY_TOLERANCE = Decimal('0.000001')
+MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024
+MAX_FEATURE_COUNT = 10_000
+MAX_VERTICES_PER_POLYGON = 100_000
+MAX_TOTAL_VERTICES = 1_000_000
+FILENAME_DATE_PATTERN = re.compile(r'(?P<date>\d{4}-\d{2}-\d{2})\.gpkg$')
+LAYER_DATE_PATTERN = re.compile(r'\d{4}-\d{2}-\d{2}')
+
+
+class WarnkarteValidationError(ValueError):
+	def __init__(
+		self,
+		code: str,
+		message: str,
+		*,
+		details: dict[str, Any] | None = None,
+		status_code: int = 400,
+	):
+		super().__init__(message)
+		self.code = code
+		self.message = message
+		self.details = details or {}
+		self.status_code = status_code
+
+	def as_detail(self) -> dict[str, Any]:
+		return {
+			'code': self.code,
+			'message': self.message,
+			'details': self.details,
+		}
+
+
+@dataclass(frozen=True)
+class ValidatedWarnkartePolygon:
+	fid: int
+	probability: Decimal
+	wkb_hex: str
+
+	def as_rpc_payload(self) -> dict[str, Any]:
+		return {
+			'fid': self.fid,
+			'probability': format(self.probability, '.1f'),
+			'wkb_hex': self.wkb_hex,
+		}
+
+
+@dataclass(frozen=True)
+class ValidatedWarnkarte:
+	source_filename: str
+	checksum_sha256: str
+	source_date: date
+	source_layer: str
+	source_crs: str
+	polygons: tuple[ValidatedWarnkartePolygon, ...]
+	warnings: tuple[dict[str, Any], ...]
+
+	@property
+	def feature_count(self) -> int:
+		return len(self.polygons)
+
+	def summary(self) -> dict[str, Any]:
+		return {
+			'source_filename': self.source_filename,
+			'checksum_sha256': self.checksum_sha256,
+			'authoritative_date': self.source_date.isoformat(),
+			'layer': self.source_layer,
+			'crs': self.source_crs,
+			'feature_count': self.feature_count,
+			'warnings': list(self.warnings),
+		}
+
+
+def parse_source_filename(filename: str | None) -> tuple[str, date]:
+	source_filename = Path(filename or '').name
+	match = FILENAME_DATE_PATTERN.search(source_filename)
+	if not match:
+		raise WarnkarteValidationError(
+			'INVALID_FILENAME',
+			'Der Dateiname muss direkt vor .gpkg ein gültiges Datum im Format JJJJ-MM-TT enthalten.',
+			details={'expected': '*YYYY-MM-DD.gpkg', 'detected': source_filename or None},
+		)
+
+	try:
+		source_date = date.fromisoformat(match.group('date'))
+	except ValueError as error:
+		raise WarnkarteValidationError(
+			'INVALID_FILENAME_DATE',
+			'Das Datum im Dateinamen ist kein gültiges Kalenderdatum.',
+			details={'detected': match.group('date')},
+		) from error
+
+	return source_filename, source_date
+
+
+def normalize_probability(value: Any, fid: int) -> Decimal:
+	if value is None or isinstance(value, bool):
+		raise WarnkarteValidationError(
+			'INVALID_PROBABILITY',
+			'Jedes Polygon benötigt einen Wahrscheinlichkeitswert.',
+			details={'fid': fid, 'detected': value},
+		)
+
+	try:
+		probability = Decimal(str(value))
+	except (InvalidOperation, ValueError) as error:
+		raise WarnkarteValidationError(
+			'INVALID_PROBABILITY',
+			'Die Wahrscheinlichkeit muss eine Zahl zwischen 0,0 und 1,0 sein.',
+			details={'fid': fid, 'detected': str(value)},
+		) from error
+
+	if not probability.is_finite():
+		raise WarnkarteValidationError(
+			'INVALID_PROBABILITY',
+			'Die Wahrscheinlichkeit muss eine endliche Zahl sein.',
+			details={'fid': fid, 'detected': str(value)},
+		)
+
+	normalized = probability.quantize(PROBABILITY_STEP, rounding=ROUND_HALF_UP)
+	if normalized < Decimal('0.0') or normalized > Decimal('1.0'):
+		raise WarnkarteValidationError(
+			'INVALID_PROBABILITY',
+			'Die Wahrscheinlichkeit muss zwischen 0,0 und 1,0 liegen.',
+			details={'fid': fid, 'detected': str(value)},
+		)
+
+	if abs(probability - normalized) > PROBABILITY_TOLERANCE:
+		raise WarnkarteValidationError(
+			'INVALID_PROBABILITY_STEP',
+			'Die Wahrscheinlichkeit muss in Schritten von 0,1 angegeben sein.',
+			details={'fid': fid, 'detected': str(value), 'step': '0.1'},
+		)
+
+	return normalized
+
+
+def describe_crs(collection) -> tuple[CRS | None, str | None]:
+	crs_input = collection.crs_wkt or collection.crs
+	if not crs_input:
+		return None, None
+
+	try:
+		crs = CRS.from_user_input(crs_input)
+	except Exception:
+		return None, str(crs_input)
+
+	detected = crs.to_string()
+	return crs, detected
+
+
+def copy_and_hash(
+	source: BinaryIO,
+	target: BinaryIO,
+	*,
+	max_bytes: int = MAX_FILE_SIZE_BYTES,
+) -> str:
+	digest = hashlib.sha256()
+	bytes_read = 0
+	while chunk := source.read(1024 * 1024):
+		bytes_read += len(chunk)
+		if bytes_read > max_bytes:
+			raise WarnkarteValidationError(
+				'FILE_TOO_LARGE',
+				'Das GeoPackage ist zu groß.',
+				details={'max_bytes': max_bytes, 'detected_at_least_bytes': bytes_read},
+				status_code=413,
+			)
+		digest.update(chunk)
+		target.write(chunk)
+	return digest.hexdigest()
+
+
+def count_polygon_vertices(geometry) -> int:
+	return len(geometry.exterior.coords) + sum(len(interior.coords) for interior in geometry.interiors)
+
+
+def validate_warnkarte_file(file_object: BinaryIO, filename: str | None) -> ValidatedWarnkarte:
+	source_filename, source_date = parse_source_filename(filename)
+
+	try:
+		file_object.seek(0)
+	except (AttributeError, OSError):
+		pass
+
+	with tempfile.TemporaryDirectory(prefix='priwa-warnkarte-') as temporary_directory:
+		temporary_path = Path(temporary_directory) / source_filename
+		with temporary_path.open('wb') as target:
+			checksum_sha256 = copy_and_hash(
+				file_object,
+				target,
+				max_bytes=MAX_FILE_SIZE_BYTES,
+			)
+
+		try:
+			layers = fiona.listlayers(temporary_path)
+		except Exception as error:
+			raise WarnkarteValidationError(
+				'INVALID_GEOPACKAGE',
+				'Die Datei ist kein lesbares GeoPackage.',
+			) from error
+
+		if len(layers) != 1:
+			raise WarnkarteValidationError(
+				'INVALID_LAYER_COUNT',
+				'Das GeoPackage muss genau einen Layer enthalten.',
+				details={'expected': 1, 'detected': len(layers)},
+			)
+
+		layer_name = layers[0]
+		try:
+			with fiona.open(temporary_path, layer=layer_name) as collection:
+				if collection.driver != 'GPKG':
+					raise WarnkarteValidationError(
+						'INVALID_GEOPACKAGE',
+						'Die Datei ist kein direktes GeoPackage.',
+						details={'expected': 'GPKG', 'detected': collection.driver},
+					)
+
+				crs, detected_crs = describe_crs(collection)
+				if crs is None or crs.to_epsg() != EXPECTED_EPSG:
+					raise WarnkarteValidationError(
+						'INVALID_CRS',
+						'Das Koordinatenreferenzsystem muss eindeutig EPSG:32632 sein.',
+						details={'expected': EXPECTED_CRS, 'detected': detected_crs},
+					)
+
+				geometry_type = collection.schema.get('geometry')
+				if geometry_type != 'Polygon':
+					raise WarnkarteValidationError(
+						'INVALID_GEOMETRY_TYPE',
+						'Der Layer darf ausschließlich Polygon-Geometrien enthalten.',
+						details={'expected': 'Polygon', 'detected': geometry_type},
+					)
+
+				property_schema = collection.schema.get('properties', {})
+				properties = list(property_schema.keys())
+				if properties != ['probability']:
+					raise WarnkarteValidationError(
+						'INVALID_COLUMNS',
+						'Der Layer muss genau ein Attribut mit dem Namen probability enthalten.',
+						details={'expected': ['probability'], 'detected': properties},
+					)
+				probability_type = str(property_schema['probability']).split(':', 1)[0]
+				if probability_type not in {'float', 'int', 'int64'}:
+					raise WarnkarteValidationError(
+						'INVALID_PROBABILITY_TYPE',
+						'Das Attribut probability muss numerisch sein.',
+						details={'expected': 'numeric', 'detected': probability_type},
+					)
+
+				polygons: list[ValidatedWarnkartePolygon] = []
+				seen_fids: set[int] = set()
+				total_vertices = 0
+				for feature_index, feature in enumerate(collection, start=1):
+					if feature_index > MAX_FEATURE_COUNT:
+						raise WarnkarteValidationError(
+							'TOO_MANY_FEATURES',
+							'Das GeoPackage enthält zu viele Polygone.',
+							details={'max_features': MAX_FEATURE_COUNT},
+							status_code=413,
+						)
+
+					try:
+						fid = int(feature.id)
+					except (TypeError, ValueError) as error:
+						raise WarnkarteValidationError(
+							'INVALID_FID',
+							'Jedes Polygon benötigt eine eindeutige intrinsische FID.',
+							details={'detected': feature.id},
+						) from error
+
+					if fid in seen_fids:
+						raise WarnkarteValidationError(
+							'DUPLICATE_FID',
+							'Die intrinsischen FIDs müssen eindeutig sein.',
+							details={'fid': fid},
+						)
+					seen_fids.add(fid)
+
+					if feature.geometry is None:
+						raise WarnkarteValidationError(
+							'INVALID_GEOMETRY',
+							'Jedes Objekt benötigt eine nicht-leere gültige Polygon-Geometrie.',
+							details={'fid': fid, 'reason': 'missing'},
+						)
+
+					geometry = shape(feature.geometry)
+					if geometry.geom_type != 'Polygon' or geometry.is_empty or not geometry.is_valid:
+						raise WarnkarteValidationError(
+							'INVALID_GEOMETRY',
+							'Jedes Objekt benötigt eine nicht-leere gültige Polygon-Geometrie.',
+							details={
+								'fid': fid,
+								'type': geometry.geom_type,
+								'reason': explain_validity(geometry),
+							},
+						)
+
+					vertex_count = count_polygon_vertices(geometry)
+					total_vertices += vertex_count
+					if vertex_count > MAX_VERTICES_PER_POLYGON or total_vertices > MAX_TOTAL_VERTICES:
+						raise WarnkarteValidationError(
+							'GEOMETRY_TOO_COMPLEX',
+							'Die Polygon-Geometrie ist zu komplex.',
+							details={
+								'fid': fid,
+								'max_vertices_per_polygon': MAX_VERTICES_PER_POLYGON,
+								'max_total_vertices': MAX_TOTAL_VERTICES,
+							},
+							status_code=413,
+						)
+
+					probability = normalize_probability(feature.properties.get('probability'), fid)
+					polygons.append(
+						ValidatedWarnkartePolygon(
+							fid=fid,
+							probability=probability,
+							wkb_hex=geometry.wkb_hex,
+						)
+					)
+		except WarnkarteValidationError:
+			raise
+		except Exception as error:
+			raise WarnkarteValidationError(
+				'INVALID_GEOPACKAGE',
+				'Das GeoPackage konnte nicht vollständig gelesen werden.',
+			) from error
+
+	if not polygons:
+		raise WarnkarteValidationError(
+			'EMPTY_LAYER',
+			'Der Warnkarten-Layer darf nicht leer sein.',
+		)
+
+	warnings: list[dict[str, Any]] = []
+	layer_dates = sorted(set(LAYER_DATE_PATTERN.findall(layer_name)))
+	if layer_dates and source_date.isoformat() not in layer_dates:
+		warnings.append(
+			{
+				'code': 'LAYER_DATE_MISMATCH',
+				'message': 'Ein Datum im Layernamen weicht vom maßgeblichen Dateinamen ab.',
+				'details': {
+					'authoritative_date': source_date.isoformat(),
+					'layer_dates': layer_dates,
+				},
+			}
+		)
+
+	return ValidatedWarnkarte(
+		source_filename=source_filename,
+		checksum_sha256=checksum_sha256,
+		source_date=source_date,
+		source_layer=layer_name,
+		source_crs=EXPECTED_CRS,
+		polygons=tuple(polygons),
+		warnings=tuple(warnings),
+	)

--- a/api/src/routers/priwa_warnkarte.py
+++ b/api/src/routers/priwa_warnkarte.py
@@ -113,12 +113,8 @@ def ensure_unique_checksum(token: str, project_id: str, validated: ValidatedWarn
 		)
 
 
-def rows_to_feature_collection(
-	rows: list[dict[str, Any]],
-	*,
-	version_id: str | None = None,
-) -> dict[str, Any]:
-	if not rows:
+def overlay_from_rpc_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+	if not rows or not isinstance(rows[0].get('payload'), dict):
 		return {
 			'version_id': None,
 			'source_date': None,
@@ -126,19 +122,7 @@ def rows_to_feature_collection(
 			'features': [],
 		}
 
-	return {
-		'version_id': version_id,
-		'source_date': rows[0]['source_date'],
-		'type': 'FeatureCollection',
-		'features': [
-			{
-				'type': 'Feature',
-				'geometry': row['geometry'],
-				'properties': {'probability': float(row['probability'])},
-			}
-			for row in rows
-		],
-	}
+	return rows[0]['payload']
 
 
 @router.post('/validate', response_model=WarnkarteValidationSummary)
@@ -299,7 +283,7 @@ def get_active_warnkarte(
 	require_project_access(token, project_id, admin=False)
 	with use_client(token) as client:
 		rows = client.rpc('priwa_current_warnkarte', {'p_project_id': project_id}).execute().data or []
-	return rows_to_feature_collection(rows)
+	return overlay_from_rpc_rows(rows)
 
 
 @router.get('/versions/{version_id}/overlay')
@@ -329,4 +313,4 @@ def get_warnkarte_version_overlay(
 				'details': {'version_id': version_id},
 			},
 		)
-	return rows_to_feature_collection(rows, version_id=version_id)
+	return overlay_from_rpc_rows(rows)

--- a/api/src/routers/priwa_warnkarte.py
+++ b/api/src/routers/priwa_warnkarte.py
@@ -1,0 +1,332 @@
+from datetime import date
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel, Field
+
+from shared.db import use_client, use_service_client, verify_token
+
+from ..priwa.warnkarte import ValidatedWarnkarte, WarnkarteValidationError, validate_warnkarte_file
+
+
+router = APIRouter(prefix='/priwa/warnkarte', tags=['priwa-warnkarte'])
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token')
+
+
+class WarnkarteValidationSummary(BaseModel):
+	source_filename: str
+	checksum_sha256: str
+	authoritative_date: date
+	layer: str
+	crs: str
+	feature_count: int
+	warnings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class WarnkarteImportResponse(BaseModel):
+	version_id: str
+	summary: WarnkarteValidationSummary
+
+
+class WarnkarteVersion(BaseModel):
+	id: str
+	source_date: date
+	source_filename: str
+	checksum_sha256: str
+	source_layer: str
+	source_crs: str
+	feature_count: int
+	imported_by: str
+	imported_at: str
+	is_current: bool
+
+
+class WarnkartePublicationResponse(BaseModel):
+	publication_id: int
+	version_id: str
+
+
+def validation_http_error(error: WarnkarteValidationError) -> HTTPException:
+	return HTTPException(status_code=error.status_code, detail=error.as_detail())
+
+
+def require_user(token: str):
+	user = verify_token(token)
+	if not user:
+		raise HTTPException(
+			status_code=status.HTTP_401_UNAUTHORIZED,
+			detail={
+				'code': 'INVALID_TOKEN',
+				'message': 'Die Anmeldung ist ungültig oder abgelaufen.',
+				'details': {},
+			},
+		)
+	return user
+
+
+def require_project_access(token: str, project_id: str, *, admin: bool) -> None:
+	rpc_name = 'priwa_is_project_admin' if admin else 'priwa_is_project_member'
+	with use_client(token) as client:
+		allowed = bool(client.rpc(rpc_name, {'p_project_id': project_id}).execute().data)
+	if not allowed:
+		code = 'ADMIN_REQUIRED' if admin else 'MEMBERSHIP_REQUIRED'
+		message = (
+			'Für diese Warnkarten-Verwaltung ist eine PRIWA-Adminrolle erforderlich.'
+			if admin
+			else 'Für diese Warnkarte ist eine PRIWA-Projektmitgliedschaft erforderlich.'
+		)
+		raise HTTPException(
+			status_code=status.HTTP_403_FORBIDDEN,
+			detail={'code': code, 'message': message, 'details': {'project_id': project_id}},
+		)
+
+
+def validate_upload(file: UploadFile) -> ValidatedWarnkarte:
+	try:
+		return validate_warnkarte_file(file.file, file.filename)
+	except WarnkarteValidationError as error:
+		raise validation_http_error(error) from error
+
+
+def ensure_unique_checksum(token: str, project_id: str, validated: ValidatedWarnkarte) -> None:
+	with use_client(token) as client:
+		response = (
+			client.table('priwa_warnkarte_versions')
+			.select('id')
+			.eq('project_id', project_id)
+			.eq('checksum_sha256', validated.checksum_sha256)
+			.limit(1)
+			.execute()
+		)
+	if response.data:
+		raise HTTPException(
+			status_code=status.HTTP_409_CONFLICT,
+			detail={
+				'code': 'DUPLICATE_CHECKSUM',
+				'message': 'Dieses GeoPackage wurde in diesem Projekt bereits importiert.',
+				'details': {
+					'checksum_sha256': validated.checksum_sha256,
+					'existing_version_id': response.data[0]['id'],
+				},
+			},
+		)
+
+
+def rows_to_feature_collection(
+	rows: list[dict[str, Any]],
+	*,
+	version_id: str | None = None,
+) -> dict[str, Any]:
+	if not rows:
+		return {
+			'version_id': None,
+			'source_date': None,
+			'type': 'FeatureCollection',
+			'features': [],
+		}
+
+	return {
+		'version_id': version_id,
+		'source_date': rows[0]['source_date'],
+		'type': 'FeatureCollection',
+		'features': [
+			{
+				'type': 'Feature',
+				'geometry': row['geometry'],
+				'properties': {'probability': float(row['probability'])},
+			}
+			for row in rows
+		],
+	}
+
+
+@router.post('/validate', response_model=WarnkarteValidationSummary)
+def validate_warnkarte_upload(
+	project_id: Annotated[str, Form()],
+	file: Annotated[UploadFile, File()],
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	require_project_access(token, project_id, admin=True)
+	validated = validate_upload(file)
+	ensure_unique_checksum(token, project_id, validated)
+	return validated.summary()
+
+
+@router.post('/import', response_model=WarnkarteImportResponse)
+def import_warnkarte(
+	project_id: Annotated[str, Form()],
+	confirmed_date: Annotated[date, Form()],
+	file: Annotated[UploadFile, File()],
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	user = require_user(token)
+	require_project_access(token, project_id, admin=True)
+	validated = validate_upload(file)
+	if confirmed_date != validated.source_date:
+		raise HTTPException(
+			status_code=status.HTTP_400_BAD_REQUEST,
+			detail={
+				'code': 'DATE_CONFIRMATION_MISMATCH',
+				'message': 'Das bestätigte Datum muss dem maßgeblichen Datum im Dateinamen entsprechen.',
+				'details': {
+					'expected': validated.source_date.isoformat(),
+					'confirmed': confirmed_date.isoformat(),
+				},
+			},
+		)
+	ensure_unique_checksum(token, project_id, validated)
+
+	try:
+		with use_service_client() as client:
+			version_id = (
+				client.rpc(
+					'priwa_import_warnkarte',
+					{
+						'p_actor': str(user.id),
+						'p_project_id': project_id,
+						'p_source_filename': validated.source_filename,
+						'p_checksum_sha256': validated.checksum_sha256,
+						'p_source_date': validated.source_date.isoformat(),
+						'p_source_layer': validated.source_layer,
+						'p_source_crs': validated.source_crs,
+						'p_polygons': [polygon.as_rpc_payload() for polygon in validated.polygons],
+					},
+				)
+				.execute()
+				.data
+			)
+	except Exception as error:
+		if 'priwa_warnkarte_versions_project_checksum_key' in str(error):
+			raise HTTPException(
+				status_code=status.HTTP_409_CONFLICT,
+				detail={
+					'code': 'DUPLICATE_CHECKSUM',
+					'message': 'Dieses GeoPackage wurde in diesem Projekt bereits importiert.',
+					'details': {'checksum_sha256': validated.checksum_sha256},
+				},
+			) from error
+		raise HTTPException(
+			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+			detail={
+				'code': 'IMPORT_FAILED',
+				'message': 'Die Warnkarte konnte nicht atomar importiert werden.',
+				'details': {},
+			},
+		) from error
+
+	return {'version_id': str(version_id), 'summary': validated.summary()}
+
+
+@router.get('/versions', response_model=list[WarnkarteVersion])
+def list_warnkarte_versions(
+	project_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	require_project_access(token, project_id, admin=True)
+	with use_client(token) as client:
+		versions = (
+			client.table('priwa_warnkarte_versions')
+			.select(
+				'id,source_date,source_filename,checksum_sha256,source_layer,source_crs,'
+				'feature_count,imported_by,imported_at'
+			)
+			.eq('project_id', project_id)
+			.order('imported_at', desc=True)
+			.execute()
+		).data or []
+		publication = (
+			client.table('priwa_warnkarte_publications')
+			.select('version_id')
+			.eq('project_id', project_id)
+			.order('published_at', desc=True)
+			.order('id', desc=True)
+			.limit(1)
+			.execute()
+		).data or []
+	current_version_id = publication[0]['version_id'] if publication else None
+	return [{**version, 'is_current': version['id'] == current_version_id} for version in versions]
+
+
+@router.post('/versions/{version_id}/publish', response_model=WarnkartePublicationResponse)
+def publish_warnkarte_version(
+	version_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	try:
+		with use_client(token) as client:
+			publication_id = client.rpc('priwa_publish_warnkarte', {'p_version_id': version_id}).execute().data
+	except Exception as error:
+		error_text = str(error)
+		if 'admin access is required' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_403_FORBIDDEN,
+				detail={
+					'code': 'ADMIN_REQUIRED',
+					'message': 'Nur PRIWA-Admins dürfen eine Warnkarte veröffentlichen.',
+					'details': {},
+				},
+			) from error
+		if 'Warnkarte version not found' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_404_NOT_FOUND,
+				detail={
+					'code': 'VERSION_NOT_FOUND',
+					'message': 'Die Warnkartenversion wurde nicht gefunden.',
+					'details': {'version_id': version_id},
+				},
+			) from error
+		raise HTTPException(
+			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+			detail={
+				'code': 'PUBLISH_FAILED',
+				'message': 'Die Warnkarte konnte nicht veröffentlicht werden.',
+				'details': {},
+			},
+		) from error
+	return {'publication_id': publication_id, 'version_id': version_id}
+
+
+@router.get('/active')
+def get_active_warnkarte(
+	project_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	require_project_access(token, project_id, admin=False)
+	with use_client(token) as client:
+		rows = client.rpc('priwa_current_warnkarte', {'p_project_id': project_id}).execute().data or []
+	return rows_to_feature_collection(rows)
+
+
+@router.get('/versions/{version_id}/overlay')
+def get_warnkarte_version_overlay(
+	version_id: str,
+	project_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	require_project_access(token, project_id, admin=True)
+	with use_client(token) as client:
+		rows = (
+			client.rpc(
+				'priwa_warnkarte_version_overlay',
+				{'p_project_id': project_id, 'p_version_id': version_id},
+			)
+			.execute()
+			.data
+			or []
+		)
+	if not rows:
+		raise HTTPException(
+			status_code=status.HTTP_404_NOT_FOUND,
+			detail={
+				'code': 'VERSION_NOT_FOUND',
+				'message': 'Die Warnkartenversion wurde nicht gefunden.',
+				'details': {'version_id': version_id},
+			},
+		)
+	return rows_to_feature_collection(rows, version_id=version_id)

--- a/api/src/server.py
+++ b/api/src/server.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 from shared.__version__ import __version__
-from .routers import process, upload, info, auth, download, dte_stats, prepackaged, search
+from .routers import process, upload, info, auth, download, dte_stats, prepackaged, search, priwa_warnkarte
 
 app = FastAPI(
 	title='Deadwood-AI API',
@@ -59,6 +59,9 @@ app.include_router(search.router)
 
 # add authenticated prepackaged dataset catalog and grant routes
 app.include_router(prepackaged.router)
+
+# add PRIWA Warnkarte validation, import, publication, and safe overlay routes
+app.include_router(priwa_warnkarte.router)
 
 # add the download routes to the app
 # app.include_router(download.download_app)

--- a/api/tests/db/test_priwa_warnkarte_schema.py
+++ b/api/tests/db/test_priwa_warnkarte_schema.py
@@ -190,6 +190,7 @@ def test_duplicate_checksum_and_polygon_failure_are_atomic(warnkarte_project):
 def test_publication_and_reversion_use_latest_append_only_record(warnkarte_project):
 	admin_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
 	member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+	large_overlay_polygons = [polygon_payload(fid, '0.9', x_offset=fid * 20) for fid in range(1, 1002)]
 
 	with use_service_client() as client:
 		old_version_id = import_version(
@@ -205,20 +206,44 @@ def test_publication_and_reversion_use_latest_append_only_record(warnkarte_proje
 			warnkarte_project['id'],
 			'new',
 			'2024-07-01',
-			[polygon_payload(2, '0.9', x_offset=30)],
+			large_overlay_polygons,
 		)
 
 	with use_client(admin_token) as client:
+		preview = (
+			client.rpc(
+				'priwa_warnkarte_version_overlay',
+				{'p_project_id': warnkarte_project['id'], 'p_version_id': new_version_id},
+			)
+			.execute()
+			.data
+		)
+		assert len(preview) == 1
+		assert len(preview[0]['payload']['features']) == 1001
+
 		client.rpc('priwa_publish_warnkarte', {'p_version_id': old_version_id}).execute()
 		client.rpc('priwa_publish_warnkarte', {'p_version_id': new_version_id}).execute()
+
+	with use_client(member_token) as client:
+		large_active = client.rpc('priwa_current_warnkarte', {'p_project_id': warnkarte_project['id']}).execute().data
+
+	assert len(large_active) == 1
+	assert len(large_active[0]['payload']['features']) == 1001
+	assert large_active[0]['payload']['version_id'] is None
+	assert large_active[0]['payload']['source_date'] == '2024-07-01'
+	assert set(large_active[0]['payload']) == {'version_id', 'source_date', 'type', 'features'}
+	assert set(large_active[0]['payload']['features'][0]) == {'type', 'geometry', 'properties'}
+	assert set(large_active[0]['payload']['features'][0]['properties']) == {'probability'}
+
+	with use_client(admin_token) as client:
 		client.rpc('priwa_publish_warnkarte', {'p_version_id': old_version_id}).execute()
 
 	with use_client(member_token) as client:
 		active = client.rpc('priwa_current_warnkarte', {'p_project_id': warnkarte_project['id']}).execute().data
 
 	assert len(active) == 1
-	assert active[0]['source_date'] == '2024-06-25'
-	assert set(active[0]) == {'source_date', 'probability', 'geometry'}
+	assert active[0]['payload']['source_date'] == '2024-06-25'
+	assert len(active[0]['payload']['features']) == 1
 
 	with use_service_client() as client:
 		publications = (

--- a/api/tests/db/test_priwa_warnkarte_schema.py
+++ b/api/tests/db/test_priwa_warnkarte_schema.py
@@ -1,0 +1,231 @@
+import hashlib
+import uuid
+
+import pytest
+from shapely.geometry import Polygon
+
+from shared.db import login, use_client, use_service_client
+from shared.settings import settings
+
+
+def polygon_payload(fid: int, probability: str, x_offset: int = 0):
+	geometry = Polygon(
+		[
+			(450000 + x_offset, 5360000),
+			(450010 + x_offset, 5360000),
+			(450010 + x_offset, 5360010),
+			(450000 + x_offset, 5360010),
+			(450000 + x_offset, 5360000),
+		]
+	)
+	return {'fid': fid, 'probability': probability, 'wkb_hex': geometry.wkb_hex}
+
+
+def checksum(label: str) -> str:
+	return hashlib.sha256(label.encode('utf-8')).hexdigest()
+
+
+@pytest.fixture
+def warnkarte_project(test_user, test_user2):
+	project_id = str(uuid.uuid4())
+	with use_service_client() as client:
+		client.table('priwa_projects').insert(
+			{'id': project_id, 'slug': f'warnkarte-{project_id}', 'name': 'Warnkarte Test'}
+		).execute()
+		client.table('priwa_project_memberships').insert(
+			[
+				{'project_id': project_id, 'user_id': test_user, 'role': 'admin'},
+				{'project_id': project_id, 'user_id': test_user2, 'role': 'field_user'},
+			]
+		).execute()
+
+	try:
+		yield {'id': project_id, 'admin_id': test_user, 'member_id': test_user2}
+	finally:
+		with use_service_client() as client:
+			client.table('priwa_warnkarte_publications').delete().eq('project_id', project_id).execute()
+			client.table('priwa_warnkarte_versions').delete().eq('project_id', project_id).execute()
+			client.table('priwa_project_memberships').delete().eq('project_id', project_id).execute()
+			client.table('priwa_projects').delete().eq('id', project_id).execute()
+
+
+def import_version(client, actor_id: str, project_id: str, label: str, source_date: str, polygons=None):
+	return (
+		client.rpc(
+			'priwa_import_warnkarte',
+			{
+				'p_actor': actor_id,
+				'p_project_id': project_id,
+				'p_source_filename': f'warnkarte_{source_date}.gpkg',
+				'p_checksum_sha256': checksum(label),
+				'p_source_date': source_date,
+				'p_source_layer': 'warning_polygons',
+				'p_source_crs': 'EPSG:32632',
+				'p_polygons': polygons or [polygon_payload(1, '0.6000000238')],
+			},
+		)
+		.execute()
+		.data
+	)
+
+
+def test_admin_import_is_normalized_and_member_cannot_read_provenance(warnkarte_project):
+	admin_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_service_client() as client:
+		version_id = import_version(
+			client,
+			warnkarte_project['admin_id'],
+			warnkarte_project['id'],
+			'normalized',
+			'2024-06-25',
+		)
+
+	with use_client(admin_token) as client:
+		version_rows = client.table('priwa_warnkarte_versions').select('*').eq('id', version_id).execute().data
+		polygon_rows = client.table('priwa_warnkarte_polygons').select('*').eq('version_id', version_id).execute().data
+
+	assert version_rows[0]['feature_count'] == 1
+	assert version_rows[0]['source_filename'] == 'warnkarte_2024-06-25.gpkg'
+	assert float(polygon_rows[0]['probability']) == 0.6
+
+	with use_client(member_token) as client:
+		assert client.table('priwa_warnkarte_versions').select('*').eq('id', version_id).execute().data == []
+		assert client.table('priwa_warnkarte_polygons').select('*').eq('version_id', version_id).execute().data == []
+
+
+def test_import_rpc_is_server_only_and_rechecks_actor_admin_role(warnkarte_project):
+	admin_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_client(admin_token) as client:
+		with pytest.raises(Exception):
+			import_version(
+				client,
+				warnkarte_project['admin_id'],
+				warnkarte_project['id'],
+				'direct-browser-call',
+				'2024-06-24',
+			)
+
+	with use_client(member_token) as client:
+		with pytest.raises(Exception):
+			client.rpc('priwa_import_warnkarte', {}).execute()
+
+	with use_service_client() as client:
+		with pytest.raises(Exception, match='admin access is required'):
+			import_version(
+				client,
+				warnkarte_project['member_id'],
+				warnkarte_project['id'],
+				'forbidden',
+				'2024-06-25',
+			)
+
+	with use_service_client() as client:
+		rows = (
+			client.table('priwa_warnkarte_versions')
+			.select('id')
+			.eq('project_id', warnkarte_project['id'])
+			.eq('checksum_sha256', checksum('forbidden'))
+			.execute()
+		).data
+	assert rows == []
+
+
+def test_duplicate_checksum_and_polygon_failure_are_atomic(warnkarte_project):
+	with use_service_client() as client:
+		import_version(client, warnkarte_project['admin_id'], warnkarte_project['id'], 'duplicate', '2024-06-25')
+		with pytest.raises(Exception):
+			import_version(
+				client,
+				warnkarte_project['admin_id'],
+				warnkarte_project['id'],
+				'duplicate',
+				'2024-06-25',
+			)
+		with pytest.raises(Exception):
+			import_version(
+				client,
+				warnkarte_project['admin_id'],
+				warnkarte_project['id'],
+				'atomic-failure',
+				'2024-06-26',
+				[
+					polygon_payload(1, '0.2'),
+					polygon_payload(1, '0.3', x_offset=20),
+				],
+			)
+		with pytest.raises(Exception, match='0.1 steps'):
+			import_version(
+				client,
+				warnkarte_project['admin_id'],
+				warnkarte_project['id'],
+				'invalid-probability',
+				'2024-06-27',
+				[polygon_payload(3, '0.65')],
+			)
+
+	with use_service_client() as client:
+		failed_versions = (
+			client.table('priwa_warnkarte_versions')
+			.select('id')
+			.eq('project_id', warnkarte_project['id'])
+			.eq('checksum_sha256', checksum('atomic-failure'))
+			.execute()
+		).data
+	assert failed_versions == []
+	with use_service_client() as client:
+		invalid_probability_versions = (
+			client.table('priwa_warnkarte_versions')
+			.select('id')
+			.eq('project_id', warnkarte_project['id'])
+			.eq('checksum_sha256', checksum('invalid-probability'))
+			.execute()
+		).data
+	assert invalid_probability_versions == []
+
+
+def test_publication_and_reversion_use_latest_append_only_record(warnkarte_project):
+	admin_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_service_client() as client:
+		old_version_id = import_version(
+			client,
+			warnkarte_project['admin_id'],
+			warnkarte_project['id'],
+			'old',
+			'2024-06-25',
+		)
+		new_version_id = import_version(
+			client,
+			warnkarte_project['admin_id'],
+			warnkarte_project['id'],
+			'new',
+			'2024-07-01',
+			[polygon_payload(2, '0.9', x_offset=30)],
+		)
+
+	with use_client(admin_token) as client:
+		client.rpc('priwa_publish_warnkarte', {'p_version_id': old_version_id}).execute()
+		client.rpc('priwa_publish_warnkarte', {'p_version_id': new_version_id}).execute()
+		client.rpc('priwa_publish_warnkarte', {'p_version_id': old_version_id}).execute()
+
+	with use_client(member_token) as client:
+		active = client.rpc('priwa_current_warnkarte', {'p_project_id': warnkarte_project['id']}).execute().data
+
+	assert len(active) == 1
+	assert active[0]['source_date'] == '2024-06-25'
+	assert set(active[0]) == {'source_date', 'probability', 'geometry'}
+
+	with use_service_client() as client:
+		publications = (
+			client.table('priwa_warnkarte_publications')
+			.select('version_id')
+			.eq('project_id', warnkarte_project['id'])
+			.order('id')
+			.execute()
+		).data
+	assert [row['version_id'] for row in publications] == [old_version_id, new_version_id, old_version_id]

--- a/api/tests/priwa/test_warnkarte_ingress.py
+++ b/api/tests/priwa/test_warnkarte_ingress.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import re
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+	'config_path',
+	[
+		Path('nginx/api-conf/storage-server.conf'),
+		Path('nginx/test-conf/storage-server.conf'),
+	],
+)
+def test_warnkarte_upload_routes_have_ingress_body_limit(config_path):
+	config = config_path.read_text()
+	location = re.search(
+		r'location ~ \^/api/v1/priwa/warnkarte/\(validate\|import\)\$ \{(?P<body>.*?)\n    \}',
+		config,
+		flags=re.DOTALL,
+	)
+
+	assert location is not None
+	assert 'client_max_body_size 52M;' in location.group('body')

--- a/api/tests/priwa/test_warnkarte_router.py
+++ b/api/tests/priwa/test_warnkarte_router.py
@@ -1,0 +1,197 @@
+from contextlib import contextmanager
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+from types import SimpleNamespace
+
+from fastapi import HTTPException, UploadFile
+import pytest
+
+from api.src.priwa.warnkarte import (
+	ValidatedWarnkarte,
+	ValidatedWarnkartePolygon,
+	WarnkarteValidationError,
+)
+from api.src.routers import priwa_warnkarte
+
+
+pytestmark = pytest.mark.unit
+
+
+def validated_warnkarte():
+	return ValidatedWarnkarte(
+		source_filename='warnkarte_2024-06-25.gpkg',
+		checksum_sha256='a' * 64,
+		source_date=date(2024, 6, 25),
+		source_layer='warning_polygons',
+		source_crs='EPSG:32632',
+		polygons=(
+			ValidatedWarnkartePolygon(
+				fid=1,
+				probability=Decimal('0.6'),
+				wkb_hex='00',
+			),
+		),
+		warnings=(),
+	)
+
+
+def test_safe_member_feature_collection_excludes_provenance_and_source_ids():
+	response = priwa_warnkarte.rows_to_feature_collection(
+		[
+			{
+				'version_id': 'hidden-version',
+				'source_date': '2024-06-25',
+				'source_fid': 77,
+				'probability': '0.6',
+				'geometry': {'type': 'Polygon', 'coordinates': []},
+				'source_filename': 'hidden.gpkg',
+				'checksum_sha256': 'hidden',
+			}
+		]
+	)
+
+	assert response['version_id'] is None
+	assert response['source_date'] == '2024-06-25'
+	assert response['features'] == [
+		{
+			'type': 'Feature',
+			'geometry': {'type': 'Polygon', 'coordinates': []},
+			'properties': {'probability': 0.6},
+		}
+	]
+
+
+def test_validation_error_keeps_structured_expected_and_detected_crs(monkeypatch):
+	def reject(*_args, **_kwargs):
+		raise WarnkarteValidationError(
+			'INVALID_CRS',
+			'Das Koordinatenreferenzsystem muss eindeutig EPSG:32632 sein.',
+			details={'expected': 'EPSG:32632', 'detected': 'EPSG:4326'},
+		)
+
+	monkeypatch.setattr(priwa_warnkarte, 'validate_warnkarte_file', reject)
+	upload = UploadFile(file=BytesIO(b'gpkg'), filename='warnkarte_2024-06-25.gpkg')
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.validate_upload(upload)
+
+	assert error.value.status_code == 400
+	assert error.value.detail == {
+		'code': 'INVALID_CRS',
+		'message': 'Das Koordinatenreferenzsystem muss eindeutig EPSG:32632 sein.',
+		'details': {'expected': 'EPSG:32632', 'detected': 'EPSG:4326'},
+	}
+
+
+def test_resource_limit_validation_error_returns_structured_413(monkeypatch):
+	def reject(*_args, **_kwargs):
+		raise WarnkarteValidationError(
+			'FILE_TOO_LARGE',
+			'Das GeoPackage ist zu groß.',
+			details={'max_bytes': 50 * 1024 * 1024},
+			status_code=413,
+		)
+
+	monkeypatch.setattr(priwa_warnkarte, 'validate_warnkarte_file', reject)
+	upload = UploadFile(file=BytesIO(b'gpkg'), filename='warnkarte_2024-06-25.gpkg')
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.validate_upload(upload)
+
+	assert error.value.status_code == 413
+	assert error.value.detail['code'] == 'FILE_TOO_LARGE'
+	assert error.value.detail['details']['max_bytes'] == 50 * 1024 * 1024
+
+
+def test_date_confirmation_mismatch_stops_before_any_database_write(monkeypatch):
+	monkeypatch.setattr(priwa_warnkarte, 'require_user', lambda _token: object())
+	monkeypatch.setattr(
+		priwa_warnkarte,
+		'require_project_access',
+		lambda _token, _project_id, admin: None,
+	)
+	monkeypatch.setattr(priwa_warnkarte, 'validate_upload', lambda _file: validated_warnkarte())
+	monkeypatch.setattr(
+		priwa_warnkarte,
+		'ensure_unique_checksum',
+		lambda *_args: pytest.fail('duplicate lookup must not run before date confirmation'),
+	)
+	upload = UploadFile(file=BytesIO(b'gpkg'), filename='warnkarte_2024-06-25.gpkg')
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.import_warnkarte(
+			project_id='project-1',
+			confirmed_date=date(2024, 6, 26),
+			file=upload,
+			token='token',
+		)
+
+	assert error.value.status_code == 400
+	assert error.value.detail['code'] == 'DATE_CONFIRMATION_MISMATCH'
+
+
+def test_import_uses_service_only_rpc_with_verified_actor(monkeypatch):
+	client = FakeClient('version-1')
+
+	@contextmanager
+	def use_fake_service_client():
+		yield client
+
+	monkeypatch.setattr(priwa_warnkarte, 'require_user', lambda _token: SimpleNamespace(id='actor-1'))
+	monkeypatch.setattr(
+		priwa_warnkarte,
+		'require_project_access',
+		lambda _token, _project_id, admin: None,
+	)
+	monkeypatch.setattr(priwa_warnkarte, 'validate_upload', lambda _file: validated_warnkarte())
+	monkeypatch.setattr(priwa_warnkarte, 'ensure_unique_checksum', lambda *_args: None)
+	monkeypatch.setattr(priwa_warnkarte, 'use_service_client', use_fake_service_client)
+	upload = UploadFile(file=BytesIO(b'gpkg'), filename='warnkarte_2024-06-25.gpkg')
+
+	response = priwa_warnkarte.import_warnkarte(
+		project_id='project-1',
+		confirmed_date=date(2024, 6, 25),
+		file=upload,
+		token='token',
+	)
+
+	assert response['version_id'] == 'version-1'
+	assert client.calls[0][0] == 'priwa_import_warnkarte'
+	assert client.calls[0][1]['p_actor'] == 'actor-1'
+	assert client.calls[0][1]['p_project_id'] == 'project-1'
+
+
+class FakeRpc:
+	def __init__(self, allowed: bool):
+		self.allowed = allowed
+
+	def execute(self):
+		return type('Response', (), {'data': self.allowed})()
+
+
+class FakeClient:
+	def __init__(self, allowed: bool):
+		self.allowed = allowed
+		self.calls = []
+
+	def rpc(self, name, payload):
+		self.calls.append((name, payload))
+		return FakeRpc(self.allowed)
+
+
+def test_project_access_uses_database_admin_authorization(monkeypatch):
+	client = FakeClient(False)
+
+	@contextmanager
+	def use_fake_client(_token):
+		yield client
+
+	monkeypatch.setattr(priwa_warnkarte, 'use_client', use_fake_client)
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.require_project_access('token', 'project-1', admin=True)
+
+	assert error.value.status_code == 403
+	assert error.value.detail['code'] == 'ADMIN_REQUIRED'
+	assert client.calls == [('priwa_is_project_admin', {'p_project_id': 'project-1'})]

--- a/api/tests/priwa/test_warnkarte_router.py
+++ b/api/tests/priwa/test_warnkarte_router.py
@@ -36,30 +36,32 @@ def validated_warnkarte():
 	)
 
 
-def test_safe_member_feature_collection_excludes_provenance_and_source_ids():
-	response = priwa_warnkarte.rows_to_feature_collection(
+def test_aggregated_member_overlay_is_returned_without_row_truncation():
+	features = [
+		{
+			'type': 'Feature',
+			'geometry': {'type': 'Polygon', 'coordinates': []},
+			'properties': {'probability': 0.6},
+		}
+		for _ in range(1001)
+	]
+	response = priwa_warnkarte.overlay_from_rpc_rows(
 		[
 			{
-				'version_id': 'hidden-version',
-				'source_date': '2024-06-25',
-				'source_fid': 77,
-				'probability': '0.6',
-				'geometry': {'type': 'Polygon', 'coordinates': []},
-				'source_filename': 'hidden.gpkg',
-				'checksum_sha256': 'hidden',
+				'payload': {
+					'version_id': None,
+					'source_date': '2024-06-25',
+					'type': 'FeatureCollection',
+					'features': features,
+				}
 			}
 		]
 	)
 
 	assert response['version_id'] is None
 	assert response['source_date'] == '2024-06-25'
-	assert response['features'] == [
-		{
-			'type': 'Feature',
-			'geometry': {'type': 'Polygon', 'coordinates': []},
-			'properties': {'probability': 0.6},
-		}
-	]
+	assert len(response['features']) == 1001
+	assert response['features'] == features
 
 
 def test_validation_error_keeps_structured_expected_and_detected_crs(monkeypatch):

--- a/api/tests/priwa/test_warnkarte_validation.py
+++ b/api/tests/priwa/test_warnkarte_validation.py
@@ -1,0 +1,234 @@
+from io import BytesIO
+from pathlib import Path
+
+import fiona
+import pytest
+from shapely.geometry import Polygon, mapping
+
+from api.src.priwa import warnkarte as warnkarte_module
+from api.src.priwa.warnkarte import WarnkarteValidationError, validate_warnkarte_file
+
+
+pytestmark = pytest.mark.unit
+
+
+def write_warnkarte(
+	path: Path,
+	*,
+	crs: str | None = 'EPSG:32632',
+	properties: dict[str, str] | None = None,
+	geometry_type: str = 'Polygon',
+	probabilities: tuple[object, ...] = (0.0, 0.6000000238, 1.0),
+	geometries: tuple[Polygon | None, ...] | None = None,
+	layer: str = 'warning_polygons_2023-01-01',
+) -> Path:
+	schema = {
+		'geometry': geometry_type,
+		'properties': properties if properties is not None else {'probability': 'float'},
+	}
+	if geometries is None:
+		geometries = tuple(
+			Polygon(
+				[
+					(450000 + index * 20, 5360000),
+					(450010 + index * 20, 5360000),
+					(450010 + index * 20, 5360010),
+					(450000 + index * 20, 5360010),
+					(450000 + index * 20, 5360000),
+				]
+			)
+			for index in range(len(probabilities))
+		)
+
+	with fiona.open(
+		path,
+		mode='w',
+		driver='GPKG',
+		layer=layer,
+		crs=crs,
+		schema=schema,
+	) as sink:
+		for index, (probability, geometry) in enumerate(zip(probabilities, geometries, strict=True)):
+			row_properties = {name: None for name in schema['properties']}
+			if 'probability' in row_properties:
+				row_properties['probability'] = probability
+			sink.write(
+				{
+					'id': str(index + 1),
+					'geometry': mapping(geometry) if geometry is not None else None,
+					'properties': row_properties,
+				}
+			)
+	return path
+
+
+def validate_path(path: Path):
+	with path.open('rb') as source:
+		return validate_warnkarte_file(source, path.name)
+
+
+def test_validates_and_normalizes_a_strict_geopackage(tmp_path):
+	path = write_warnkarte(tmp_path / 'warnkarte_2024-06-25.gpkg')
+
+	validated = validate_path(path)
+
+	assert validated.source_date.isoformat() == '2024-06-25'
+	assert validated.source_crs == 'EPSG:32632'
+	assert validated.feature_count == 3
+	assert [str(polygon.probability) for polygon in validated.polygons] == ['0.0', '0.6', '1.0']
+	assert validated.warnings[0]['code'] == 'LAYER_DATE_MISMATCH'
+
+
+@pytest.mark.parametrize(
+	('filename', 'code'),
+	[
+		('warnkarte_2024-06-25.zip', 'INVALID_FILENAME'),
+		('warnkarte_2024-06-25.geojson', 'INVALID_FILENAME'),
+		('warnkarte.gpkg', 'INVALID_FILENAME'),
+		('warnkarte_2024-02-31.gpkg', 'INVALID_FILENAME_DATE'),
+	],
+)
+def test_rejects_non_gpkg_and_invalid_filename_dates(filename, code):
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_warnkarte_file(BytesIO(b'not a geopackage'), filename)
+
+	assert error.value.code == code
+
+
+def test_rejects_oversized_file_with_structured_413(monkeypatch):
+	monkeypatch.setattr(warnkarte_module, 'MAX_FILE_SIZE_BYTES', 4)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_warnkarte_file(BytesIO(b'12345'), 'warnkarte_2024-06-25.gpkg')
+
+	assert error.value.code == 'FILE_TOO_LARGE'
+	assert error.value.status_code == 413
+	assert error.value.details['max_bytes'] == 4
+
+
+def test_rejects_excessive_feature_count_with_structured_413(tmp_path, monkeypatch):
+	path = write_warnkarte(tmp_path / 'warnkarte_2024-06-25.gpkg')
+	monkeypatch.setattr(warnkarte_module, 'MAX_FEATURE_COUNT', 2)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'TOO_MANY_FEATURES'
+	assert error.value.status_code == 413
+
+
+def test_rejects_excessive_geometry_complexity_with_structured_413(tmp_path, monkeypatch):
+	path = write_warnkarte(
+		tmp_path / 'warnkarte_2024-06-25.gpkg',
+		probabilities=(0.5,),
+	)
+	monkeypatch.setattr(warnkarte_module, 'MAX_VERTICES_PER_POLYGON', 4)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'GEOMETRY_TOO_COMPLEX'
+	assert error.value.status_code == 413
+
+
+@pytest.mark.parametrize('crs', [None, 'EPSG:4326'])
+def test_rejects_missing_or_wrong_crs(tmp_path, crs):
+	path = write_warnkarte(tmp_path / 'warnkarte_2024-06-25.gpkg', crs=crs)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'INVALID_CRS'
+	assert error.value.details['expected'] == 'EPSG:32632'
+
+
+def test_rejects_multiple_layers(tmp_path):
+	path = write_warnkarte(tmp_path / 'warnkarte_2024-06-25.gpkg')
+	write_warnkarte(path, layer='second_layer', probabilities=(0.2,))
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'INVALID_LAYER_COUNT'
+
+
+@pytest.mark.parametrize(
+	'properties',
+	[
+		{},
+		{'risk': 'float'},
+		{'probability': 'float', 'model': 'str'},
+	],
+)
+def test_rejects_missing_or_unexpected_user_attributes(tmp_path, properties):
+	path = write_warnkarte(
+		tmp_path / 'warnkarte_2024-06-25.gpkg',
+		properties=properties,
+		probabilities=(0.5,),
+	)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'INVALID_COLUMNS'
+
+
+@pytest.mark.parametrize('probability', [None, -0.1, 1.1, 0.65])
+def test_rejects_invalid_probabilities(tmp_path, probability):
+	path = write_warnkarte(
+		tmp_path / 'warnkarte_2024-06-25.gpkg',
+		probabilities=(probability,),
+	)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code in {'INVALID_PROBABILITY', 'INVALID_PROBABILITY_STEP'}
+
+
+def test_rejects_non_numeric_probability_attribute(tmp_path):
+	path = write_warnkarte(
+		tmp_path / 'warnkarte_2024-06-25.gpkg',
+		properties={'probability': 'str'},
+		probabilities=('not-a-number',),
+	)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'INVALID_PROBABILITY_TYPE'
+
+
+def test_rejects_invalid_polygon_geometry(tmp_path):
+	bow_tie = Polygon(
+		[
+			(450000, 5360000),
+			(450010, 5360010),
+			(450010, 5360000),
+			(450000, 5360010),
+			(450000, 5360000),
+		]
+	)
+	path = write_warnkarte(
+		tmp_path / 'warnkarte_2024-06-25.gpkg',
+		probabilities=(0.5,),
+		geometries=(bow_tie,),
+	)
+
+	with pytest.raises(WarnkarteValidationError) as error:
+		validate_path(path)
+
+	assert error.value.code == 'INVALID_GEOMETRY'
+
+
+def test_representative_supplier_geopackage_when_available():
+	path = Path('.local/fixtures/warning_polygons_newSKs_trainAll_2024-06-25.gpkg')
+	if not path.exists():
+		pytest.skip('Representative supplier GeoPackage is not available in ignored local test space')
+
+	validated = validate_path(path)
+
+	assert validated.source_date.isoformat() == '2024-06-25'
+	assert validated.source_crs == 'EPSG:32632'
+	assert validated.feature_count == 99
+	assert {str(polygon.probability) for polygon in validated.polygons} <= {f'{step / 10:.1f}' for step in range(11)}

--- a/frontend/e2e-local/priwa-warnkarte-local.spec.ts
+++ b/frontend/e2e-local/priwa-warnkarte-local.spec.ts
@@ -1,0 +1,247 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { installLocalSession } from "./support/localAuth";
+
+const localSupabaseUrl =
+  process.env.VITE_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  "http://127.0.0.1:54321";
+const admin = {
+  id: "00000000-0000-4000-8000-0000000000c3",
+  email: "priwa-warnkarte-admin@example.com",
+};
+const projectId = "00000000-0000-4000-8000-0000000000d4";
+
+const polygon = {
+  type: "Feature" as const,
+  properties: { probability: 0.6 },
+  geometry: {
+    type: "Polygon" as const,
+    coordinates: [
+      [
+        [8.1, 48.4],
+        [8.2, 48.4],
+        [8.2, 48.5],
+        [8.1, 48.4],
+      ],
+    ],
+  },
+};
+
+async function installWarnkarteAdmin(page: Page) {
+  await installLocalSession(page, {
+    user: admin,
+    supabaseUrl: localSupabaseUrl,
+    refreshToken: "priwa-warnkarte-refresh-token",
+  });
+
+  await page.route(`${localSupabaseUrl}/rest/v1/**`, fulfillSupabaseRequest);
+}
+
+async function fulfillSupabaseRequest(route: Route) {
+  const url = new URL(route.request().url());
+  const resource = url.pathname.split("/").filter(Boolean).at(-1);
+
+  if (url.pathname.includes("/rpc/")) {
+    await route.fulfill({ contentType: "application/json", json: [] });
+    return;
+  }
+
+  if (resource === "privileged_users") {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        user_id: admin.id,
+        can_upload_private: false,
+        can_audit: false,
+        can_view_all_private: false,
+      },
+    });
+    return;
+  }
+
+  if (resource === "priwa_project_memberships") {
+    await route.fulfill({
+      contentType: "application/json",
+      json: [
+        {
+          project_id: projectId,
+          role: "admin",
+          created_at: "2024-01-01T00:00:00Z",
+          priwa_projects: {
+            id: projectId,
+            slug: "warnkarte-local",
+            name: "Warnkarte Local",
+          },
+        },
+      ],
+    });
+    return;
+  }
+
+  await route.fulfill({
+    contentType: "application/json",
+    headers: { "content-range": "0-0/0" },
+    json: [],
+  });
+}
+
+async function installWarnkarteApi(page: Page) {
+  let published = false;
+
+  await page.route("**/priwa/warnkarte/active?*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        version_id: null,
+        source_date: published ? "2024-07-01" : "2024-06-25",
+        type: "FeatureCollection",
+        features: [polygon],
+      },
+    });
+  });
+  await page.route("**/priwa/warnkarte/versions?*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: [
+        {
+          id: "version-new",
+          source_date: "2024-07-01",
+          source_filename: "warnkarte_2024-07-01.gpkg",
+          checksum_sha256: "b".repeat(64),
+          source_layer: "warning_polygons",
+          source_crs: "EPSG:32632",
+          feature_count: 1,
+          imported_by: admin.id,
+          imported_at: "2024-07-01T12:00:00Z",
+          is_current: published,
+        },
+        {
+          id: "version-old",
+          source_date: "2024-06-25",
+          source_filename: "warnkarte_2024-06-25.gpkg",
+          checksum_sha256: "a".repeat(64),
+          source_layer: "warning_polygons",
+          source_crs: "EPSG:32632",
+          feature_count: 1,
+          imported_by: admin.id,
+          imported_at: "2024-06-25T12:00:00Z",
+          is_current: !published,
+        },
+      ],
+    });
+  });
+  await page.route("**/priwa/warnkarte/validate", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        source_filename: "warnkarte_2024-07-01.gpkg",
+        checksum_sha256: "b".repeat(64),
+        authoritative_date: "2024-07-01",
+        layer: "warning_polygons",
+        crs: "EPSG:32632",
+        feature_count: 1,
+        warnings: [],
+      },
+    });
+  });
+  await page.route("**/priwa/warnkarte/import", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        version_id: "version-new",
+        summary: {
+          source_filename: "warnkarte_2024-07-01.gpkg",
+          checksum_sha256: "b".repeat(64),
+          authoritative_date: "2024-07-01",
+          layer: "warning_polygons",
+          crs: "EPSG:32632",
+          feature_count: 1,
+          warnings: [],
+        },
+      },
+    });
+  });
+  await page.route(
+    "**/priwa/warnkarte/versions/version-new/overlay?*",
+    async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          version_id: "version-new",
+          source_date: "2024-07-01",
+          type: "FeatureCollection",
+          features: [polygon],
+        },
+      });
+    },
+  );
+  await page.route(
+    "**/priwa/warnkarte/versions/version-new/publish",
+    async (route) => {
+      published = true;
+      await route.fulfill({
+        contentType: "application/json",
+        json: { publication_id: 2, version_id: "version-new" },
+      });
+    },
+  );
+}
+
+test.describe("PRIWA Warnkarte local UI", () => {
+  test("desktop admin validates, confirms, previews, and explicitly publishes", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await installWarnkarteAdmin(page);
+    await installWarnkarteApi(page);
+    await page.goto("/priwa-field");
+
+    await expect(page.getByText("Warnkarte vom 25.06.2024")).toBeVisible();
+    await page.getByRole("button", { name: "Warnkarte verwalten" }).click();
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "warnkarte_2024-07-01.gpkg",
+      mimeType: "application/geopackage+sqlite3",
+      buffer: Buffer.from("mocked direct geopackage"),
+    });
+    await page.getByRole("button", { name: "Datei validieren" }).click();
+    await expect(page.getByText("01.07.2024", { exact: true })).toBeVisible();
+    await page.getByRole("checkbox").check();
+    await page
+      .getByRole("button", {
+        name: "Unveröffentlicht importieren und Vorschau öffnen",
+      })
+      .click();
+    await expect(
+      page.getByText(/Vorschau · Warnkarte vom 01.07.2024/),
+    ).toBeVisible();
+
+    const newVersion = page.getByText("Warnkarte vom 01.07.2024").last();
+    const versionRow = newVersion.locator("xpath=ancestor::li");
+    await versionRow.getByRole("button", { name: "Veröffentlichen" }).click();
+    await page
+      .getByRole("button", { name: "Veröffentlichen", exact: true })
+      .last()
+      .click();
+    await expect(page.getByText("Warnkarte veröffentlicht.")).toBeVisible();
+    await expect(page.getByText(/Vorschau ·/)).toHaveCount(0);
+    await expect(
+      page.getByText("Warnkarte vom 01.07.2024").first(),
+    ).toBeVisible();
+  });
+
+  test("mobile shows the published overlay label without management controls", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await installWarnkarteAdmin(page);
+    await installWarnkarteApi(page);
+    await page.goto("/priwa-field");
+
+    await expect(page.getByText("Warnkarte vom 25.06.2024")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Warnkarte verwalten" }),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("priwa-field-map")).toBeVisible();
+  });
+});

--- a/frontend/e2e-local/priwa-warnkarte-local.spec.ts
+++ b/frontend/e2e-local/priwa-warnkarte-local.spec.ts
@@ -86,7 +86,10 @@ async function fulfillSupabaseRequest(route: Route) {
   });
 }
 
-async function installWarnkarteApi(page: Page) {
+async function installWarnkarteApi(
+  page: Page,
+  { validateDelayMs = 0 }: { validateDelayMs?: number } = {},
+) {
   let published = false;
 
   await page.route("**/priwa/warnkarte/active?*", async (route) => {
@@ -132,6 +135,9 @@ async function installWarnkarteApi(page: Page) {
     });
   });
   await page.route("**/priwa/warnkarte/validate", async (route) => {
+    if (validateDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, validateDelayMs));
+    }
     await route.fulfill({
       contentType: "application/json",
       json: {
@@ -228,6 +234,28 @@ test.describe("PRIWA Warnkarte local UI", () => {
     await expect(
       page.getByText("Warnkarte vom 01.07.2024").first(),
     ).toBeVisible();
+  });
+
+  test("desktop admin cannot replace a file while its validation is pending", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await installWarnkarteAdmin(page);
+    await installWarnkarteApi(page, { validateDelayMs: 750 });
+    await page.goto("/priwa-field");
+
+    await page.getByRole("button", { name: "Warnkarte verwalten" }).click();
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: "warnkarte_2024-07-01.gpkg",
+      mimeType: "application/geopackage+sqlite3",
+      buffer: Buffer.from("mocked direct geopackage"),
+    });
+    await page.getByRole("button", { name: "Datei validieren" }).click();
+
+    await expect(fileInput).toBeDisabled();
+    await expect(page.getByText("01.07.2024", { exact: true })).toBeVisible();
+    await expect(fileInput).toBeEnabled();
   });
 
   test("mobile shows the published overlay label without management controls", async ({

--- a/frontend/e2e-local/priwa-warnkarte-local.spec.ts
+++ b/frontend/e2e-local/priwa-warnkarte-local.spec.ts
@@ -204,13 +204,20 @@ test.describe("PRIWA Warnkarte local UI", () => {
     await page.goto("/priwa-field");
 
     await expect(page.getByText("Warnkarte vom 25.06.2024")).toBeVisible();
-    await page.getByRole("button", { name: "Warnkarte verwalten" }).click();
+    const warnkarteControl = page
+      .locator(".priwa-map-control-stack")
+      .getByRole("button", { name: "Warnkarte verwalten" });
+    await expect(warnkarteControl).toBeVisible();
+    await expect(warnkarteControl).toHaveClass(/ant-btn-circle/);
+    await warnkarteControl.click();
     await page.locator('input[type="file"]').setInputFiles({
       name: "warnkarte_2024-07-01.gpkg",
       mimeType: "application/geopackage+sqlite3",
       buffer: Buffer.from("mocked direct geopackage"),
     });
-    await page.getByRole("button", { name: "Datei validieren" }).click();
+    await expect(
+      page.getByRole("button", { name: "Datei validieren" }),
+    ).toHaveCount(0);
     await expect(page.getByText("01.07.2024", { exact: true })).toBeVisible();
     await page.getByRole("checkbox").check();
     await page
@@ -251,11 +258,42 @@ test.describe("PRIWA Warnkarte local UI", () => {
       mimeType: "application/geopackage+sqlite3",
       buffer: Buffer.from("mocked direct geopackage"),
     });
-    await page.getByRole("button", { name: "Datei validieren" }).click();
 
     await expect(fileInput).toBeDisabled();
+    await expect(page.getByText("GeoPackage wird validiert …")).toBeVisible();
     await expect(page.getByText("01.07.2024", { exact: true })).toBeVisible();
     await expect(fileInput).toBeEnabled();
+  });
+
+  test("desktop preview explains when Warnkarte API routes are not deployed", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await installWarnkarteAdmin(page);
+    await installWarnkarteApi(page);
+    const unavailable = (route: Route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        json: { detail: "Not Found" },
+      });
+    await page.route("**/priwa/warnkarte/versions?*", unavailable);
+    await page.route("**/priwa/warnkarte/validate", unavailable);
+    await page.goto("/priwa-field");
+
+    await page.getByRole("button", { name: "Warnkarte verwalten" }).click();
+    const explanation =
+      "Die Warnkarten-Funktion ist in dieser Vorschau noch nicht verfügbar. Die Datei wurde nicht validiert.";
+    await expect(page.getByText(explanation)).toHaveCount(1);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "warnkarte_2024-07-01.gpkg",
+      mimeType: "application/geopackage+sqlite3",
+      buffer: Buffer.from("mocked direct geopackage"),
+    });
+
+    await expect(page.getByText(explanation)).toHaveCount(2);
+    await expect(page.getByText("Not Found", { exact: true })).toHaveCount(0);
   });
 
   test("mobile shows the published overlay label without management controls", async ({

--- a/frontend/src/api/priwaWarnkarte.test.ts
+++ b/frontend/src/api/priwaWarnkarte.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchPriwaWarnkarteVersions } from "./priwaWarnkarte";
+
+describe("PRIWA Warnkarte API errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("explains when a preview points to an API without Warnkarte routes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const request = fetchPriwaWarnkarteVersions("project-1", "token");
+
+    await expect(request).rejects.toMatchObject({
+      code: "WARNKARTE_API_UNAVAILABLE",
+      message:
+        "Die Warnkarten-Funktion ist in dieser Vorschau noch nicht verfügbar. Die Datei wurde nicht validiert.",
+      details: { status: 404 },
+    });
+  });
+});

--- a/frontend/src/api/priwaWarnkarte.ts
+++ b/frontend/src/api/priwaWarnkarte.ts
@@ -1,0 +1,172 @@
+import type { FeatureCollection, Polygon } from "geojson";
+
+import { Settings } from "../config";
+
+export interface IPriwaWarnkarteValidationWarning {
+  code: string;
+  message: string;
+  details: Record<string, unknown>;
+}
+
+export interface IPriwaWarnkarteValidationSummary {
+  source_filename: string;
+  checksum_sha256: string;
+  authoritative_date: string;
+  layer: string;
+  crs: string;
+  feature_count: number;
+  warnings: IPriwaWarnkarteValidationWarning[];
+}
+
+export type IPriwaWarnkarteOverlay = FeatureCollection<
+  Polygon,
+  { probability: number }
+> & {
+  version_id: string | null;
+  source_date: string | null;
+};
+
+export interface IPriwaWarnkarteVersion {
+  id: string;
+  source_date: string;
+  source_filename: string;
+  checksum_sha256: string;
+  source_layer: string;
+  source_crs: string;
+  feature_count: number;
+  imported_by: string;
+  imported_at: string;
+  is_current: boolean;
+}
+
+export interface IPriwaWarnkarteImportResponse {
+  version_id: string;
+  summary: IPriwaWarnkarteValidationSummary;
+}
+
+export class PriwaWarnkarteApiError extends Error {
+  code: string;
+  details: Record<string, unknown>;
+
+  constructor(
+    code: string,
+    message: string,
+    details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = "PriwaWarnkarteApiError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const authHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+});
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  if (response.ok) return response.json() as Promise<T>;
+
+  const body = await response.json().catch(() => null);
+  const detail = body?.detail;
+  if (detail && typeof detail === "object") {
+    throw new PriwaWarnkarteApiError(
+      detail.code || "REQUEST_FAILED",
+      detail.message || "Die Warnkarten-Anfrage ist fehlgeschlagen.",
+      detail.details || {},
+    );
+  }
+
+  throw new PriwaWarnkarteApiError(
+    "REQUEST_FAILED",
+    typeof detail === "string"
+      ? detail
+      : `Die Warnkarten-Anfrage ist fehlgeschlagen (${response.status}).`,
+  );
+}
+
+const uploadForm = (projectId: string, file: File) => {
+  const form = new FormData();
+  form.append("project_id", projectId);
+  form.append("file", file);
+  return form;
+};
+
+export async function validatePriwaWarnkarte(
+  projectId: string,
+  file: File,
+  token: string,
+) {
+  const response = await fetch(`${Settings.API_URL}/priwa/warnkarte/validate`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: uploadForm(projectId, file),
+  });
+  return parseResponse<IPriwaWarnkarteValidationSummary>(response);
+}
+
+export async function importPriwaWarnkarte(
+  projectId: string,
+  file: File,
+  confirmedDate: string,
+  token: string,
+) {
+  const form = uploadForm(projectId, file);
+  form.append("confirmed_date", confirmedDate);
+  const response = await fetch(`${Settings.API_URL}/priwa/warnkarte/import`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: form,
+  });
+  return parseResponse<IPriwaWarnkarteImportResponse>(response);
+}
+
+export async function fetchPriwaWarnkarteVersions(
+  projectId: string,
+  token: string,
+) {
+  const query = new URLSearchParams({ project_id: projectId });
+  const response = await fetch(
+    `${Settings.API_URL}/priwa/warnkarte/versions?${query}`,
+    { headers: authHeaders(token) },
+  );
+  return parseResponse<IPriwaWarnkarteVersion[]>(response);
+}
+
+export async function fetchActivePriwaWarnkarte(
+  projectId: string,
+  token: string,
+) {
+  const query = new URLSearchParams({ project_id: projectId });
+  const response = await fetch(
+    `${Settings.API_URL}/priwa/warnkarte/active?${query}`,
+    { headers: authHeaders(token) },
+  );
+  return parseResponse<IPriwaWarnkarteOverlay>(response);
+}
+
+export async function fetchPriwaWarnkarteVersionOverlay(
+  projectId: string,
+  versionId: string,
+  token: string,
+) {
+  const query = new URLSearchParams({ project_id: projectId });
+  const response = await fetch(
+    `${Settings.API_URL}/priwa/warnkarte/versions/${versionId}/overlay?${query}`,
+    { headers: authHeaders(token) },
+  );
+  return parseResponse<IPriwaWarnkarteOverlay>(response);
+}
+
+export async function publishPriwaWarnkarteVersion(
+  versionId: string,
+  token: string,
+) {
+  const response = await fetch(
+    `${Settings.API_URL}/priwa/warnkarte/versions/${versionId}/publish`,
+    { method: "POST", headers: authHeaders(token) },
+  );
+  return parseResponse<{ publication_id: number; version_id: string }>(
+    response,
+  );
+}

--- a/frontend/src/api/priwaWarnkarte.ts
+++ b/frontend/src/api/priwaWarnkarte.ts
@@ -77,6 +77,14 @@ async function parseResponse<T>(response: Response): Promise<T> {
     );
   }
 
+  if (response.status === 404 && detail === "Not Found") {
+    throw new PriwaWarnkarteApiError(
+      "WARNKARTE_API_UNAVAILABLE",
+      "Die Warnkarten-Funktion ist in dieser Vorschau noch nicht verfügbar. Die Datei wurde nicht validiert.",
+      { status: response.status },
+    );
+  }
+
   throw new PriwaWarnkarteApiError(
     "REQUEST_FAILED",
     typeof detail === "string"

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -12,7 +12,7 @@ import { fromLonLat, toLonLat, transformExtent } from "ol/proj";
 import View from "ol/View";
 import { boundingExtent } from "ol/extent";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PointerEvent } from "react";
+import type { PointerEvent, ReactNode } from "react";
 
 import { createStandardMapControls } from "../../utils/basemaps";
 import parseBBox from "../../utils/parseBBox";
@@ -74,6 +74,7 @@ interface PriwaFieldMapProps {
   isSavingPoint?: boolean;
   projectName: string;
   warnkarteOverlay?: IPriwaWarnkarteOverlay | null;
+  additionalMapControl?: ReactNode;
   mosaics?: IPriwaMosaic[];
   groups?: IPriwaBefallsgruppe[];
   isCogLoading?: boolean;
@@ -107,6 +108,7 @@ export default function PriwaFieldMap({
   isSavingPoint = false,
   projectName,
   warnkarteOverlay = null,
+  additionalMapControl,
   mosaics = [],
   groups = [],
   isCogLoading = false,
@@ -786,6 +788,7 @@ export default function PriwaFieldMap({
             onCache={handleCacheBasemapArea}
             onClear={handleClearBasemapArea}
           />
+          {additionalMapControl}
           {isMobile && (
             <PriwaMobileFieldTools
               points={points}

--- a/frontend/src/components/PriwaField/PriwaFieldMap.tsx
+++ b/frontend/src/components/PriwaField/PriwaFieldMap.tsx
@@ -33,6 +33,10 @@ import {
   createPriwaPreviewLayer,
 } from "./createPriwaPointLayer";
 import { createPriwaBefallsgruppeLayer } from "./createPriwaBefallsgruppeLayer";
+import {
+  createPriwaWarnkarteLayer,
+  setPriwaWarnkarteLayerData,
+} from "./createPriwaWarnkarteLayer";
 import PriwaPointDrawer from "./PriwaPointDrawer";
 import PriwaPointListPanel from "./PriwaPointListPanel";
 import PriwaOfflineStatus from "./PriwaOfflineStatus";
@@ -50,6 +54,7 @@ import { usePriwaReviewController } from "./usePriwaReviewController";
 import { usePriwaReviewMapLayers } from "./usePriwaReviewMapLayers";
 import type { IPriwaMosaic, PriwaFlightType } from "./usePriwaMosaics";
 import type { IPriwaSyncSummary } from "./priwaOfflineSync";
+import type { IPriwaWarnkarteOverlay } from "../../api/priwaWarnkarte";
 import type {
   IPriwaBefallsgruppe,
   IPriwaBefallsgruppeSaveInput,
@@ -68,6 +73,7 @@ interface PriwaFieldMapProps {
   isLoadingPoints?: boolean;
   isSavingPoint?: boolean;
   projectName: string;
+  warnkarteOverlay?: IPriwaWarnkarteOverlay | null;
   mosaics?: IPriwaMosaic[];
   groups?: IPriwaBefallsgruppe[];
   isCogLoading?: boolean;
@@ -100,6 +106,7 @@ export default function PriwaFieldMap({
   isLoadingPoints = false,
   isSavingPoint = false,
   projectName,
+  warnkarteOverlay = null,
   mosaics = [],
   groups = [],
   isCogLoading = false,
@@ -130,6 +137,9 @@ export default function PriwaFieldMap({
   );
   const groupLayerRef = useRef<ReturnType<
     typeof createPriwaBefallsgruppeLayer
+  > | null>(null);
+  const warnkarteLayerRef = useRef<ReturnType<
+    typeof createPriwaWarnkarteLayer
   > | null>(null);
   const previewLayerRef = useRef<ReturnType<
     typeof createPriwaPreviewLayer
@@ -307,6 +317,7 @@ export default function PriwaFieldMap({
     const dopLayer = createLglDop20Layer();
     const offlineAreaLayer = createPriwaOfflineAreaLayer();
     const mosaicFootprintLayer = createPriwaMosaicFootprintLayer();
+    const warnkarteLayer = createPriwaWarnkarteLayer();
     const groupLayer = createPriwaBefallsgruppeLayer();
     const pointLayer = createPriwaPointLayer([]);
     const previewLayer = createPriwaPreviewLayer();
@@ -314,6 +325,7 @@ export default function PriwaFieldMap({
     topographicLayerRef.current = topographicLayer;
     offlineAreaLayerRef.current = offlineAreaLayer;
     mosaicFootprintLayerRef.current = mosaicFootprintLayer;
+    warnkarteLayerRef.current = warnkarteLayer;
     groupLayerRef.current = groupLayer;
     pointLayerRef.current = pointLayer;
     previewLayerRef.current = previewLayer;
@@ -324,6 +336,7 @@ export default function PriwaFieldMap({
         topographicLayer,
         dopLayer,
         offlineAreaLayer,
+        warnkarteLayer,
         mosaicFootprintLayer,
         groupLayer,
         pointLayer,
@@ -419,11 +432,17 @@ export default function PriwaFieldMap({
       aerialLayerRef.current = null;
       topographicLayerRef.current = null;
       mosaicFootprintLayerRef.current = null;
+      warnkarteLayerRef.current = null;
       groupLayerRef.current = null;
       pointLayerRef.current = null;
       previewLayerRef.current = null;
     };
   }, [stopUserLocation, userLocationLayer]);
+
+  useEffect(() => {
+    if (!warnkarteLayerRef.current) return;
+    setPriwaWarnkarteLayerData(warnkarteLayerRef.current, warnkarteOverlay);
+  }, [warnkarteOverlay]);
 
   useEffect(() => {
     aerialLayerRef.current?.setVisible(baseLayer === "aerial");

--- a/frontend/src/components/PriwaField/PriwaWarnkarteAdminDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteAdminDrawer.tsx
@@ -1,0 +1,150 @@
+import { WarningOutlined } from "@ant-design/icons";
+import { Alert, App, Button, Divider, Drawer, Spin, Typography } from "antd";
+import { useState } from "react";
+
+import type {
+  IPriwaWarnkarteValidationSummary,
+  IPriwaWarnkarteVersion,
+} from "../../api/priwaWarnkarte";
+import PriwaWarnkarteUploadPanel from "./PriwaWarnkarteUploadPanel";
+import PriwaWarnkarteVersionList from "./PriwaWarnkarteVersionList";
+import { formatPriwaWarnkarteError } from "./priwaWarnkartePresentation";
+
+interface PriwaWarnkarteAdminDrawerProps {
+  versions: IPriwaWarnkarteVersion[];
+  versionsError: unknown;
+  isLoadingVersions: boolean;
+  previewVersionId: string | null;
+  onClearPreview: () => void;
+  onValidate: (file: File) => Promise<IPriwaWarnkarteValidationSummary>;
+  onImport: (file: File, confirmedDate: string) => Promise<unknown>;
+  onPreview: (versionId: string) => Promise<void>;
+  onPublish: (versionId: string) => Promise<void>;
+}
+
+export default function PriwaWarnkarteAdminDrawer({
+  versions,
+  versionsError,
+  isLoadingVersions,
+  previewVersionId,
+  onClearPreview,
+  onValidate,
+  onImport,
+  onPreview,
+  onPublish,
+}: PriwaWarnkarteAdminDrawerProps) {
+  const { message } = App.useApp();
+  const [open, setOpen] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [summary, setSummary] =
+    useState<IPriwaWarnkarteValidationSummary | null>(null);
+  const [isConfirmed, setConfirmed] = useState(false);
+  const [isBusy, setBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const run = async (operation: () => Promise<void>) => {
+    setBusy(true);
+    setErrorMessage(null);
+    try {
+      await operation();
+    } catch (error) {
+      setErrorMessage(formatPriwaWarnkarteError(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const validate = () => {
+    if (!file) return;
+    void run(async () => {
+      setSummary(await onValidate(file));
+      setConfirmed(false);
+    });
+  };
+
+  const importFile = () => {
+    if (!file || !summary || !isConfirmed) return;
+    void run(async () => {
+      await onImport(file, summary.authoritative_date);
+      message.success(
+        "Warnkarte unveröffentlicht importiert. Die Vorschau ist aktiv.",
+      );
+    });
+  };
+
+  const preview = (versionId: string) =>
+    void run(async () => {
+      await onPreview(versionId);
+      message.success("Warnkarten-Vorschau geladen.");
+    });
+
+  const publish = (versionId: string) =>
+    void run(async () => {
+      await onPublish(versionId);
+      message.success("Warnkarte veröffentlicht.");
+    });
+
+  return (
+    <>
+      <Button
+        className="absolute right-4 top-4 z-[70] shadow-md"
+        icon={<WarningOutlined />}
+        onClick={() => setOpen(true)}
+      >
+        Warnkarte verwalten
+      </Button>
+      <Drawer
+        title="PRIWA Warnkarte verwalten"
+        width={620}
+        open={open}
+        onClose={() => setOpen(false)}
+        extra={
+          previewVersionId ? (
+            <Button onClick={onClearPreview}>Vorschau beenden</Button>
+          ) : null
+        }
+      >
+        <Typography.Title level={5}>Neue Version</Typography.Title>
+        <PriwaWarnkarteUploadPanel
+          file={file}
+          summary={summary}
+          isConfirmed={isConfirmed}
+          isBusy={isBusy}
+          errorMessage={errorMessage}
+          onFileChange={(nextFile) => {
+            setFile(nextFile);
+            setSummary(null);
+            setConfirmed(false);
+            setErrorMessage(null);
+          }}
+          onConfirmedChange={setConfirmed}
+          onValidate={validate}
+          onImport={importFile}
+        />
+        <Divider />
+        <Typography.Title level={5}>Importierte Versionen</Typography.Title>
+        {!!versionsError && (
+          <Alert
+            type="error"
+            showIcon
+            message="Versionen konnten nicht geladen werden"
+            description={formatPriwaWarnkarteError(versionsError)}
+          />
+        )}
+        {isLoadingVersions ? (
+          <div className="flex justify-center p-8">
+            <Spin />
+          </div>
+        ) : (
+          <PriwaWarnkarteVersionList
+            versions={versions}
+            previewVersionId={previewVersionId}
+            isBusy={isBusy}
+            onPreview={preview}
+            onPublish={publish}
+          />
+        )}
+      </Drawer>
+    </>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaWarnkarteAdminDrawer.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteAdminDrawer.tsx
@@ -1,5 +1,14 @@
 import { WarningOutlined } from "@ant-design/icons";
-import { Alert, App, Button, Divider, Drawer, Spin, Typography } from "antd";
+import {
+  Alert,
+  App,
+  Button,
+  Divider,
+  Drawer,
+  Spin,
+  Tooltip,
+  Typography,
+} from "antd";
 import { useState } from "react";
 
 import type {
@@ -54,10 +63,15 @@ export default function PriwaWarnkarteAdminDrawer({
     }
   };
 
-  const validate = () => {
-    if (!file) return;
+  const selectFile = (nextFile: File | null) => {
+    setFile(nextFile);
+    setSummary(null);
+    setConfirmed(false);
+    setErrorMessage(null);
+    if (!nextFile) return;
+
     void run(async () => {
-      setSummary(await onValidate(file));
+      setSummary(await onValidate(nextFile));
       setConfirmed(false);
     });
   };
@@ -86,13 +100,16 @@ export default function PriwaWarnkarteAdminDrawer({
 
   return (
     <>
-      <Button
-        className="absolute right-4 top-4 z-[70] shadow-md"
-        icon={<WarningOutlined />}
-        onClick={() => setOpen(true)}
-      >
-        Warnkarte verwalten
-      </Button>
+      <Tooltip title="Warnkarte verwalten" placement="right">
+        <Button
+          className="pointer-events-auto shadow-md"
+          shape="circle"
+          size="large"
+          icon={<WarningOutlined />}
+          aria-label="Warnkarte verwalten"
+          onClick={() => setOpen(true)}
+        />
+      </Tooltip>
       <Drawer
         title="PRIWA Warnkarte verwalten"
         width={620}
@@ -106,19 +123,12 @@ export default function PriwaWarnkarteAdminDrawer({
       >
         <Typography.Title level={5}>Neue Version</Typography.Title>
         <PriwaWarnkarteUploadPanel
-          file={file}
           summary={summary}
           isConfirmed={isConfirmed}
           isBusy={isBusy}
           errorMessage={errorMessage}
-          onFileChange={(nextFile) => {
-            setFile(nextFile);
-            setSummary(null);
-            setConfirmed(false);
-            setErrorMessage(null);
-          }}
+          onFileChange={selectFile}
           onConfirmedChange={setConfirmed}
-          onValidate={validate}
           onImport={importFile}
         />
         <Divider />

--- a/frontend/src/components/PriwaField/PriwaWarnkarteStatus.test.ts
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteStatus.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import PriwaWarnkarteStatus from "./PriwaWarnkarteStatus";
+
+describe("PriwaWarnkarteStatus", () => {
+  it("renders the safe German date label for members", () => {
+    const html = renderToStaticMarkup(
+      createElement(PriwaWarnkarteStatus, {
+        sourceDate: "2024-06-25",
+        isPreviewing: false,
+      }),
+    );
+
+    expect(html).toContain("Warnkarte vom 25.06.2024");
+    expect(html).not.toContain("checksum");
+  });
+
+  it("marks an unpublished admin overlay as a preview", () => {
+    const html = renderToStaticMarkup(
+      createElement(PriwaWarnkarteStatus, {
+        sourceDate: "2024-06-25",
+        isPreviewing: true,
+      }),
+    );
+
+    expect(html).toContain("Vorschau");
+  });
+});

--- a/frontend/src/components/PriwaField/PriwaWarnkarteStatus.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteStatus.tsx
@@ -1,0 +1,24 @@
+import { Tag } from "antd";
+
+import { formatPriwaWarnkarteDate } from "./priwaWarnkartePresentation";
+
+interface PriwaWarnkarteStatusProps {
+  sourceDate: string | null;
+  isPreviewing: boolean;
+}
+
+export default function PriwaWarnkarteStatus({
+  sourceDate,
+  isPreviewing,
+}: PriwaWarnkarteStatusProps) {
+  const formattedDate = formatPriwaWarnkarteDate(sourceDate);
+  if (!formattedDate) return null;
+
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-4 z-[60] -translate-x-1/2">
+      <Tag color={isPreviewing ? "gold" : "red"} className="m-0 shadow-md">
+        {isPreviewing ? "Vorschau · " : ""}Warnkarte vom {formattedDate}
+      </Tag>
+    </div>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
@@ -43,6 +43,7 @@ export default function PriwaWarnkarteUploadPanel({
       </Typography.Paragraph>
       <Upload
         accept=".gpkg"
+        disabled={isBusy}
         maxCount={1}
         beforeUpload={(nextFile) => {
           onFileChange(nextFile);

--- a/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
@@ -13,26 +13,22 @@ import type { IPriwaWarnkarteValidationSummary } from "../../api/priwaWarnkarte"
 import { formatPriwaWarnkarteDate } from "./priwaWarnkartePresentation";
 
 interface PriwaWarnkarteUploadPanelProps {
-  file: File | null;
   summary: IPriwaWarnkarteValidationSummary | null;
   isConfirmed: boolean;
   isBusy: boolean;
   errorMessage: string | null;
   onFileChange: (file: File | null) => void;
   onConfirmedChange: (confirmed: boolean) => void;
-  onValidate: () => void;
   onImport: () => void;
 }
 
 export default function PriwaWarnkarteUploadPanel({
-  file,
   summary,
   isConfirmed,
   isBusy,
   errorMessage,
   onFileChange,
   onConfirmedChange,
-  onValidate,
   onImport,
 }: PriwaWarnkarteUploadPanelProps) {
   return (
@@ -56,14 +52,15 @@ export default function PriwaWarnkarteUploadPanel({
       >
         <Button icon={<UploadOutlined />}>GeoPackage auswählen</Button>
       </Upload>
-      <Button
-        type="primary"
-        disabled={!file || isBusy}
-        loading={isBusy && !summary}
-        onClick={onValidate}
-      >
-        Datei validieren
-      </Button>
+
+      {isBusy && !summary && (
+        <Alert
+          type="info"
+          showIcon
+          message="GeoPackage wird validiert …"
+          description="Die Datei wird geprüft. Anschließend werden Datum, Layer, CRS und Polygonanzahl angezeigt."
+        />
+      )}
 
       {errorMessage && (
         <Alert

--- a/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteUploadPanel.tsx
@@ -1,0 +1,122 @@
+import { UploadOutlined } from "@ant-design/icons";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Descriptions,
+  Space,
+  Typography,
+  Upload,
+} from "antd";
+
+import type { IPriwaWarnkarteValidationSummary } from "../../api/priwaWarnkarte";
+import { formatPriwaWarnkarteDate } from "./priwaWarnkartePresentation";
+
+interface PriwaWarnkarteUploadPanelProps {
+  file: File | null;
+  summary: IPriwaWarnkarteValidationSummary | null;
+  isConfirmed: boolean;
+  isBusy: boolean;
+  errorMessage: string | null;
+  onFileChange: (file: File | null) => void;
+  onConfirmedChange: (confirmed: boolean) => void;
+  onValidate: () => void;
+  onImport: () => void;
+}
+
+export default function PriwaWarnkarteUploadPanel({
+  file,
+  summary,
+  isConfirmed,
+  isBusy,
+  errorMessage,
+  onFileChange,
+  onConfirmedChange,
+  onValidate,
+  onImport,
+}: PriwaWarnkarteUploadPanelProps) {
+  return (
+    <Space direction="vertical" size="middle" className="w-full">
+      <Typography.Paragraph type="secondary" className="mb-0">
+        Nur direkte GeoPackages mit genau einem Polygon-Layer und EPSG:32632.
+        ZIP und GeoJSON werden nicht akzeptiert.
+      </Typography.Paragraph>
+      <Upload
+        accept=".gpkg"
+        maxCount={1}
+        beforeUpload={(nextFile) => {
+          onFileChange(nextFile);
+          return false;
+        }}
+        onRemove={() => {
+          onFileChange(null);
+          return true;
+        }}
+      >
+        <Button icon={<UploadOutlined />}>GeoPackage auswählen</Button>
+      </Upload>
+      <Button
+        type="primary"
+        disabled={!file || isBusy}
+        loading={isBusy && !summary}
+        onClick={onValidate}
+      >
+        Datei validieren
+      </Button>
+
+      {errorMessage && (
+        <Alert
+          type="error"
+          showIcon
+          message="Validierung fehlgeschlagen"
+          description={errorMessage}
+        />
+      )}
+
+      {summary && (
+        <>
+          <Descriptions bordered size="small" column={1}>
+            <Descriptions.Item label="Maßgebliches Datum">
+              {formatPriwaWarnkarteDate(summary.authoritative_date)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Polygone">
+              {summary.feature_count}
+            </Descriptions.Item>
+            <Descriptions.Item label="Layer">{summary.layer}</Descriptions.Item>
+            <Descriptions.Item label="CRS">{summary.crs}</Descriptions.Item>
+            <Descriptions.Item label="Prüfsumme">
+              <Typography.Text copyable ellipsis className="max-w-64">
+                {summary.checksum_sha256}
+              </Typography.Text>
+            </Descriptions.Item>
+          </Descriptions>
+          {summary.warnings.map((warning) => (
+            <Alert
+              key={warning.code}
+              type="warning"
+              showIcon
+              message={warning.message}
+            />
+          ))}
+          <Checkbox
+            checked={isConfirmed}
+            onChange={(event) => onConfirmedChange(event.target.checked)}
+          >
+            Ich bestätige das maßgebliche Datum{" "}
+            {formatPriwaWarnkarteDate(summary.authoritative_date)} aus dem
+            Dateinamen.
+          </Checkbox>
+          <Button
+            type="primary"
+            danger
+            disabled={!isConfirmed || isBusy}
+            loading={isBusy}
+            onClick={onImport}
+          >
+            Unveröffentlicht importieren und Vorschau öffnen
+          </Button>
+        </>
+      )}
+    </Space>
+  );
+}

--- a/frontend/src/components/PriwaField/PriwaWarnkarteVersionList.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteVersionList.tsx
@@ -1,0 +1,83 @@
+import { Button, Empty, List, Popconfirm, Space, Tag, Typography } from "antd";
+
+import type { IPriwaWarnkarteVersion } from "../../api/priwaWarnkarte";
+import { formatPriwaWarnkarteDate } from "./priwaWarnkartePresentation";
+
+interface PriwaWarnkarteVersionListProps {
+  versions: IPriwaWarnkarteVersion[];
+  previewVersionId: string | null;
+  isBusy: boolean;
+  onPreview: (versionId: string) => void;
+  onPublish: (versionId: string) => void;
+}
+
+export default function PriwaWarnkarteVersionList({
+  versions,
+  previewVersionId,
+  isBusy,
+  onPreview,
+  onPublish,
+}: PriwaWarnkarteVersionListProps) {
+  if (versions.length === 0) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description="Noch keine Warnkarten importiert"
+      />
+    );
+  }
+
+  return (
+    <List
+      dataSource={versions}
+      renderItem={(version) => (
+        <List.Item
+          actions={[
+            <Button
+              key="preview"
+              size="small"
+              disabled={isBusy}
+              onClick={() => onPreview(version.id)}
+            >
+              Vorschau
+            </Button>,
+            <Popconfirm
+              key="publish"
+              title="Diese Version als aktive Warnkarte veröffentlichen?"
+              description="Die bisherige Version bleibt erhalten und kann erneut veröffentlicht werden."
+              okText="Veröffentlichen"
+              cancelText="Abbrechen"
+              onConfirm={() => onPublish(version.id)}
+            >
+              <Button size="small" type="primary" danger disabled={isBusy}>
+                {version.is_current
+                  ? "Erneut veröffentlichen"
+                  : "Veröffentlichen"}
+              </Button>
+            </Popconfirm>,
+          ]}
+        >
+          <List.Item.Meta
+            title={
+              <Space wrap>
+                <span>
+                  Warnkarte vom {formatPriwaWarnkarteDate(version.source_date)}
+                </span>
+                {version.is_current && <Tag color="red">Aktiv</Tag>}
+                {previewVersionId === version.id && (
+                  <Tag color="gold">Vorschau</Tag>
+                )}
+              </Space>
+            }
+            description={
+              <Typography.Text type="secondary">
+                {version.feature_count} Polygone · importiert{" "}
+                {new Date(version.imported_at).toLocaleString("de-DE")}
+              </Typography.Text>
+            }
+          />
+        </List.Item>
+      )}
+    />
+  );
+}

--- a/frontend/src/components/PriwaField/createPriwaWarnkarteLayer.test.ts
+++ b/frontend/src/components/PriwaField/createPriwaWarnkarteLayer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { IPriwaWarnkarteOverlay } from "../../api/priwaWarnkarte";
+import {
+  PRIWA_WARNKARTE_RED_BANDS,
+  createPriwaWarnkarteLayer,
+  getPriwaWarnkarteBandIndex,
+  getPriwaWarnkarteStyle,
+  setPriwaWarnkarteLayerData,
+} from "./createPriwaWarnkarteLayer";
+
+const overlay: IPriwaWarnkarteOverlay = {
+  version_id: "version-1",
+  source_date: "2024-06-25",
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      id: 1,
+      properties: { probability: 0.6 },
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [8.1, 48.4],
+            [8.2, 48.4],
+            [8.2, 48.5],
+            [8.1, 48.4],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
+describe("PRIWA Warnkarte layer", () => {
+  it("maps 0.0 and 0.1 to the lightest band and 1.0 to the darkest", () => {
+    expect(getPriwaWarnkarteBandIndex(0)).toBe(0);
+    expect(getPriwaWarnkarteBandIndex(0.1)).toBe(0);
+    expect(getPriwaWarnkarteBandIndex(0.2)).toBe(1);
+    expect(getPriwaWarnkarteBandIndex(1)).toBe(9);
+    expect(getPriwaWarnkarteStyle(1).getFill()?.getColor()).toBe(
+      PRIWA_WARNKARTE_RED_BANDS[9],
+    );
+  });
+
+  it("loads safe GeoJSON into an independent EPSG:3857 vector layer", () => {
+    const layer = createPriwaWarnkarteLayer();
+
+    setPriwaWarnkarteLayerData(layer, overlay);
+
+    const features = layer.getSource()?.getFeatures() ?? [];
+    expect(features).toHaveLength(1);
+    expect(features[0].get("probability")).toBe(0.6);
+    expect(features[0].getGeometry()?.getType()).toBe("Polygon");
+  });
+});

--- a/frontend/src/components/PriwaField/createPriwaWarnkarteLayer.ts
+++ b/frontend/src/components/PriwaField/createPriwaWarnkarteLayer.ts
@@ -1,0 +1,59 @@
+import GeoJSON from "ol/format/GeoJSON";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import { Fill, Stroke, Style } from "ol/style";
+
+import type { IPriwaWarnkarteOverlay } from "../../api/priwaWarnkarte";
+
+export const PRIWA_WARNKARTE_RED_BANDS = [
+  "rgba(254, 226, 226, 0.58)",
+  "rgba(254, 202, 202, 0.60)",
+  "rgba(252, 165, 165, 0.62)",
+  "rgba(248, 113, 113, 0.64)",
+  "rgba(239, 68, 68, 0.66)",
+  "rgba(220, 38, 38, 0.68)",
+  "rgba(185, 28, 28, 0.70)",
+  "rgba(153, 27, 27, 0.72)",
+  "rgba(127, 29, 29, 0.74)",
+  "rgba(69, 10, 10, 0.78)",
+] as const;
+
+export const getPriwaWarnkarteBandIndex = (probability: number) => {
+  const bounded = Math.min(1, Math.max(0, probability));
+  return bounded === 0 ? 0 : Math.ceil(bounded * 10) - 1;
+};
+
+export const getPriwaWarnkarteStyle = (probability: number) => {
+  const band = getPriwaWarnkarteBandIndex(probability);
+  return new Style({
+    fill: new Fill({ color: PRIWA_WARNKARTE_RED_BANDS[band] }),
+    stroke: new Stroke({
+      color: band >= 7 ? "rgba(69, 10, 10, 0.82)" : "rgba(153, 27, 27, 0.62)",
+      width: 1,
+    }),
+  });
+};
+
+export const createPriwaWarnkarteLayer = () =>
+  new VectorLayer({
+    source: new VectorSource({ wrapX: false }),
+    zIndex: 25,
+    style: (feature) =>
+      getPriwaWarnkarteStyle(Number(feature.get("probability") ?? 0)),
+  });
+
+export const setPriwaWarnkarteLayerData = (
+  layer: ReturnType<typeof createPriwaWarnkarteLayer>,
+  overlay: IPriwaWarnkarteOverlay | null,
+) => {
+  const source = layer.getSource();
+  source?.clear();
+  if (!source || !overlay || overlay.features.length === 0) return;
+
+  source.addFeatures(
+    new GeoJSON().readFeatures(overlay, {
+      dataProjection: "EPSG:4326",
+      featureProjection: "EPSG:3857",
+    }),
+  );
+};

--- a/frontend/src/components/PriwaField/priwaWarnkartePresentation.test.ts
+++ b/frontend/src/components/PriwaField/priwaWarnkartePresentation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { PriwaWarnkarteApiError } from "../../api/priwaWarnkarte";
+import {
+  formatPriwaWarnkarteDate,
+  formatPriwaWarnkarteError,
+} from "./priwaWarnkartePresentation";
+
+describe("PRIWA Warnkarte presentation", () => {
+  it("formats the authoritative date for the German label", () => {
+    expect(formatPriwaWarnkarteDate("2024-06-25")).toBe("25.06.2024");
+  });
+
+  it("shows expected and detected CRS from a structured backend error", () => {
+    const error = new PriwaWarnkarteApiError(
+      "INVALID_CRS",
+      "Das Koordinatenreferenzsystem ist ungültig.",
+      { expected: "EPSG:32632", detected: "EPSG:4326" },
+    );
+
+    expect(formatPriwaWarnkarteError(error)).toContain("Erwartet: EPSG:32632");
+    expect(formatPriwaWarnkarteError(error)).toContain("Erkannt: EPSG:4326");
+  });
+});

--- a/frontend/src/components/PriwaField/priwaWarnkartePresentation.ts
+++ b/frontend/src/components/PriwaField/priwaWarnkartePresentation.ts
@@ -1,0 +1,24 @@
+import { PriwaWarnkarteApiError } from "../../api/priwaWarnkarte";
+
+export const formatPriwaWarnkarteDate = (value: string | null) => {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  return match ? `${match[3]}.${match[2]}.${match[1]}` : value;
+};
+
+export const formatPriwaWarnkarteError = (error: unknown) => {
+  if (!(error instanceof PriwaWarnkarteApiError)) {
+    return error instanceof Error
+      ? error.message
+      : "Die Warnkarten-Anfrage ist fehlgeschlagen.";
+  }
+
+  const expected = error.details.expected;
+  const detected = error.details.detected;
+  if (error.code === "INVALID_CRS") {
+    return `${error.message} Erwartet: ${String(expected)}. Erkannt: ${
+      detected ? String(detected) : "nicht angegeben"
+    }.`;
+  }
+  return error.message;
+};

--- a/frontend/src/components/PriwaField/usePriwaWarnkarte.ts
+++ b/frontend/src/components/PriwaField/usePriwaWarnkarte.ts
@@ -1,0 +1,98 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import {
+  fetchActivePriwaWarnkarte,
+  fetchPriwaWarnkarteVersionOverlay,
+  fetchPriwaWarnkarteVersions,
+  importPriwaWarnkarte,
+  publishPriwaWarnkarteVersion,
+  validatePriwaWarnkarte,
+  type IPriwaWarnkarteOverlay,
+} from "../../api/priwaWarnkarte";
+import { useAuth } from "../../hooks/useAuthProvider";
+
+export function usePriwaWarnkarte(projectId: string, canManage: boolean) {
+  const { session } = useAuth();
+  const token = session?.access_token ?? null;
+  const queryClient = useQueryClient();
+  const [previewOverlay, setPreviewOverlay] =
+    useState<IPriwaWarnkarteOverlay | null>(null);
+
+  const activeQuery = useQuery({
+    queryKey: ["priwa-warnkarte", projectId, "active"],
+    enabled: !!projectId && !!token,
+    queryFn: () => fetchActivePriwaWarnkarte(projectId, token!),
+    staleTime: 60 * 1000,
+  });
+  const versionsQuery = useQuery({
+    queryKey: ["priwa-warnkarte", projectId, "versions"],
+    enabled: !!projectId && !!token && canManage,
+    queryFn: () => fetchPriwaWarnkarteVersions(projectId, token!),
+  });
+
+  const requireToken = () => {
+    if (!token) throw new Error("Die Anmeldung ist abgelaufen.");
+    return token;
+  };
+
+  const validateFile = (file: File) =>
+    validatePriwaWarnkarte(projectId, file, requireToken());
+
+  const importFile = async (file: File, confirmedDate: string) => {
+    const imported = await importPriwaWarnkarte(
+      projectId,
+      file,
+      confirmedDate,
+      requireToken(),
+    );
+    await queryClient.invalidateQueries({
+      queryKey: ["priwa-warnkarte", projectId, "versions"],
+    });
+    const overlay = await fetchPriwaWarnkarteVersionOverlay(
+      projectId,
+      imported.version_id,
+      requireToken(),
+    );
+    setPreviewOverlay(overlay);
+    return imported;
+  };
+
+  const previewVersion = async (versionId: string) => {
+    const overlay = await fetchPriwaWarnkarteVersionOverlay(
+      projectId,
+      versionId,
+      requireToken(),
+    );
+    setPreviewOverlay(overlay);
+  };
+
+  const publishVersion = async (versionId: string) => {
+    await publishPriwaWarnkarteVersion(versionId, requireToken());
+    setPreviewOverlay(null);
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["priwa-warnkarte", projectId, "active"],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["priwa-warnkarte", projectId, "versions"],
+      }),
+    ]);
+  };
+
+  return {
+    activeOverlay: activeQuery.data ?? null,
+    displayedOverlay: previewOverlay ?? activeQuery.data ?? null,
+    isPreviewing: previewOverlay !== null,
+    overlayError: activeQuery.error,
+    previewOverlay,
+    versions: versionsQuery.data ?? [],
+    versionsError: versionsQuery.error,
+    isLoadingVersions: versionsQuery.isLoading,
+    clearPreview: () => setPreviewOverlay(null),
+    importFile,
+    previewVersion,
+    publishVersion,
+    validateFile,
+  };
+}

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -112,6 +112,20 @@ export default function PriwaField() {
     );
   }
 
+  const warnkarteAdminControl = canManageWarnkarte ? (
+    <PriwaWarnkarteAdminDrawer
+      versions={warnkarte.versions}
+      versionsError={warnkarte.versionsError}
+      isLoadingVersions={warnkarte.isLoadingVersions}
+      previewVersionId={warnkarte.previewOverlay?.version_id ?? null}
+      onClearPreview={warnkarte.clearPreview}
+      onValidate={warnkarte.validateFile}
+      onImport={warnkarte.importFile}
+      onPreview={warnkarte.previewVersion}
+      onPublish={warnkarte.publishVersion}
+    />
+  ) : null;
+
   return (
     <div className="relative min-h-[100dvh]">
       <PriwaFieldMap
@@ -119,6 +133,7 @@ export default function PriwaField() {
         projectId={activeMembership.projectId}
         projectName={activeMembership.projectName}
         warnkarteOverlay={warnkarte.displayedOverlay}
+        additionalMapControl={warnkarteAdminControl}
         isLoadingPoints={isLoadingPoints || isRefetching}
         isSavingPoint={isSaving}
         mosaics={mosaics}
@@ -148,19 +163,6 @@ export default function PriwaField() {
         sourceDate={warnkarte.displayedOverlay?.source_date ?? null}
         isPreviewing={warnkarte.isPreviewing}
       />
-      {canManageWarnkarte && (
-        <PriwaWarnkarteAdminDrawer
-          versions={warnkarte.versions}
-          versionsError={warnkarte.versionsError}
-          isLoadingVersions={warnkarte.isLoadingVersions}
-          previewVersionId={warnkarte.previewOverlay?.version_id ?? null}
-          onClearPreview={warnkarte.clearPreview}
-          onValidate={warnkarte.validateFile}
-          onImport={warnkarte.importFile}
-          onPreview={warnkarte.previewVersion}
-          onPublish={warnkarte.publishVersion}
-        />
-      )}
       {warnkarte.overlayError && (
         <Alert
           className="absolute bottom-4 left-1/2 z-[65] w-[min(32rem,calc(100%-2rem))] -translate-x-1/2 shadow-lg"

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -4,7 +4,11 @@ import { usePriwaOfflineKaeferbaeume } from "../components/PriwaField/usePriwaOf
 import { usePriwaMosaics } from "../components/PriwaField/usePriwaMosaics";
 import { usePriwaBefallsgruppen } from "../components/PriwaField/usePriwaBefallsgruppen";
 import { usePriwaProjectMemberships } from "../hooks/usePriwaProjectMemberships";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { Alert, Button, Result, Spin } from "antd";
+import PriwaWarnkarteAdminDrawer from "../components/PriwaField/PriwaWarnkarteAdminDrawer";
+import PriwaWarnkarteStatus from "../components/PriwaField/PriwaWarnkarteStatus";
+import { usePriwaWarnkarte } from "../components/PriwaField/usePriwaWarnkarte";
 
 export default function PriwaField() {
   const { isOnline, serviceWorker } = usePriwaOfflineStatus();
@@ -14,6 +18,7 @@ export default function PriwaField() {
     isLoading: isLoadingMemberships,
   } = usePriwaProjectMemberships();
   const activeMembership = memberships[0] ?? null;
+  const isMobile = useIsMobile();
   const {
     points,
     isLoading: isLoadingPoints,
@@ -43,6 +48,11 @@ export default function PriwaField() {
     deleteGroup,
     isSaving: isSavingGroup,
   } = usePriwaBefallsgruppen(activeMembership?.projectId);
+  const canManageWarnkarte = activeMembership?.role === "admin" && !isMobile;
+  const warnkarte = usePriwaWarnkarte(
+    activeMembership?.projectId ?? "",
+    canManageWarnkarte,
+  );
 
   if (!isOnline && isLoadingMemberships) {
     return (
@@ -103,34 +113,62 @@ export default function PriwaField() {
   }
 
   return (
-    <PriwaFieldMap
-      points={points}
-      projectId={activeMembership.projectId}
-      projectName={activeMembership.projectName}
-      isLoadingPoints={isLoadingPoints || isRefetching}
-      isSavingPoint={isSaving}
-      mosaics={mosaics}
-      groups={groups}
-      isLoadingGroups={isLoadingGroups}
-      isSavingGroup={isSavingGroup}
-      groupsErrorMessage={
-        groupsError instanceof Error ? groupsError.message : null
-      }
-      isCogLoading={isLoadingMosaics || isRefetchingMosaics}
-      cogErrorMessage={
-        mosaicsError instanceof Error ? mosaicsError.message : null
-      }
-      errorMessage={pointsError instanceof Error ? pointsError.message : null}
-      onAddPoint={createPoint}
-      onUpdatePoint={updatePoint}
-      onDeletePoint={deletePoint}
-      onSaveGroup={saveGroup}
-      onAssignFlightToGroup={addFlightToGroup}
-      onDeleteGroup={deleteGroup}
-      onSetFlightType={setFlightType}
-      isClassifyingFlight={isClassifyingFlight}
-      syncSummary={syncSummary}
-      onSyncNow={syncNow}
-    />
+    <div className="relative min-h-[100dvh]">
+      <PriwaFieldMap
+        points={points}
+        projectId={activeMembership.projectId}
+        projectName={activeMembership.projectName}
+        warnkarteOverlay={warnkarte.displayedOverlay}
+        isLoadingPoints={isLoadingPoints || isRefetching}
+        isSavingPoint={isSaving}
+        mosaics={mosaics}
+        groups={groups}
+        isLoadingGroups={isLoadingGroups}
+        isSavingGroup={isSavingGroup}
+        groupsErrorMessage={
+          groupsError instanceof Error ? groupsError.message : null
+        }
+        isCogLoading={isLoadingMosaics || isRefetchingMosaics}
+        cogErrorMessage={
+          mosaicsError instanceof Error ? mosaicsError.message : null
+        }
+        errorMessage={pointsError instanceof Error ? pointsError.message : null}
+        onAddPoint={createPoint}
+        onUpdatePoint={updatePoint}
+        onDeletePoint={deletePoint}
+        onSaveGroup={saveGroup}
+        onAssignFlightToGroup={addFlightToGroup}
+        onDeleteGroup={deleteGroup}
+        onSetFlightType={setFlightType}
+        isClassifyingFlight={isClassifyingFlight}
+        syncSummary={syncSummary}
+        onSyncNow={syncNow}
+      />
+      <PriwaWarnkarteStatus
+        sourceDate={warnkarte.displayedOverlay?.source_date ?? null}
+        isPreviewing={warnkarte.isPreviewing}
+      />
+      {canManageWarnkarte && (
+        <PriwaWarnkarteAdminDrawer
+          versions={warnkarte.versions}
+          versionsError={warnkarte.versionsError}
+          isLoadingVersions={warnkarte.isLoadingVersions}
+          previewVersionId={warnkarte.previewOverlay?.version_id ?? null}
+          onClearPreview={warnkarte.clearPreview}
+          onValidate={warnkarte.validateFile}
+          onImport={warnkarte.importFile}
+          onPreview={warnkarte.previewVersion}
+          onPublish={warnkarte.publishVersion}
+        />
+      )}
+      {warnkarte.overlayError && (
+        <Alert
+          className="absolute bottom-4 left-1/2 z-[65] w-[min(32rem,calc(100%-2rem))] -translate-x-1/2 shadow-lg"
+          type="error"
+          showIcon
+          message="Warnkarte konnte nicht geladen werden"
+        />
+      )}
+    </div>
   );
 }

--- a/nginx/api-conf/storage-server.conf
+++ b/nginx/api-conf/storage-server.conf
@@ -44,6 +44,16 @@ server {
         proxy_send_timeout 3600s;
     }
 
+    location ~ ^/api/v1/priwa/warnkarte/(validate|import)$ {
+        client_max_body_size 52M;
+        rewrite  ^/api/v1/(.*)  /$1 break;
+        proxy_pass http://api:40831;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/v1/ {
         rewrite  ^/api/v1/(.*)  /$1 break;
         proxy_pass http://api:40831;

--- a/nginx/test-conf/storage-server.conf
+++ b/nginx/test-conf/storage-server.conf
@@ -32,6 +32,17 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location ~ ^/api/v1/priwa/warnkarte/(validate|import)$ {
+        set $api_backend "api-test:8017";
+        client_max_body_size 52M;
+        rewrite  ^/api/v1/?(.*)$ /$1 break;
+        proxy_pass http://$api_backend;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     location /api/v1 {
         set $api_backend "api-test:8017";

--- a/supabase/migrations/20260807100000_add_priwa_warnkarte.sql
+++ b/supabase/migrations/20260807100000_add_priwa_warnkarte.sql
@@ -1,0 +1,413 @@
+create table public.priwa_warnkarte_versions (
+    id uuid primary key default gen_random_uuid(),
+    project_id uuid not null references public.priwa_projects(id) on update cascade on delete cascade,
+    source_date date not null,
+    source_filename text not null,
+    checksum_sha256 text not null,
+    source_layer text not null,
+    source_crs text not null,
+    feature_count integer not null,
+    imported_by uuid not null references auth.users(id) on update cascade,
+    imported_at timestamp with time zone not null default now(),
+    constraint priwa_warnkarte_versions_project_checksum_key unique (project_id, checksum_sha256),
+    constraint priwa_warnkarte_versions_id_project_key unique (id, project_id),
+    constraint priwa_warnkarte_versions_checksum_check
+        check (checksum_sha256 ~ '^[0-9a-f]{64}$'),
+    constraint priwa_warnkarte_versions_filename_check
+        check (source_filename ~ '[0-9]{4}-[0-9]{2}-[0-9]{2}\.gpkg$'),
+    constraint priwa_warnkarte_versions_filename_date_check
+        check (right(source_filename, 15) = source_date::text || '.gpkg'),
+    constraint priwa_warnkarte_versions_crs_check
+        check (source_crs = 'EPSG:32632'),
+    constraint priwa_warnkarte_versions_feature_count_check
+        check (feature_count > 0)
+);
+
+create table public.priwa_warnkarte_polygons (
+    id bigint generated always as identity primary key,
+    version_id uuid not null references public.priwa_warnkarte_versions(id) on delete cascade,
+    source_fid bigint not null,
+    probability numeric(2,1) not null,
+    geom geometry(Polygon, 4326) not null,
+    constraint priwa_warnkarte_polygons_version_fid_key unique (version_id, source_fid),
+    constraint priwa_warnkarte_polygons_probability_check
+        check (probability between 0.0 and 1.0),
+    constraint priwa_warnkarte_polygons_geom_check
+        check (not st_isempty(geom) and st_isvalid(geom))
+);
+
+create table public.priwa_warnkarte_publications (
+    id bigint generated always as identity primary key,
+    project_id uuid not null references public.priwa_projects(id) on update cascade on delete cascade,
+    version_id uuid not null,
+    published_by uuid not null references auth.users(id) on update cascade,
+    published_at timestamp with time zone not null default now(),
+    constraint priwa_warnkarte_publications_version_project_fkey
+        foreign key (version_id, project_id)
+        references public.priwa_warnkarte_versions(id, project_id)
+        on delete no action
+        deferrable initially deferred
+);
+
+create index priwa_warnkarte_versions_project_imported_idx
+    on public.priwa_warnkarte_versions (project_id, imported_at desc);
+create index priwa_warnkarte_versions_imported_by_idx
+    on public.priwa_warnkarte_versions (imported_by);
+create index priwa_warnkarte_polygons_version_idx
+    on public.priwa_warnkarte_polygons (version_id);
+create index priwa_warnkarte_polygons_geom_idx
+    on public.priwa_warnkarte_polygons using gist (geom);
+create index priwa_warnkarte_publications_project_published_idx
+    on public.priwa_warnkarte_publications (project_id, published_at desc, id desc);
+create index priwa_warnkarte_publications_version_idx
+    on public.priwa_warnkarte_publications (version_id);
+create index priwa_warnkarte_publications_published_by_idx
+    on public.priwa_warnkarte_publications (published_by);
+
+alter table public.priwa_warnkarte_versions enable row level security;
+alter table public.priwa_warnkarte_polygons enable row level security;
+alter table public.priwa_warnkarte_publications enable row level security;
+
+create or replace function public.priwa_is_project_admin(p_project_id uuid)
+returns boolean
+language sql
+stable
+set search_path = ''
+as $$
+    select exists (
+        select 1
+        from public.priwa_project_memberships membership
+        where membership.project_id = p_project_id
+          and membership.user_id = (select auth.uid())
+          and membership.role = 'admin'::public.priwa_project_role
+    );
+$$;
+
+revoke all on function public.priwa_is_project_admin(uuid) from public, anon;
+grant execute on function public.priwa_is_project_admin(uuid) to authenticated, service_role;
+
+create policy "PRIWA admins can read Warnkarte versions"
+on public.priwa_warnkarte_versions
+for select to authenticated
+using ((select public.priwa_is_project_admin(project_id)));
+
+create policy "PRIWA admins can read Warnkarte polygons"
+on public.priwa_warnkarte_polygons
+for select to authenticated
+using (
+    exists (
+        select 1
+        from public.priwa_warnkarte_versions version
+        where version.id = version_id
+          and (select public.priwa_is_project_admin(version.project_id))
+    )
+);
+
+create policy "PRIWA admins can read Warnkarte publications"
+on public.priwa_warnkarte_publications
+for select to authenticated
+using ((select public.priwa_is_project_admin(project_id)));
+
+grant select on public.priwa_warnkarte_versions to authenticated;
+grant select on public.priwa_warnkarte_polygons to authenticated;
+grant select on public.priwa_warnkarte_publications to authenticated;
+grant all on public.priwa_warnkarte_versions to service_role;
+grant all on public.priwa_warnkarte_polygons to service_role;
+grant all on public.priwa_warnkarte_publications to service_role;
+grant usage, select on sequence public.priwa_warnkarte_polygons_id_seq to service_role;
+grant usage, select on sequence public.priwa_warnkarte_publications_id_seq to service_role;
+
+create schema if not exists internal;
+
+create or replace function internal.priwa_import_warnkarte(
+    p_actor uuid,
+    p_project_id uuid,
+    p_source_filename text,
+    p_checksum_sha256 text,
+    p_source_date date,
+    p_source_layer text,
+    p_source_crs text,
+    p_polygons jsonb
+)
+returns uuid
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+    actor uuid := p_actor;
+    imported_version_id uuid;
+    expected_count integer;
+    inserted_count integer;
+begin
+    if actor is null or not exists (
+        select 1
+        from public.priwa_project_memberships membership
+        where membership.project_id = p_project_id
+          and membership.user_id = actor
+          and membership.role = 'admin'::public.priwa_project_role
+    ) then
+        raise exception 'PRIWA project admin access is required' using errcode = '42501';
+    end if;
+
+    if p_source_crs is distinct from 'EPSG:32632' then
+        raise exception 'Warnkarte source CRS must be EPSG:32632' using errcode = '22023';
+    end if;
+
+    if jsonb_typeof(p_polygons) is distinct from 'array' or jsonb_array_length(p_polygons) = 0 then
+        raise exception 'Warnkarte must contain at least one polygon' using errcode = '22023';
+    end if;
+
+    if exists (
+        select 1
+        from jsonb_array_elements(p_polygons) item
+        cross join lateral (
+            select round((item ->> 'probability')::numeric, 1) as normalized
+        ) value
+        where value.normalized < 0.0
+           or value.normalized > 1.0
+           or abs((item ->> 'probability')::numeric - value.normalized) > 0.000001
+    ) then
+        raise exception 'Warnkarte probability must be between 0.0 and 1.0 in 0.1 steps'
+            using errcode = '22023';
+    end if;
+
+    expected_count := jsonb_array_length(p_polygons);
+
+    insert into public.priwa_warnkarte_versions (
+        project_id,
+        source_date,
+        source_filename,
+        checksum_sha256,
+        source_layer,
+        source_crs,
+        feature_count,
+        imported_by
+    ) values (
+        p_project_id,
+        p_source_date,
+        p_source_filename,
+        p_checksum_sha256,
+        p_source_layer,
+        p_source_crs,
+        expected_count,
+        actor
+    ) returning id into imported_version_id;
+
+    insert into public.priwa_warnkarte_polygons (
+        version_id,
+        source_fid,
+        probability,
+        geom
+    )
+    select
+        imported_version_id,
+        (item ->> 'fid')::bigint,
+        round((item ->> 'probability')::numeric, 1)::numeric(2,1),
+        public.st_transform(
+            public.st_geomfromwkb(decode(item ->> 'wkb_hex', 'hex'), 32632),
+            4326
+        )::public.geometry(Polygon, 4326)
+    from jsonb_array_elements(p_polygons) item;
+
+    get diagnostics inserted_count = row_count;
+    if inserted_count <> expected_count then
+        raise exception 'Warnkarte polygon count mismatch' using errcode = '22023';
+    end if;
+
+    return imported_version_id;
+end;
+$$;
+
+create or replace function public.priwa_import_warnkarte(
+    p_actor uuid,
+    p_project_id uuid,
+    p_source_filename text,
+    p_checksum_sha256 text,
+    p_source_date date,
+    p_source_layer text,
+    p_source_crs text,
+    p_polygons jsonb
+)
+returns uuid
+language sql
+volatile
+set search_path = ''
+as $$
+    select internal.priwa_import_warnkarte(
+        p_actor,
+        p_project_id,
+        p_source_filename,
+        p_checksum_sha256,
+        p_source_date,
+        p_source_layer,
+        p_source_crs,
+        p_polygons
+    );
+$$;
+
+create or replace function internal.priwa_publish_warnkarte(p_version_id uuid)
+returns bigint
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+    actor uuid := (select auth.uid());
+    version_project_id uuid;
+    publication_id bigint;
+begin
+    select version.project_id
+    into version_project_id
+    from public.priwa_warnkarte_versions version
+    where version.id = p_version_id;
+
+    if version_project_id is null then
+        raise exception 'Warnkarte version not found' using errcode = 'P0002';
+    end if;
+
+    if actor is null or not public.priwa_is_project_admin(version_project_id) then
+        raise exception 'PRIWA project admin access is required' using errcode = '42501';
+    end if;
+
+    insert into public.priwa_warnkarte_publications (
+        project_id,
+        version_id,
+        published_by
+    ) values (
+        version_project_id,
+        p_version_id,
+        actor
+    ) returning id into publication_id;
+
+    return publication_id;
+end;
+$$;
+
+create or replace function public.priwa_publish_warnkarte(p_version_id uuid)
+returns bigint
+language sql
+volatile
+set search_path = ''
+as $$
+    select internal.priwa_publish_warnkarte(p_version_id);
+$$;
+
+create or replace function internal.priwa_current_warnkarte(p_project_id uuid)
+returns table (
+    source_date date,
+    probability numeric,
+    geometry jsonb
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+    with current_publication as (
+        select publication.version_id
+        from public.priwa_warnkarte_publications publication
+        where publication.project_id = p_project_id
+          and public.priwa_is_project_member(p_project_id)
+        order by publication.published_at desc, publication.id desc
+        limit 1
+    )
+    select
+        version.source_date,
+        polygon.probability,
+        public.st_asgeojson(polygon.geom)::jsonb
+    from current_publication publication
+    join public.priwa_warnkarte_versions version on version.id = publication.version_id
+    join public.priwa_warnkarte_polygons polygon on polygon.version_id = version.id
+    order by polygon.source_fid;
+$$;
+
+create or replace function public.priwa_current_warnkarte(p_project_id uuid)
+returns table (
+    source_date date,
+    probability numeric,
+    geometry jsonb
+)
+language sql
+stable
+set search_path = ''
+as $$
+    select * from internal.priwa_current_warnkarte(p_project_id);
+$$;
+
+create or replace function internal.priwa_warnkarte_version_overlay(
+    p_project_id uuid,
+    p_version_id uuid
+)
+returns table (
+    version_id uuid,
+    source_date date,
+    source_fid bigint,
+    probability numeric,
+    geometry jsonb
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+    select
+        version.id,
+        version.source_date,
+        polygon.source_fid,
+        polygon.probability,
+        public.st_asgeojson(polygon.geom)::jsonb
+    from public.priwa_warnkarte_versions version
+    join public.priwa_warnkarte_polygons polygon on polygon.version_id = version.id
+    where version.id = p_version_id
+      and version.project_id = p_project_id
+      and public.priwa_is_project_admin(p_project_id)
+    order by polygon.source_fid;
+$$;
+
+create or replace function public.priwa_warnkarte_version_overlay(
+    p_project_id uuid,
+    p_version_id uuid
+)
+returns table (
+    version_id uuid,
+    source_date date,
+    source_fid bigint,
+    probability numeric,
+    geometry jsonb
+)
+language sql
+stable
+set search_path = ''
+as $$
+    select * from internal.priwa_warnkarte_version_overlay(p_project_id, p_version_id);
+$$;
+
+revoke all on function internal.priwa_import_warnkarte(uuid, uuid, text, text, date, text, text, jsonb) from public, anon, authenticated;
+revoke all on function internal.priwa_publish_warnkarte(uuid) from public, anon;
+revoke all on function internal.priwa_current_warnkarte(uuid) from public, anon;
+revoke all on function internal.priwa_warnkarte_version_overlay(uuid, uuid) from public, anon;
+grant execute on function internal.priwa_import_warnkarte(uuid, uuid, text, text, date, text, text, jsonb) to service_role;
+grant execute on function internal.priwa_publish_warnkarte(uuid) to authenticated, service_role;
+grant execute on function internal.priwa_current_warnkarte(uuid) to authenticated, service_role;
+grant execute on function internal.priwa_warnkarte_version_overlay(uuid, uuid) to authenticated, service_role;
+
+revoke all on function public.priwa_import_warnkarte(uuid, uuid, text, text, date, text, text, jsonb) from public, anon, authenticated;
+revoke all on function public.priwa_publish_warnkarte(uuid) from public, anon;
+revoke all on function public.priwa_current_warnkarte(uuid) from public, anon;
+revoke all on function public.priwa_warnkarte_version_overlay(uuid, uuid) from public, anon;
+grant execute on function public.priwa_import_warnkarte(uuid, uuid, text, text, date, text, text, jsonb) to service_role;
+grant execute on function public.priwa_publish_warnkarte(uuid) to authenticated, service_role;
+grant execute on function public.priwa_current_warnkarte(uuid) to authenticated, service_role;
+grant execute on function public.priwa_warnkarte_version_overlay(uuid, uuid) to authenticated, service_role;
+
+comment on table public.priwa_warnkarte_versions
+is 'Immutable admin-only provenance for validated PRIWA Warnkarte GeoPackage imports.';
+comment on table public.priwa_warnkarte_polygons
+is 'Normalized immutable EPSG:4326 polygons for PRIWA Warnkarte versions.';
+comment on table public.priwa_warnkarte_publications
+is 'Append-only publication history; the newest row per project selects the visible Warnkarte.';
+comment on function public.priwa_current_warnkarte(uuid)
+is 'Returns only the active Warnkarte date, geometry, and probability to project members.';

--- a/supabase/migrations/20260807100000_add_priwa_warnkarte.sql
+++ b/supabase/migrations/20260807100000_add_priwa_warnkarte.sql
@@ -296,11 +296,7 @@ as $$
 $$;
 
 create or replace function internal.priwa_current_warnkarte(p_project_id uuid)
-returns table (
-    source_date date,
-    probability numeric,
-    geometry jsonb
-)
+returns table (payload jsonb)
 language sql
 stable
 security definer
@@ -314,22 +310,27 @@ as $$
         order by publication.published_at desc, publication.id desc
         limit 1
     )
-    select
-        version.source_date,
-        polygon.probability,
-        public.st_asgeojson(polygon.geom)::jsonb
+    select jsonb_build_object(
+        'version_id', null,
+        'source_date', version.source_date,
+        'type', 'FeatureCollection',
+        'features', jsonb_agg(
+            jsonb_build_object(
+                'type', 'Feature',
+                'geometry', public.st_asgeojson(polygon.geom)::jsonb,
+                'properties', jsonb_build_object('probability', polygon.probability)
+            )
+            order by polygon.source_fid
+        )
+    )
     from current_publication publication
     join public.priwa_warnkarte_versions version on version.id = publication.version_id
     join public.priwa_warnkarte_polygons polygon on polygon.version_id = version.id
-    order by polygon.source_fid;
+    group by version.id, version.source_date;
 $$;
 
 create or replace function public.priwa_current_warnkarte(p_project_id uuid)
-returns table (
-    source_date date,
-    probability numeric,
-    geometry jsonb
-)
+returns table (payload jsonb)
 language sql
 stable
 set search_path = ''
@@ -341,43 +342,38 @@ create or replace function internal.priwa_warnkarte_version_overlay(
     p_project_id uuid,
     p_version_id uuid
 )
-returns table (
-    version_id uuid,
-    source_date date,
-    source_fid bigint,
-    probability numeric,
-    geometry jsonb
-)
+returns table (payload jsonb)
 language sql
 stable
 security definer
 set search_path = ''
 as $$
-    select
-        version.id,
-        version.source_date,
-        polygon.source_fid,
-        polygon.probability,
-        public.st_asgeojson(polygon.geom)::jsonb
+    select jsonb_build_object(
+        'version_id', version.id,
+        'source_date', version.source_date,
+        'type', 'FeatureCollection',
+        'features', jsonb_agg(
+            jsonb_build_object(
+                'type', 'Feature',
+                'geometry', public.st_asgeojson(polygon.geom)::jsonb,
+                'properties', jsonb_build_object('probability', polygon.probability)
+            )
+            order by polygon.source_fid
+        )
+    )
     from public.priwa_warnkarte_versions version
     join public.priwa_warnkarte_polygons polygon on polygon.version_id = version.id
     where version.id = p_version_id
       and version.project_id = p_project_id
       and public.priwa_is_project_admin(p_project_id)
-    order by polygon.source_fid;
+    group by version.id, version.source_date;
 $$;
 
 create or replace function public.priwa_warnkarte_version_overlay(
     p_project_id uuid,
     p_version_id uuid
 )
-returns table (
-    version_id uuid,
-    source_date date,
-    source_fid bigint,
-    probability numeric,
-    geometry jsonb
-)
+returns table (payload jsonb)
 language sql
 stable
 set search_path = ''


### PR DESCRIPTION
## Briefing

Adds the complete PRIWA Warnkarte GeoPackage workflow for desktop project admins and a safe published overlay for desktop and mobile project members. Imports are strictly validated, immutable, unpublished by default, and explicitly published or reverted through append-only publication records. The original GeoPackage is never retained; only normalized PostGIS polygons and admin-only provenance are stored.

## What changed

- Validate direct `.gpkg` uploads against the filename date, single-layer, EPSG:32632, Polygon/FID/probability, geometry validity, checksum, file-size, feature-count, and vertex-complexity contracts with structured German errors.
- Store immutable versions and normalized EPSG:4326 polygons with RLS-protected provenance, a service-only atomic import RPC, append-only publish/re-publish history, and single-row aggregated overlays that cannot be truncated by PostgREST row limits.
- Add the desktop admin select-and-auto-validate/confirm/import/preview/publish/version-history flow through a dedicated circular map control while exposing members only to the current safe geometry, probability, and date label.
- Explain undeployed Warnkarte API routes in German instead of exposing the raw preview response `Not Found`.
- Render the active Warnkarte through an independent responsive OpenLayers overlay with ten fixed red probability bands on desktop and mobile.
- Cap the two Warnkarte multipart ingress routes at 52 MiB while preserving existing large-upload behavior elsewhere.

## Validation

- Isolated per-worktree Supabase reset applied all migrations from scratch, including the Warnkarte migration: passed.
- `api/tests/db/test_priwa_warnkarte_schema.py` against local Supabase/Postgres 15.8: 4 passed, including complete admin/member overlays with 1,001 polygons.
- Focused Warnkarte validator/router/ingress unit suite: 29 passed.
- Patricia's representative supplier GeoPackage: passed locally with one layer, 99 Polygon features, EPSG:32632, authoritative filename date 2024-06-25, and the expected non-blocking layer-date warning.
- Repository API smoke gate in isolated Docker: 3 settings tests passed; 282 passed and 1 unrelated real-data test skipped.
- Frontend Vitest suite: 55 files and 292 tests passed; frontend build and lint passed.
- Focused frontend tests for Warnkarte API/presentation/layer/status behavior: 7 passed; frontend lint, production build, and repository ast-grep guardrail passed.
- Focused Chromium local smoke: 4 passed for circular map-control placement, automatic validation and import/publish flow, locked file selection during delayed validation, friendly undeployed-preview errors, and mobile published-overlay/no-management-controls behavior.
- Isolated nginx configuration: `nginx -t` passed; generated 53 MiB multipart Warnkarte upload returned HTTP 413.

## Risk and limitations

This adds a database migration, new API surface, nginx routing, and frontend UI. Existing projects remain unchanged and show no Warnkarte until an admin imports and explicitly publishes a valid version; no production data was modified during local validation.

## Reviewer guide

Review the migration/RLS and service-only import RPC first, then the authoritative GeoPackage validator and its resource bounds, followed by the focused frontend overlay/admin boundary.
