### PR TITLE
fix(frontend): restore dataset audit processing overview

### DIFF
--- a/frontend/e2e-local/auditor-local.spec.ts
+++ b/frontend/e2e-local/auditor-local.spec.ts
@@ -161,7 +161,11 @@ let savedAoiPayloads: Array<Record<string, unknown>> = [];
 
 const installAuthenticatedUser = async (
   page: Page,
-  options: { canAudit: boolean; auditDatasetRequestFails?: boolean },
+  options: {
+    canAudit: boolean;
+    auditDatasetRequestFails?: boolean;
+    processingOverviewRequestFails?: boolean;
+  },
 ) => {
   await installLocalSession(page, {
     user: auditor,
@@ -212,7 +216,11 @@ const installAuthenticatedUser = async (
 
 const fulfillSupabaseRequest = async (
   route: Route,
-  options: { canAudit: boolean; auditDatasetRequestFails?: boolean },
+  options: {
+    canAudit: boolean;
+    auditDatasetRequestFails?: boolean;
+    processingOverviewRequestFails?: boolean;
+  },
 ) => {
   const request = route.request();
   const url = new URL(request.url());
@@ -296,6 +304,18 @@ const fulfillSupabaseRequest = async (
   }
 
   if (resource === "v2_processing_overview") {
+    if (options.processingOverviewRequestFails) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        json: {
+          code: "57014",
+          message: "canceling statement due to statement timeout",
+        },
+      });
+      return;
+    }
+
     await fulfillJson(route, [
       {
         dataset_id: incompleteDataset.id,
@@ -619,6 +639,64 @@ test.describe("auditor local e2e", () => {
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
     await expect(page.getByText("📋 Pending")).toHaveCount(0);
+  });
+
+  test("processing overview requests only the fields rendered by the audit table", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, { canAudit: true });
+
+    const processingRequest = page.waitForRequest((request) =>
+      new URL(request.url()).pathname.endsWith("/v2_processing_overview"),
+    );
+
+    await page.goto("/dataset-audit?tab=processing");
+    await dismissCookieBanner(page);
+    const request = await processingRequest;
+    const selectedColumns = new URL(request.url()).searchParams
+      .get("select")
+      ?.split(",");
+
+    expect(selectedColumns).toEqual([
+      "dataset_id",
+      "file_name",
+      "processing_status",
+      "current_status",
+      "has_error",
+      "error_message",
+      "hours_in_current_status",
+      "status_last_updated",
+      "user_email",
+      "queue_priority",
+      "queued_at",
+      "last_20_logs",
+    ]);
+    expect(selectedColumns).not.toContain("ortho_metadata");
+    expect(selectedColumns).not.toContain("raw_images_metadata");
+    await expect(page.getByText(incompleteDataset.file_name)).toBeVisible();
+  });
+
+  test("processing overview reports load failures instead of showing no data", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, {
+      canAudit: true,
+      processingOverviewRequestFails: true,
+    });
+
+    await page.goto("/dataset-audit?tab=processing");
+    await dismissCookieBanner(page);
+
+    await expect(
+      page.getByText("Could not load processing data", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "The processing overview could not be loaded. Please try again.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+    await expect(page.getByText("No data", { exact: true })).toHaveCount(0);
   });
 
   test("auditor start action checks the lock before opening detail", async ({

--- a/frontend/e2e-local/auditor-local.spec.ts
+++ b/frontend/e2e-local/auditor-local.spec.ts
@@ -165,6 +165,7 @@ const installAuthenticatedUser = async (
     canAudit: boolean;
     auditDatasetRequestFails?: boolean;
     processingOverviewRequestFails?: boolean;
+    processingOverviewRefetchFails?: boolean;
   },
 ) => {
   await installLocalSession(page, {
@@ -173,8 +174,22 @@ const installAuthenticatedUser = async (
     refreshToken: "local-auditor-e2e-refresh-token",
   });
 
+  let processingOverviewRequestCount = 0;
   await page.route(`${localSupabaseUrl}/rest/v1/**`, async (route) => {
-    await fulfillSupabaseRequest(route, options);
+    const resource = new URL(route.request().url()).pathname
+      .split("/")
+      .filter(Boolean)
+      .at(-1);
+    if (resource === "v2_processing_overview") {
+      processingOverviewRequestCount += 1;
+    }
+    await fulfillSupabaseRequest(route, {
+      ...options,
+      processingOverviewRequestFails:
+        options.processingOverviewRequestFails ||
+        (options.processingOverviewRefetchFails &&
+          processingOverviewRequestCount > 1),
+    });
   });
 
   await page.route("**/cogs/v1/**", async (route) => {
@@ -697,6 +712,29 @@ test.describe("auditor local e2e", () => {
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
     await expect(page.getByText("No data", { exact: true })).toHaveCount(0);
+  });
+
+  test("processing overview keeps cached rows visible after a failed refresh", async ({
+    page,
+  }) => {
+    await installAuthenticatedUser(page, {
+      canAudit: true,
+      processingOverviewRefetchFails: true,
+    });
+
+    await page.goto("/dataset-audit?tab=processing");
+    await dismissCookieBanner(page);
+    await expect(page.getByText(incompleteDataset.file_name)).toBeVisible();
+
+    await page.getByRole("button", { name: "Refresh" }).click();
+
+    await expect(
+      page.getByText("Processing data may be stale", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText(incompleteDataset.file_name)).toBeVisible();
+    await expect(
+      page.getByText("Could not load processing data", { exact: true }),
+    ).toHaveCount(0);
   });
 
   test("auditor start action checks the lock before opening detail", async ({

--- a/frontend/src/components/DatasetAudit/ProcessingAuditTab.tsx
+++ b/frontend/src/components/DatasetAudit/ProcessingAuditTab.tsx
@@ -1,0 +1,349 @@
+import { useMemo, useState } from "react";
+import { Alert, Button, Drawer, Result, Select, Space, Table, Tag, Tooltip, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import {
+	useDatasetLogs,
+	type ProcessingOverviewRow,
+	type ProcessingStatus,
+} from "../../hooks/useProcessingOverview";
+import { useIsMobile } from "../../hooks/useIsMobile";
+
+const { Text } = Typography;
+
+export const PROCESSING_ACTIVE_STATUSES = ["QUEUED", "PROCESSING", "FAILED"] as const satisfies readonly ProcessingStatus[];
+
+type ProcessingAuditTabProps = {
+	rows: ProcessingOverviewRow[];
+	isLoading: boolean;
+	isError: boolean;
+	onRefresh: () => void;
+};
+
+const formatHours = (value: number | null | undefined): string => {
+	if (typeof value !== "number" || Number.isNaN(value)) return "—";
+	return `${value.toFixed(1)}h`;
+};
+
+export default function ProcessingAuditTab({ rows, isLoading, isError, onRefresh }: ProcessingAuditTabProps) {
+	const isMobile = useIsMobile();
+	const [statusFilters, setStatusFilters] = useState<ProcessingStatus[]>([...PROCESSING_ACTIVE_STATUSES]);
+	const [stageFilter, setStageFilter] = useState<string | undefined>(undefined);
+	const [userFilter, setUserFilter] = useState<string | undefined>(undefined);
+	const [selectedDatasetId, setSelectedDatasetId] = useState<number | null>(null);
+	const [logLimit, setLogLimit] = useState(100);
+
+	const stageOptions = useMemo(() => {
+		const stages = new Set(
+			rows
+				.map((row) => row.current_status)
+				.filter((status): status is string => typeof status === "string" && status.length > 0)
+		);
+		return Array.from(stages)
+			.sort()
+			.map((value) => ({ label: value, value }));
+	}, [rows]);
+
+	const userOptions = useMemo(() => {
+		const users = new Set(
+			rows
+				.map((row) => row.user_email)
+				.filter((email): email is string => typeof email === "string" && email.length > 0)
+		);
+		return Array.from(users)
+			.sort()
+			.map((value) => ({ label: value, value }));
+	}, [rows]);
+
+	const filteredRows = useMemo(() => {
+		return rows.filter((row) => {
+			if (statusFilters.length > 0 && !statusFilters.includes((row.processing_status || "") as ProcessingStatus)) {
+				return false;
+			}
+			if (stageFilter && row.current_status !== stageFilter) return false;
+			if (userFilter && row.user_email !== userFilter) return false;
+			return true;
+		});
+	}, [rows, statusFilters, stageFilter, userFilter]);
+
+	const selectedRow = useMemo(
+		() => rows.find((row) => row.dataset_id === selectedDatasetId) || null,
+		[rows, selectedDatasetId]
+	);
+	const { data: selectedDatasetLogs = [], isLoading: isLogsLoading, refetch: refetchSelectedDatasetLogs } =
+		useDatasetLogs(selectedDatasetId, logLimit);
+
+	const columns: ColumnsType<ProcessingOverviewRow> = [
+		{
+			title: "ID",
+			dataIndex: "dataset_id",
+			key: "dataset_id",
+			width: 90,
+			defaultSortOrder: "descend",
+			sorter: (a, b) => a.dataset_id - b.dataset_id,
+		},
+		{
+			title: "File",
+			dataIndex: "file_name",
+			key: "file_name",
+			width: 220,
+			ellipsis: true,
+			render: (value: string | null) => value || "—",
+		},
+		{
+			title: "Processing",
+			key: "processing_status",
+			width: 170,
+			render: (_, record) => {
+				const status = record.processing_status || "UNKNOWN";
+				const color =
+					status === "PROCESSING"
+						? "blue"
+						: status === "QUEUED"
+							? "orange"
+							: status === "FAILED"
+								? "red"
+								: "green";
+				return (
+					<Tag color={color} className="whitespace-nowrap">
+						{status}
+					</Tag>
+				);
+			},
+		},
+		{
+			title: "Stage",
+			dataIndex: "current_status",
+			key: "current_status",
+			width: 130,
+			render: (value: string | null) => <Tag>{value || "idle"}</Tag>,
+		},
+		{
+			title: "Stuck",
+			key: "hours_in_current_status",
+			width: 100,
+			render: (_, record) => <span className="font-mono text-xs">{formatHours(record.hours_in_current_status)}</span>,
+			sorter: (a, b) => (a.hours_in_current_status || 0) - (b.hours_in_current_status || 0),
+		},
+		{
+			title: "Owner",
+			dataIndex: "user_email",
+			key: "user_email",
+			width: 220,
+			render: (value: string | null) => value || "—",
+		},
+		{
+			title: "Queue",
+			key: "queue",
+			width: 90,
+			render: (_, record) => (record.queue_priority === null ? "—" : `P${record.queue_priority}`),
+		},
+		{
+			title: "Error",
+			key: "error",
+			width: 200,
+			render: (_, record) => {
+				if (!record.has_error) return <span className="text-gray-400">—</span>;
+				const messageText = record.error_message || "Error";
+				const shortText = messageText.length > 80 ? `${messageText.slice(0, 80)}...` : messageText;
+				return (
+					<Tooltip title={messageText}>
+						<span className="text-red-600">{shortText}</span>
+					</Tooltip>
+				);
+			},
+		},
+		{
+			title: "Logs Preview",
+			key: "logs_preview",
+			width: 280,
+			render: (_, record) => {
+				if (!record.last_20_logs) return <span className="text-gray-400">No logs</span>;
+				const preview = record.last_20_logs.split("\n").slice(0, 2).join("\n");
+				return (
+					<Tooltip title={record.last_20_logs}>
+						<pre className="m-0 max-h-16 overflow-hidden whitespace-pre-wrap text-xs leading-tight">{preview}</pre>
+					</Tooltip>
+				);
+			},
+		},
+		{
+			title: "Actions",
+			key: "actions",
+			width: 120,
+			render: (_, record) => (
+				<Button size="small" onClick={() => setSelectedDatasetId(record.dataset_id)}>
+					View Logs
+				</Button>
+			),
+		},
+	];
+
+	if (isError && rows.length === 0) {
+		return (
+			<Result
+				status="error"
+				title="Could not load processing data"
+				subTitle="The processing overview could not be loaded. Please try again."
+				extra={<Button onClick={onRefresh}>Try again</Button>}
+			/>
+		);
+	}
+
+	return (
+		<>
+			{isError && (
+				<Alert
+					type="warning"
+					showIcon
+					message="Processing data may be stale"
+					description="The latest refresh failed. Previously loaded processing data remains visible."
+					action={<Button onClick={onRefresh}>Try again</Button>}
+					className="mb-4"
+				/>
+			)}
+			<div className="mb-4 flex flex-wrap items-end gap-3 rounded-md border border-gray-100 bg-gray-50 p-3">
+				<div>
+					<Text type="secondary" className="block mb-1 text-xs">
+						Processing Status
+					</Text>
+					<Select
+						mode="multiple"
+						allowClear
+						placeholder="Select statuses"
+						style={{ width: isMobile ? 280 : 360 }}
+						value={statusFilters}
+						onChange={(value) => setStatusFilters(value as ProcessingStatus[])}
+						options={[
+							{ label: "Processing", value: "PROCESSING" },
+							{ label: "Queued", value: "QUEUED" },
+							{ label: "Failed", value: "FAILED" },
+							{ label: "Completed", value: "COMPLETED" },
+						]}
+					/>
+				</div>
+				<div>
+					<Text type="secondary" className="block mb-1 text-xs">
+						Stage
+					</Text>
+					<Select
+						allowClear
+						placeholder="All stages"
+						style={{ width: isMobile ? 160 : 200 }}
+						value={stageFilter}
+						onChange={setStageFilter}
+						options={stageOptions}
+						showSearch
+					/>
+				</div>
+				<div>
+					<Text type="secondary" className="block mb-1 text-xs">
+						Owner
+					</Text>
+					<Select
+						allowClear
+						placeholder="All owners"
+						style={{ width: isMobile ? 220 : 260 }}
+						value={userFilter}
+						onChange={setUserFilter}
+						options={userOptions}
+						showSearch
+					/>
+				</div>
+				<Space>
+					<Button onClick={onRefresh}>Refresh</Button>
+					<Button
+						onClick={() => {
+							setStatusFilters([...PROCESSING_ACTIVE_STATUSES]);
+							setStageFilter(undefined);
+							setUserFilter(undefined);
+						}}
+					>
+						Reset
+					</Button>
+				</Space>
+			</div>
+
+			<Table
+				dataSource={filteredRows}
+				columns={columns}
+				rowKey="dataset_id"
+				loading={isLoading}
+				onRow={(record) => ({
+					onClick: () => setSelectedDatasetId(record.dataset_id),
+				})}
+				pagination={{
+					pageSize: 25,
+					showSizeChanger: true,
+					showQuickJumper: true,
+					showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} datasets`,
+				}}
+				scroll={{ x: isMobile ? 980 : 1400 }}
+			/>
+
+			<Drawer
+				title={`Dataset ${selectedDatasetId || ""} Logs`}
+				open={selectedDatasetId !== null}
+				onClose={() => setSelectedDatasetId(null)}
+				width={isMobile ? "100%" : 820}
+			>
+				<div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+					<Space>
+						<Text type="secondary">Log entries</Text>
+						<Select
+							value={logLimit}
+							onChange={setLogLimit}
+							style={{ width: 110 }}
+							options={[
+								{ label: "50", value: 50 },
+								{ label: "100", value: 100 },
+								{ label: "200", value: 200 },
+							]}
+						/>
+					</Space>
+					<Space>
+						{selectedRow?.current_status && <Tag>{selectedRow.current_status}</Tag>}
+						<Button onClick={() => refetchSelectedDatasetLogs()}>Refresh Logs</Button>
+					</Space>
+				</div>
+				<Table
+					rowKey="id"
+					size="small"
+					loading={isLogsLoading}
+					dataSource={selectedDatasetLogs}
+					pagination={false}
+					columns={[
+						{
+							title: "Time",
+							dataIndex: "created_at",
+							key: "created_at",
+							width: 170,
+							render: (value: string) => new Date(value).toLocaleString(),
+						},
+						{
+							title: "Level",
+							dataIndex: "level",
+							key: "level",
+							width: 90,
+							render: (value: string | null) => <Tag>{value || "INFO"}</Tag>,
+						},
+						{
+							title: "Category",
+							dataIndex: "category",
+							key: "category",
+							width: 140,
+							render: (value: string | null) => value || "general",
+						},
+						{
+							title: "Message",
+							dataIndex: "message",
+							key: "message",
+							render: (value: string | null) => (
+								<span className="whitespace-pre-wrap text-xs">{value || ""}</span>
+							),
+						},
+					]}
+				/>
+			</Drawer>
+		</>
+	);
+}

--- a/frontend/src/hooks/useProcessingOverview.ts
+++ b/frontend/src/hooks/useProcessingOverview.ts
@@ -17,19 +17,11 @@ export interface ProcessingOverviewRow {
 	user_email: string | null;
 	queue_priority: number | null;
 	queued_at: string | null;
-	is_upload_done: boolean | null;
-	is_odm_done: boolean | null;
-	is_ortho_done: boolean | null;
-	is_cog_done: boolean | null;
-	is_thumbnail_done: boolean | null;
-	is_metadata_done: boolean | null;
-	is_deadwood_done: boolean | null;
-	is_forest_cover_done: boolean | null;
-	is_combined_model_done: boolean | null;
-	is_aoi_done: boolean | null;
-	is_aoi_required: boolean | null;
 	last_20_logs: string | null;
 }
+
+const PROCESSING_OVERVIEW_COLUMNS =
+	"dataset_id,file_name,processing_status,current_status,has_error,error_message,hours_in_current_status,status_last_updated,user_email,queue_priority,queued_at,last_20_logs";
 
 export interface DatasetLogRow {
 	id: number;
@@ -49,10 +41,13 @@ export function useProcessingOverview() {
 		queryKey: ["processing-overview"],
 		enabled: !!user?.id && canAudit,
 		queryFn: async () => {
-			const { data, error } = await supabase.from("v2_processing_overview").select("*");
+			const { data, error } = await supabase
+				.from("v2_processing_overview")
+				.select(PROCESSING_OVERVIEW_COLUMNS);
 			if (error) throw error;
 			return (data || []) as ProcessingOverviewRow[];
 		},
+		retry: false,
 		staleTime: 60 * 1000,
 	});
 }

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -19,6 +19,7 @@ import {
 	Badge,
 	DatePicker,
 	Drawer,
+	Alert,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import {
@@ -1180,7 +1181,7 @@ function DatasetAuditInner() {
 
 				<div className="rounded-2xl border border-gray-200/60 bg-white p-6 shadow-sm">
 					{activeTab === "processing" &&
-						(isProcessingError ? (
+						(isProcessingError && processingRows.length === 0 ? (
 							<Result
 								status="error"
 								title="Could not load processing data"
@@ -1189,6 +1190,16 @@ function DatasetAuditInner() {
 							/>
 						) : (
 							<>
+					{isProcessingError && (
+						<Alert
+							type="warning"
+							showIcon
+							message="Processing data may be stale"
+							description="The latest refresh failed. Previously loaded processing data remains visible."
+							action={<Button onClick={() => refetchProcessingRows()}>Try again</Button>}
+							className="mb-4"
+						/>
+					)}
 					<div className="mb-4 flex flex-wrap items-end gap-3 rounded-md border border-gray-100 bg-gray-50 p-3">
 						<div>
 							<Text type="secondary" className="block mb-1 text-xs">

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -18,8 +18,6 @@ import {
 	Collapse,
 	Badge,
 	DatePicker,
-	Drawer,
-	Alert,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import {
@@ -34,6 +32,7 @@ import { useDatasetById } from "../hooks/useDatasets";
 import { useAuditDatasets } from "../hooks/useAuditDatasets";
 import type { AuditDataset } from "../hooks/useAuditDatasets";
 import DatasetAuditDetail from "../components/DatasetAudit/DatasetAuditDetail";
+import ProcessingAuditTab, { PROCESSING_ACTIVE_STATUSES } from "../components/DatasetAudit/ProcessingAuditTab";
 import { useDatasetAudits, DatasetAuditUserInfo, useDatasetContributors } from "../hooks/useDatasetAudit";
 import { supabase } from "../hooks/useSupabase";
 import { useFlaggedDatasets } from "../hooks/useDatasetFlags";
@@ -42,7 +41,7 @@ import { useAuditNavigation } from "../hooks/useAuditNavigation";
 import { usePendingCorrections } from "../hooks/usePendingCorrections";
 import { palette } from "../theme/palette";
 import { getBiomeEmoji, getBiomeTagColor, truncateBiomeLabel } from "../utils/biomeDisplay";
-import { useDatasetLogs, useProcessingOverview, ProcessingOverviewRow, ProcessingStatus } from "../hooks/useProcessingOverview";
+import { useProcessingOverview } from "../hooks/useProcessingOverview";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { isDatasetReadyForAudit } from "../utils/processingSteps";
@@ -78,13 +77,6 @@ const PROCESSING_STATE_TO_FIELD: Record<ProcessingStateFilterKey, keyof AuditDat
 const DEFAULT_PROCESSING_STATE_FILTERS: ProcessingStateFilterKey[] = PROCESSING_STATE_OPTIONS.map((option) => option.value);
 
 const BADGE_OVERFLOW_COUNT = 999999;
-const DEFAULT_PROCESSING_STATUS_FILTERS: ProcessingStatus[] = ["QUEUED", "PROCESSING", "FAILED"];
-
-const formatHours = (value: number | null | undefined): string => {
-	if (typeof value !== "number" || Number.isNaN(value)) return "—";
-	return `${value.toFixed(1)}h`;
-};
-
 // Helper function to check if a dataset is ready to be audited.
 // Auditing only depends on the legacy pipeline; it must not be gated on the v2
 // combined segmentation model, AOI generation, or the current processing status.
@@ -242,14 +234,6 @@ function DatasetAuditInner() {
 	const [hasProcessingStates, setHasProcessingStates] = useState<ProcessingStateFilterKey[]>(DEFAULT_PROCESSING_STATE_FILTERS);
 	const [inSeasonOnly, setInSeasonOnly] = useState<boolean>(false);
 	const [filtersExpanded, setFiltersExpanded] = useState<boolean>(true);
-	const [processingStatusFilters, setProcessingStatusFilters] = useState<ProcessingStatus[]>(
-		DEFAULT_PROCESSING_STATUS_FILTERS
-	);
-	const [processingStageFilter, setProcessingStageFilter] = useState<string | undefined>(undefined);
-	const [processingUserFilter, setProcessingUserFilter] = useState<string | undefined>(undefined);
-	const [selectedProcessingDatasetId, setSelectedProcessingDatasetId] = useState<number | null>(null);
-	const [logLimit, setLogLimit] = useState<number>(100);
-
 	// Update URL when filters change
 	useEffect(() => {
 		const params = new URLSearchParams();
@@ -301,55 +285,11 @@ function DatasetAuditInner() {
 		return Array.from(contributors).sort() as string[];
 	}, [contributorMap]);
 
-	const processingStageOptions = useMemo(() => {
-		const stages = new Set(
-			processingRows
-				.map((row) => row.current_status)
-				.filter((status): status is string => typeof status === "string" && status.length > 0)
-		);
-		return Array.from(stages)
-			.sort()
-			.map((value) => ({ label: value, value }));
-	}, [processingRows]);
-
-	const processingUserOptions = useMemo(() => {
-		const users = new Set(
-			processingRows
-				.map((row) => row.user_email)
-				.filter((email): email is string => typeof email === "string" && email.length > 0)
-		);
-		return Array.from(users)
-			.sort()
-			.map((value) => ({ label: value, value }));
-	}, [processingRows]);
-
-	const filteredProcessingRows = useMemo(() => {
-		return processingRows.filter((row) => {
-			if (processingStatusFilters.length > 0) {
-				const rowStatus = row.processing_status || "";
-				if (!processingStatusFilters.includes(rowStatus as ProcessingStatus)) return false;
-			}
-			if (processingStageFilter && row.current_status !== processingStageFilter) return false;
-			if (processingUserFilter && row.user_email !== processingUserFilter) return false;
-			return true;
-		});
-	}, [processingRows, processingStatusFilters, processingStageFilter, processingUserFilter]);
-
 	const processingCount = useMemo(() => {
 		return processingRows.filter((row) =>
-			DEFAULT_PROCESSING_STATUS_FILTERS.includes((row.processing_status || "") as ProcessingStatus)
+			PROCESSING_ACTIVE_STATUSES.some((status) => status === row.processing_status)
 		).length;
 	}, [processingRows]);
-
-	const selectedProcessingRow = useMemo(
-		() => processingRows.find((row) => row.dataset_id === selectedProcessingDatasetId) || null,
-		[processingRows, selectedProcessingDatasetId]
-	);
-
-	const { data: selectedDatasetLogs = [], isLoading: isLogsLoading, refetch: refetchSelectedDatasetLogs } = useDatasetLogs(
-		selectedProcessingDatasetId,
-		logLimit
-	);
 
 	// Filter datasets based on tab and filters
 	const filteredDatasets = useMemo(() => {
@@ -608,108 +548,6 @@ function DatasetAuditInner() {
 			/>
 		);
 	}
-
-	const processingColumns: ColumnsType<ProcessingOverviewRow> = [
-		{
-			title: "ID",
-			dataIndex: "dataset_id",
-			key: "dataset_id",
-			width: 90,
-			defaultSortOrder: "descend",
-			sorter: (a, b) => a.dataset_id - b.dataset_id,
-		},
-		{
-			title: "File",
-			dataIndex: "file_name",
-			key: "file_name",
-			width: 220,
-			ellipsis: true,
-			render: (value: string | null) => value || "—",
-		},
-		{
-			title: "Processing",
-			key: "processing_status",
-			width: 170,
-			render: (_, record) => {
-				const status = record.processing_status || "UNKNOWN";
-				const color =
-					status === "PROCESSING"
-						? "blue"
-						: status === "QUEUED"
-							? "orange"
-							: status === "FAILED"
-								? "red"
-								: "green";
-				return <Tag color={color} className="whitespace-nowrap">{status}</Tag>;
-			},
-		},
-		{
-			title: "Stage",
-			dataIndex: "current_status",
-			key: "current_status",
-			width: 130,
-			render: (value: string | null) => <Tag>{value || "idle"}</Tag>,
-		},
-		{
-			title: "Stuck",
-			key: "hours_in_current_status",
-			width: 100,
-			render: (_, record) => <span className="font-mono text-xs">{formatHours(record.hours_in_current_status)}</span>,
-			sorter: (a, b) => (a.hours_in_current_status || 0) - (b.hours_in_current_status || 0),
-		},
-		{
-			title: "Owner",
-			dataIndex: "user_email",
-			key: "user_email",
-			width: 220,
-			render: (value: string | null) => value || "—",
-		},
-		{
-			title: "Queue",
-			key: "queue",
-			width: 90,
-			render: (_, record) => (record.queue_priority === null ? "—" : `P${record.queue_priority}`),
-		},
-		{
-			title: "Error",
-			key: "error",
-			width: 200,
-			render: (_, record) => {
-				if (!record.has_error) return <span className="text-gray-400">—</span>;
-				const messageText = record.error_message || "Error";
-				const shortText = messageText.length > 80 ? `${messageText.slice(0, 80)}...` : messageText;
-				return (
-					<Tooltip title={messageText}>
-						<span className="text-red-600">{shortText}</span>
-					</Tooltip>
-				);
-			},
-		},
-		{
-			title: "Logs Preview",
-			key: "logs_preview",
-			width: 280,
-			render: (_, record) => {
-				if (!record.last_20_logs) return <span className="text-gray-400">No logs</span>;
-				const preview = record.last_20_logs.split("\n").slice(0, 2).join("\n");
-				return (
-					<Tooltip title={record.last_20_logs}>
-						<pre className="m-0 max-h-16 overflow-hidden whitespace-pre-wrap text-xs leading-tight">{preview}</pre>
-					</Tooltip>
-				);
-			},
-		},
-		{
-			title: "Actions",
-			key: "actions",
-			width: 120,
-			render: (_, record) => (
-				<Button size="small" onClick={() => setSelectedProcessingDatasetId(record.dataset_id)}>
-					View Logs
-				</Button>
-			),
-		},
-	];
 
 	// Build columns based on active tab
 	const baseColumns: ColumnsType<AuditDataset> = [
@@ -1180,169 +1018,14 @@ function DatasetAuditInner() {
 				</div>
 
 				<div className="rounded-2xl border border-gray-200/60 bg-white p-6 shadow-sm">
-					{activeTab === "processing" &&
-						(isProcessingError && processingRows.length === 0 ? (
-							<Result
-								status="error"
-								title="Could not load processing data"
-								subTitle="The processing overview could not be loaded. Please try again."
-								extra={<Button onClick={() => refetchProcessingRows()}>Try again</Button>}
-							/>
-						) : (
-							<>
-					{isProcessingError && (
-						<Alert
-							type="warning"
-							showIcon
-							message="Processing data may be stale"
-							description="The latest refresh failed. Previously loaded processing data remains visible."
-							action={<Button onClick={() => refetchProcessingRows()}>Try again</Button>}
-							className="mb-4"
+					{activeTab === "processing" && (
+						<ProcessingAuditTab
+							rows={processingRows}
+							isLoading={isProcessingLoading}
+							isError={isProcessingError}
+							onRefresh={() => void refetchProcessingRows()}
 						/>
 					)}
-					<div className="mb-4 flex flex-wrap items-end gap-3 rounded-md border border-gray-100 bg-gray-50 p-3">
-						<div>
-							<Text type="secondary" className="block mb-1 text-xs">
-								Processing Status
-							</Text>
-							<Select
-								mode="multiple"
-								allowClear
-								placeholder="Select statuses"
-								style={{ width: isMobile ? 280 : 360 }}
-								value={processingStatusFilters}
-								onChange={(value) => setProcessingStatusFilters(value as ProcessingStatus[])}
-								options={[
-									{ label: "Processing", value: "PROCESSING" },
-									{ label: "Queued", value: "QUEUED" },
-									{ label: "Failed", value: "FAILED" },
-									{ label: "Completed", value: "COMPLETED" },
-								]}
-							/>
-						</div>
-						<div>
-							<Text type="secondary" className="block mb-1 text-xs">
-								Stage
-							</Text>
-							<Select
-								allowClear
-								placeholder="All stages"
-								style={{ width: isMobile ? 160 : 200 }}
-								value={processingStageFilter}
-								onChange={setProcessingStageFilter}
-								options={processingStageOptions}
-								showSearch
-							/>
-						</div>
-						<div>
-							<Text type="secondary" className="block mb-1 text-xs">
-								Owner
-							</Text>
-							<Select
-								allowClear
-								placeholder="All owners"
-								style={{ width: isMobile ? 220 : 260 }}
-								value={processingUserFilter}
-								onChange={setProcessingUserFilter}
-								options={processingUserOptions}
-								showSearch
-							/>
-						</div>
-						<Space>
-							<Button onClick={() => refetchProcessingRows()}>Refresh</Button>
-							<Button
-								onClick={() => {
-									setProcessingStatusFilters(DEFAULT_PROCESSING_STATUS_FILTERS);
-									setProcessingStageFilter(undefined);
-									setProcessingUserFilter(undefined);
-								}}
-							>
-								Reset
-							</Button>
-						</Space>
-					</div>
-
-					<Table
-						dataSource={filteredProcessingRows}
-						columns={processingColumns}
-						rowKey="dataset_id"
-						loading={isProcessingLoading}
-						onRow={(record) => ({
-							onClick: () => setSelectedProcessingDatasetId(record.dataset_id),
-						})}
-						pagination={{
-							pageSize: 25,
-							showSizeChanger: true,
-							showQuickJumper: true,
-							showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} datasets`,
-						}}
-						scroll={{ x: isMobile ? 980 : 1400 }}
-					/>
-
-					<Drawer
-						title={`Dataset ${selectedProcessingDatasetId || ""} Logs`}
-						open={selectedProcessingDatasetId !== null}
-						onClose={() => setSelectedProcessingDatasetId(null)}
-						width={isMobile ? "100%" : 820}
-					>
-						<div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-							<Space>
-								<Text type="secondary">Log entries</Text>
-								<Select
-									value={logLimit}
-									onChange={setLogLimit}
-									style={{ width: 110 }}
-									options={[
-										{ label: "50", value: 50 },
-										{ label: "100", value: 100 },
-										{ label: "200", value: 200 },
-									]}
-								/>
-							</Space>
-							<Space>
-								{selectedProcessingRow?.current_status && <Tag>{selectedProcessingRow.current_status}</Tag>}
-								<Button onClick={() => refetchSelectedDatasetLogs()}>Refresh Logs</Button>
-							</Space>
-						</div>
-						<Table
-							rowKey="id"
-							size="small"
-							loading={isLogsLoading}
-							dataSource={selectedDatasetLogs}
-							pagination={false}
-							columns={[
-								{
-									title: "Time",
-									dataIndex: "created_at",
-									key: "created_at",
-									width: 170,
-									render: (value: string) => new Date(value).toLocaleString(),
-								},
-								{
-									title: "Level",
-									dataIndex: "level",
-									key: "level",
-									width: 90,
-									render: (value: string | null) => <Tag>{value || "INFO"}</Tag>,
-								},
-								{
-									title: "Category",
-									dataIndex: "category",
-									key: "category",
-									width: 140,
-									render: (value: string | null) => value || "general",
-								},
-								{
-									title: "Message",
-									dataIndex: "message",
-									key: "message",
-									render: (value: string | null) => <span className="whitespace-pre-wrap text-xs">{value || ""}</span>,
-								},
-							]}
-						/>
-					</Drawer>
-							</>
-						))}
 
 			{activeTab !== "processing" && (
 				<>

--- a/frontend/src/pages/DatasetAudit.tsx
+++ b/frontend/src/pages/DatasetAudit.tsx
@@ -216,6 +216,7 @@ function DatasetAuditInner() {
 	const {
 		data: processingRows = [],
 		isLoading: isProcessingLoading,
+		isError: isProcessingError,
 		refetch: refetchProcessingRows,
 	} = useProcessingOverview();
 
@@ -1178,8 +1179,16 @@ function DatasetAuditInner() {
 				</div>
 
 				<div className="rounded-2xl border border-gray-200/60 bg-white p-6 shadow-sm">
-					{activeTab === "processing" && (
-						<>
+					{activeTab === "processing" &&
+						(isProcessingError ? (
+							<Result
+								status="error"
+								title="Could not load processing data"
+								subTitle="The processing overview could not be loaded. Please try again."
+								extra={<Button onClick={() => refetchProcessingRows()}>Try again</Button>}
+							/>
+						) : (
+							<>
 					<div className="mb-4 flex flex-wrap items-end gap-3 rounded-md border border-gray-100 bg-gray-50 p-3">
 						<div>
 							<Text type="secondary" className="block mb-1 text-xs">
@@ -1321,8 +1330,8 @@ function DatasetAuditInner() {
 							]}
 						/>
 					</Drawer>
-				</>
-			)}
+							</>
+						))}
 
 			{activeTab !== "processing" && (
 				<>


### PR DESCRIPTION
## Briefing

Restores the Dataset Audits Processing tab, which currently renders an empty table because its production PostgREST request exceeds the statement timeout. Auditors regain the failed/queued/active dataset overview, while genuine initial-load failures are shown explicitly and transient refresh failures keep the last successful data visible.

## What changed

- Fetch only the 12 processing-overview fields rendered by the table instead of the entire heavyweight view.
- Stop automatic retries for the expensive overview request and provide explicit retry actions.
- Render a blocking error for initial-load failures and a non-destructive stale-data warning after failed refreshes.
- Keep the Processing tab's filters, table, error modes, and log drawer in a focused component instead of the audit-page monolith.
- Cover the lightweight projection, initial timeout UX, and success-then-failed-refresh behavior in the auditor browser suite.

## Validation

- Production database comparison: rendered-field projection completed in about 4 seconds; full-row projection required about 17 seconds.
- Production-connected local frontend with an authenticated auditor session: Processing badge showed 19, all 19 failed rows rendered with owner/error/log previews, and the browser console had no errors.
- `npm --prefix frontend run test:e2e:local:audit`: 12 passed on the final diff.
- `npm --prefix frontend test`: 286 passed across 52 files on the final diff.
- `npm --prefix frontend run lint`: passed on the final diff.
- `npm --prefix frontend run build`: passed on the final diff.
- `scripts/lint-ast-grep.sh`: passed on the final diff.

## Risk and limitations

Frontend-only query, component-boundary, and error-state change; no schema, RLS, API, queue, or production data mutation. The deployed site remains affected until the normal merge-to-main frontend deployment completes.
