### PR TITLE
feat(priwa): archive Warnkarte versions

### DIFF
--- a/api/src/routers/priwa_warnkarte.py
+++ b/api/src/routers/priwa_warnkarte.py
@@ -40,11 +40,17 @@ class WarnkarteVersion(BaseModel):
 	imported_by: str
 	imported_at: str
 	is_current: bool
+	is_archived: bool
 
 
 class WarnkartePublicationResponse(BaseModel):
 	publication_id: int
 	version_id: str
+
+
+class WarnkarteArchiveStateResponse(BaseModel):
+	version_id: str
+	is_archived: bool
 
 
 def validation_http_error(error: WarnkarteValidationError) -> HTTPException:
@@ -123,6 +129,65 @@ def overlay_from_rpc_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
 		}
 
 	return rows[0]['payload']
+
+
+def run_version_rpc(
+	token: str,
+	rpc_name: str,
+	version_id: str,
+	*,
+	failure_code: str,
+	failure_message: str,
+) -> int:
+	try:
+		with use_client(token) as client:
+			return client.rpc(rpc_name, {'p_version_id': version_id}).execute().data
+	except Exception as error:
+		error_text = str(error)
+		if 'admin access is required' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_403_FORBIDDEN,
+				detail={
+					'code': 'ADMIN_REQUIRED',
+					'message': 'Nur PRIWA-Admins dürfen Warnkartenversionen verwalten.',
+					'details': {},
+				},
+			) from error
+		if 'Warnkarte version not found' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_404_NOT_FOUND,
+				detail={
+					'code': 'VERSION_NOT_FOUND',
+					'message': 'Die Warnkartenversion wurde nicht gefunden.',
+					'details': {'version_id': version_id},
+				},
+			) from error
+		if 'Warnkarte current version cannot be archived' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_409_CONFLICT,
+				detail={
+					'code': 'CURRENT_VERSION_ARCHIVE_FORBIDDEN',
+					'message': 'Die aktuell veröffentlichte Warnkarte kann nicht archiviert werden.',
+					'details': {'version_id': version_id},
+				},
+			) from error
+		if 'Warnkarte archived version cannot be published' in error_text:
+			raise HTTPException(
+				status_code=status.HTTP_409_CONFLICT,
+				detail={
+					'code': 'ARCHIVED_VERSION_PUBLISH_FORBIDDEN',
+					'message': 'Die Warnkartenversion muss vor dem Veröffentlichen wiederhergestellt werden.',
+					'details': {'version_id': version_id},
+				},
+			) from error
+		raise HTTPException(
+			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+			detail={
+				'code': failure_code,
+				'message': failure_message,
+				'details': {},
+			},
+		) from error
 
 
 @router.post('/validate', response_model=WarnkarteValidationSummary)
@@ -230,8 +295,22 @@ def list_warnkarte_versions(
 			.limit(1)
 			.execute()
 		).data or []
+		archive_states = (
+			client.table('priwa_warnkarte_archive_states')
+			.select('version_id,is_archived')
+			.eq('project_id', project_id)
+			.execute()
+		).data or []
 	current_version_id = publication[0]['version_id'] if publication else None
-	return [{**version, 'is_current': version['id'] == current_version_id} for version in versions]
+	archived_version_ids = {state['version_id'] for state in archive_states if state['is_archived']}
+	return [
+		{
+			**version,
+			'is_current': version['id'] == current_version_id,
+			'is_archived': version['id'] in archived_version_ids,
+		}
+		for version in versions
+	]
 
 
 @router.post('/versions/{version_id}/publish', response_model=WarnkartePublicationResponse)
@@ -240,38 +319,46 @@ def publish_warnkarte_version(
 	token: Annotated[str, Depends(oauth2_scheme)],
 ):
 	require_user(token)
-	try:
-		with use_client(token) as client:
-			publication_id = client.rpc('priwa_publish_warnkarte', {'p_version_id': version_id}).execute().data
-	except Exception as error:
-		error_text = str(error)
-		if 'admin access is required' in error_text:
-			raise HTTPException(
-				status_code=status.HTTP_403_FORBIDDEN,
-				detail={
-					'code': 'ADMIN_REQUIRED',
-					'message': 'Nur PRIWA-Admins dürfen eine Warnkarte veröffentlichen.',
-					'details': {},
-				},
-			) from error
-		if 'Warnkarte version not found' in error_text:
-			raise HTTPException(
-				status_code=status.HTTP_404_NOT_FOUND,
-				detail={
-					'code': 'VERSION_NOT_FOUND',
-					'message': 'Die Warnkartenversion wurde nicht gefunden.',
-					'details': {'version_id': version_id},
-				},
-			) from error
-		raise HTTPException(
-			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-			detail={
-				'code': 'PUBLISH_FAILED',
-				'message': 'Die Warnkarte konnte nicht veröffentlicht werden.',
-				'details': {},
-			},
-		) from error
+	publication_id = run_version_rpc(
+		token,
+		'priwa_publish_warnkarte',
+		version_id,
+		failure_code='PUBLISH_FAILED',
+		failure_message='Die Warnkarte konnte nicht veröffentlicht werden.',
+	)
 	return {'publication_id': publication_id, 'version_id': version_id}
+
+
+@router.post('/versions/{version_id}/archive', response_model=WarnkarteArchiveStateResponse)
+def archive_warnkarte_version(
+	version_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	run_version_rpc(
+		token,
+		'priwa_archive_warnkarte',
+		version_id,
+		failure_code='ARCHIVE_FAILED',
+		failure_message='Die Warnkartenversion konnte nicht archiviert werden.',
+	)
+	return {'version_id': version_id, 'is_archived': True}
+
+
+@router.post('/versions/{version_id}/restore', response_model=WarnkarteArchiveStateResponse)
+def restore_warnkarte_version(
+	version_id: str,
+	token: Annotated[str, Depends(oauth2_scheme)],
+):
+	require_user(token)
+	run_version_rpc(
+		token,
+		'priwa_restore_warnkarte',
+		version_id,
+		failure_code='RESTORE_FAILED',
+		failure_message='Die Warnkartenversion konnte nicht wiederhergestellt werden.',
+	)
+	return {'version_id': version_id, 'is_archived': False}
 
 
 @router.get('/active')

--- a/api/tests/db/test_priwa_warnkarte_schema.py
+++ b/api/tests/db/test_priwa_warnkarte_schema.py
@@ -44,6 +44,7 @@ def warnkarte_project(test_user, test_user2):
 	finally:
 		with use_service_client() as client:
 			client.table('priwa_warnkarte_publications').delete().eq('project_id', project_id).execute()
+			client.table('priwa_warnkarte_archive_events').delete().eq('project_id', project_id).execute()
 			client.table('priwa_warnkarte_versions').delete().eq('project_id', project_id).execute()
 			client.table('priwa_project_memberships').delete().eq('project_id', project_id).execute()
 			client.table('priwa_projects').delete().eq('id', project_id).execute()
@@ -254,3 +255,101 @@ def test_publication_and_reversion_use_latest_append_only_record(warnkarte_proje
 			.execute()
 		).data
 	assert [row['version_id'] for row in publications] == [old_version_id, new_version_id, old_version_id]
+
+
+def test_archiving_is_reversible_admin_only_and_cannot_hide_current_version(warnkarte_project):
+	admin_token = login(settings.TEST_USER_EMAIL, settings.TEST_USER_PASSWORD, use_cached_session=False)
+	member_token = login(settings.TEST_USER_EMAIL2, settings.TEST_USER_PASSWORD2, use_cached_session=False)
+
+	with use_service_client() as client:
+		current_version_id = import_version(
+			client,
+			warnkarte_project['admin_id'],
+			warnkarte_project['id'],
+			'current-for-archive',
+			'2024-07-01',
+		)
+		older_version_id = import_version(
+			client,
+			warnkarte_project['admin_id'],
+			warnkarte_project['id'],
+			'older-for-archive',
+			'2024-06-25',
+		)
+
+	with use_client(admin_token) as client:
+		client.rpc('priwa_publish_warnkarte', {'p_version_id': current_version_id}).execute()
+		with pytest.raises(Exception, match='current version cannot be archived'):
+			client.rpc('priwa_archive_warnkarte', {'p_version_id': current_version_id}).execute()
+
+	with use_client(member_token) as client:
+		with pytest.raises(Exception, match='admin access is required'):
+			client.rpc('priwa_archive_warnkarte', {'p_version_id': older_version_id}).execute()
+
+	with use_client(admin_token) as client:
+		first_event_id = client.rpc('priwa_archive_warnkarte', {'p_version_id': older_version_id}).execute().data
+		second_event_id = client.rpc('priwa_archive_warnkarte', {'p_version_id': older_version_id}).execute().data
+		assert second_event_id == first_event_id
+
+		archive_state = (
+			client.table('priwa_warnkarte_archive_states')
+			.select('is_archived')
+			.eq('version_id', older_version_id)
+			.single()
+			.execute()
+		).data
+		assert archive_state == {'is_archived': True}
+
+		archived_overlay = (
+			client.rpc(
+				'priwa_warnkarte_version_overlay',
+				{'p_project_id': warnkarte_project['id'], 'p_version_id': older_version_id},
+			)
+			.execute()
+			.data
+		)
+		assert archived_overlay == []
+
+		with pytest.raises(Exception, match='archived version cannot be published'):
+			client.rpc('priwa_publish_warnkarte', {'p_version_id': older_version_id}).execute()
+
+	with use_client(member_token) as client:
+		assert (
+			client.table('priwa_warnkarte_archive_events')
+			.select('*')
+			.eq('project_id', warnkarte_project['id'])
+			.execute()
+			.data
+			== []
+		)
+		assert (
+			client.table('priwa_warnkarte_archive_states')
+			.select('*')
+			.eq('project_id', warnkarte_project['id'])
+			.execute()
+			.data
+			== []
+		)
+
+	with use_client(admin_token) as client:
+		client.rpc('priwa_restore_warnkarte', {'p_version_id': older_version_id}).execute()
+		restored_overlay = (
+			client.rpc(
+				'priwa_warnkarte_version_overlay',
+				{'p_project_id': warnkarte_project['id'], 'p_version_id': older_version_id},
+			)
+			.execute()
+			.data
+		)
+		assert len(restored_overlay[0]['payload']['features']) == 1
+		client.rpc('priwa_publish_warnkarte', {'p_version_id': older_version_id}).execute()
+
+	with use_service_client() as client:
+		events = (
+			client.table('priwa_warnkarte_archive_events')
+			.select('action')
+			.eq('version_id', older_version_id)
+			.order('id')
+			.execute()
+		).data
+	assert [event['action'] for event in events] == ['archive', 'restore']

--- a/api/tests/priwa/test_warnkarte_router.py
+++ b/api/tests/priwa/test_warnkarte_router.py
@@ -165,21 +165,23 @@ def test_import_uses_service_only_rpc_with_verified_actor(monkeypatch):
 
 
 class FakeRpc:
-	def __init__(self, allowed: bool):
-		self.allowed = allowed
+	def __init__(self, result):
+		self.result = result
 
 	def execute(self):
-		return type('Response', (), {'data': self.allowed})()
+		if isinstance(self.result, Exception):
+			raise self.result
+		return type('Response', (), {'data': self.result})()
 
 
 class FakeClient:
-	def __init__(self, allowed: bool):
-		self.allowed = allowed
+	def __init__(self, result):
+		self.result = result
 		self.calls = []
 
 	def rpc(self, name, payload):
 		self.calls.append((name, payload))
-		return FakeRpc(self.allowed)
+		return FakeRpc(self.result)
 
 
 def test_project_access_uses_database_admin_authorization(monkeypatch):
@@ -197,3 +199,88 @@ def test_project_access_uses_database_admin_authorization(monkeypatch):
 	assert error.value.status_code == 403
 	assert error.value.detail['code'] == 'ADMIN_REQUIRED'
 	assert client.calls == [('priwa_is_project_admin', {'p_project_id': 'project-1'})]
+
+
+@pytest.mark.parametrize(
+	('error_text', 'expected_status', 'expected_code'),
+	[
+		('Warnkarte current version cannot be archived', 409, 'CURRENT_VERSION_ARCHIVE_FORBIDDEN'),
+		('Warnkarte archived version cannot be published', 409, 'ARCHIVED_VERSION_PUBLISH_FORBIDDEN'),
+		('Warnkarte version not found', 404, 'VERSION_NOT_FOUND'),
+		('PRIWA project admin access is required', 403, 'ADMIN_REQUIRED'),
+	],
+)
+def test_version_action_database_errors_are_structured(
+	monkeypatch,
+	error_text,
+	expected_status,
+	expected_code,
+):
+	client = FakeClient(Exception(error_text))
+
+	@contextmanager
+	def use_fake_client(_token):
+		yield client
+
+	monkeypatch.setattr(priwa_warnkarte, 'use_client', use_fake_client)
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.run_version_rpc(
+			'token',
+			'priwa_archive_warnkarte',
+			'version-1',
+			failure_code='ARCHIVE_FAILED',
+			failure_message='Archivierung fehlgeschlagen.',
+		)
+
+	assert error.value.status_code == expected_status
+	assert error.value.detail['code'] == expected_code
+	expected_details = {} if expected_code == 'ADMIN_REQUIRED' else {'version_id': 'version-1'}
+	assert error.value.detail['details'] == expected_details
+
+
+def test_archive_and_restore_endpoints_use_authenticated_database_rpcs(monkeypatch):
+	client = FakeClient(42)
+
+	@contextmanager
+	def use_fake_client(_token):
+		yield client
+
+	monkeypatch.setattr(priwa_warnkarte, 'require_user', lambda _token: object())
+	monkeypatch.setattr(priwa_warnkarte, 'use_client', use_fake_client)
+
+	archived = priwa_warnkarte.archive_warnkarte_version('version-1', 'token')
+	restored = priwa_warnkarte.restore_warnkarte_version('version-1', 'token')
+
+	assert archived == {'version_id': 'version-1', 'is_archived': True}
+	assert restored == {'version_id': 'version-1', 'is_archived': False}
+	assert client.calls == [
+		('priwa_archive_warnkarte', {'p_version_id': 'version-1'}),
+		('priwa_restore_warnkarte', {'p_version_id': 'version-1'}),
+	]
+
+
+def test_unknown_archive_database_error_uses_operation_specific_failure(monkeypatch):
+	client = FakeClient(Exception('database unavailable'))
+
+	@contextmanager
+	def use_fake_client(_token):
+		yield client
+
+	monkeypatch.setattr(priwa_warnkarte, 'use_client', use_fake_client)
+
+	with pytest.raises(HTTPException) as error:
+		priwa_warnkarte.run_version_rpc(
+			'token',
+			'priwa_archive_warnkarte',
+			'version-1',
+			failure_code='ARCHIVE_FAILED',
+			failure_message='Archivierung fehlgeschlagen.',
+		)
+
+	assert error.value.status_code == 500
+	assert error.value.detail == {
+		'code': 'ARCHIVE_FAILED',
+		'message': 'Archivierung fehlgeschlagen.',
+		'details': {},
+	}

--- a/frontend/e2e-local/priwa-warnkarte-local.spec.ts
+++ b/frontend/e2e-local/priwa-warnkarte-local.spec.ts
@@ -150,6 +150,7 @@ async function installWarnkarteApi(
   }: { validateDelayMs?: number; overlayDelayMs?: number } = {},
 ) {
   let published = false;
+  let archived = false;
 
   await page.route("**/priwa/warnkarte/active?*", async (route) => {
     await route.fulfill({
@@ -177,6 +178,7 @@ async function installWarnkarteApi(
           imported_by: admin.id,
           imported_at: "2024-07-01T12:00:00Z",
           is_current: published,
+          is_archived: archived,
         },
         {
           id: "version-old",
@@ -189,6 +191,7 @@ async function installWarnkarteApi(
           imported_by: admin.id,
           imported_at: "2024-06-25T12:00:00Z",
           is_current: !published,
+          is_archived: false,
         },
       ],
     });
@@ -251,6 +254,26 @@ async function installWarnkarteApi(
       await route.fulfill({
         contentType: "application/json",
         json: { publication_id: 2, version_id: "version-new" },
+      });
+    },
+  );
+  await page.route(
+    "**/priwa/warnkarte/versions/version-new/archive",
+    async (route) => {
+      archived = true;
+      await route.fulfill({
+        contentType: "application/json",
+        json: { version_id: "version-new", is_archived: true },
+      });
+    },
+  );
+  await page.route(
+    "**/priwa/warnkarte/versions/version-new/restore",
+    async (route) => {
+      archived = false;
+      await route.fulfill({
+        contentType: "application/json",
+        json: { version_id: "version-new", is_archived: false },
       });
     },
   );
@@ -387,6 +410,57 @@ test.describe("PRIWA Warnkarte local UI", () => {
     await expect(page.getByTestId("priwa-warnkarte-legend")).toContainText(
       "Warnkarte 25.06.2024",
     );
+  });
+
+  test("desktop admin archives and restores an inactive Warnkarte", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await installWarnkarteAdmin(page);
+    await installWarnkarteApi(page);
+    await page.goto("/priwa-field");
+
+    await page.getByRole("button", { name: "Warnkarte verwalten" }).click();
+    await expect(
+      page
+        .getByTestId("priwa-warnkarte-version-version-old")
+        .getByRole("button", { name: "Archivieren" }),
+    ).toHaveCount(0);
+    const version = page.getByTestId("priwa-warnkarte-version-version-new");
+    await version.getByRole("radio", { name: "Auf Karte anzeigen" }).click();
+    await expect(page.getByTestId("priwa-warnkarte-legend")).toContainText(
+      "Warnkarte 01.07.2024",
+    );
+
+    await version.getByRole("button", { name: "Archivieren" }).click();
+    await page
+      .getByRole("button", { name: "Archivieren", exact: true })
+      .last()
+      .click();
+
+    await expect(page.getByText("Warnkartenversion archiviert.")).toBeVisible();
+    await expect(
+      page.getByTestId("priwa-warnkarte-version-version-new"),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("priwa-warnkarte-legend")).toContainText(
+      "Warnkarte 25.06.2024",
+    );
+    await page.getByText("Archiviert (1)").click();
+
+    const archivedVersion = page.getByTestId(
+      "priwa-warnkarte-archived-version-new",
+    );
+    await archivedVersion
+      .getByRole("button", { name: "Wiederherstellen" })
+      .click();
+
+    await expect(
+      page.getByText("Warnkartenversion wiederhergestellt."),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("priwa-warnkarte-version-version-new"),
+    ).toBeVisible();
+    await expect(page.getByText("Archiviert (1)")).toHaveCount(0);
   });
 
   test("desktop admin cannot replace a file while its validation is pending", async ({

--- a/frontend/src/api/priwaWarnkarte.ts
+++ b/frontend/src/api/priwaWarnkarte.ts
@@ -37,6 +37,7 @@ export interface IPriwaWarnkarteVersion {
   imported_by: string;
   imported_at: string;
   is_current: boolean;
+  is_archived: boolean;
 }
 
 export interface IPriwaWarnkarteImportResponse {
@@ -178,3 +179,25 @@ export async function publishPriwaWarnkarteVersion(
     response,
   );
 }
+
+async function updatePriwaWarnkarteArchiveState(
+  versionId: string,
+  action: "archive" | "restore",
+  token: string,
+) {
+  const response = await fetch(
+    `${Settings.API_URL}/priwa/warnkarte/versions/${versionId}/${action}`,
+    { method: "POST", headers: authHeaders(token) },
+  );
+  return parseResponse<{ version_id: string; is_archived: boolean }>(response);
+}
+
+export const archivePriwaWarnkarteVersion = (
+  versionId: string,
+  token: string,
+) => updatePriwaWarnkarteArchiveState(versionId, "archive", token);
+
+export const restorePriwaWarnkarteVersion = (
+  versionId: string,
+  token: string,
+) => updatePriwaWarnkarteArchiveState(versionId, "restore", token);

--- a/frontend/src/components/PriwaField/PriwaWarnkarteAdminPanel.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteAdminPanel.tsx
@@ -20,6 +20,8 @@ interface PriwaWarnkarteAdminPanelProps {
   onImport: (file: File, confirmedDate: string) => Promise<unknown>;
   onShowVersion: (versionId: string) => Promise<void>;
   onPublish: (versionId: string) => Promise<void>;
+  onArchive: (versionId: string) => Promise<void>;
+  onRestore: (versionId: string) => Promise<void>;
 }
 
 export default function PriwaWarnkarteAdminPanel({
@@ -32,6 +34,8 @@ export default function PriwaWarnkarteAdminPanel({
   onImport,
   onShowVersion,
   onPublish,
+  onArchive,
+  onRestore,
 }: PriwaWarnkarteAdminPanelProps) {
   const { message } = App.useApp();
   const [file, setFile] = useState<File | null>(null);
@@ -85,6 +89,18 @@ export default function PriwaWarnkarteAdminPanel({
     void run(async () => {
       await onPublish(versionId);
       message.success("Warnkarte veröffentlicht.");
+    });
+
+  const archive = (versionId: string) =>
+    void run(async () => {
+      await onArchive(versionId);
+      message.success("Warnkartenversion archiviert.");
+    });
+
+  const restore = (versionId: string) =>
+    void run(async () => {
+      await onRestore(versionId);
+      message.success("Warnkartenversion wiederhergestellt.");
     });
 
   return (
@@ -141,6 +157,8 @@ export default function PriwaWarnkarteAdminPanel({
           isBusy={isBusy}
           onShowVersion={showVersion}
           onPublish={publish}
+          onArchive={archive}
+          onRestore={restore}
         />
       )}
     </div>

--- a/frontend/src/components/PriwaField/PriwaWarnkarteVersionList.tsx
+++ b/frontend/src/components/PriwaField/PriwaWarnkarteVersionList.tsx
@@ -1,5 +1,7 @@
+import { InboxOutlined, UndoOutlined } from "@ant-design/icons";
 import {
   Button,
+  Collapse,
   Empty,
   List,
   Popconfirm,
@@ -18,7 +20,22 @@ interface PriwaWarnkarteVersionListProps {
   isBusy: boolean;
   onShowVersion: (versionId: string) => void;
   onPublish: (versionId: string) => void;
+  onArchive: (versionId: string) => void;
+  onRestore: (versionId: string) => void;
 }
+
+const versionTitle = (version: IPriwaWarnkarteVersion) => (
+  <Typography.Text strong>
+    Warnkarte vom {formatPriwaWarnkarteDate(version.source_date)}
+  </Typography.Text>
+);
+
+const versionMetadata = (version: IPriwaWarnkarteVersion) => (
+  <Typography.Paragraph type="secondary" className="!mb-3 !mt-1 text-xs">
+    {version.feature_count} Polygone · importiert{" "}
+    {new Date(version.imported_at).toLocaleString("de-DE")}
+  </Typography.Paragraph>
+);
 
 export default function PriwaWarnkarteVersionList({
   versions,
@@ -26,7 +43,12 @@ export default function PriwaWarnkarteVersionList({
   isBusy,
   onShowVersion,
   onPublish,
+  onArchive,
+  onRestore,
 }: PriwaWarnkarteVersionListProps) {
+  const availableVersions = versions.filter((version) => !version.is_archived);
+  const archivedVersions = versions.filter((version) => version.is_archived);
+
   if (versions.length === 0) {
     return (
       <Empty
@@ -37,68 +59,127 @@ export default function PriwaWarnkarteVersionList({
   }
 
   return (
-    <Radio.Group
-      className="w-full"
-      value={visibleVersionId}
-      onChange={(event) => onShowVersion(event.target.value)}
-    >
-      <List
-        className="w-full"
-        dataSource={versions}
-        renderItem={(version) => {
-          const isVisible = visibleVersionId === version.id;
-          return (
-            <List.Item className="!block !px-0">
-              <div
-                className={`rounded-lg border p-3 ${
-                  isVisible
-                    ? "border-emerald-300 bg-emerald-50/70"
-                    : "border-slate-200 bg-white"
-                }`}
-              >
-                <Space wrap size={[6, 4]}>
-                  <Typography.Text strong>
-                    Warnkarte vom{" "}
-                    {formatPriwaWarnkarteDate(version.source_date)}
-                  </Typography.Text>
-                  {version.is_current && <Tag color="red">Aktiv</Tag>}
-                  {isVisible && <Tag color="green">Sichtbar</Tag>}
-                </Space>
-                <Typography.Paragraph
-                  type="secondary"
-                  className="!mb-3 !mt-1 text-xs"
+    <div className="space-y-3">
+      {availableVersions.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="Keine verfügbaren Warnkarten"
+        />
+      ) : (
+        <Radio.Group
+          className="w-full"
+          value={visibleVersionId}
+          onChange={(event) => onShowVersion(event.target.value)}
+        >
+          <List
+            className="w-full"
+            dataSource={availableVersions}
+            renderItem={(version) => {
+              const isVisible = visibleVersionId === version.id;
+              return (
+                <List.Item
+                  className="!block !px-0"
+                  data-testid={`priwa-warnkarte-version-${version.id}`}
                 >
-                  {version.feature_count} Polygone · importiert{" "}
-                  {new Date(version.imported_at).toLocaleString("de-DE")}
-                </Typography.Paragraph>
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <Radio value={version.id} disabled={isBusy}>
-                    {isVisible ? "Auf Karte sichtbar" : "Auf Karte anzeigen"}
-                  </Radio>
-                  {!version.is_current && (
-                    <Popconfirm
-                      title="Diese Version als aktive Warnkarte veröffentlichen?"
-                      description="Die bisherige Version bleibt erhalten und kann erneut veröffentlicht werden."
-                      okText="Veröffentlichen"
-                      cancelText="Abbrechen"
-                      onConfirm={() => onPublish(version.id)}
+                  <div
+                    className={`rounded-lg border p-3 ${
+                      isVisible
+                        ? "border-emerald-300 bg-emerald-50/70"
+                        : "border-slate-200 bg-white"
+                    }`}
+                  >
+                    <Space wrap size={[6, 4]}>
+                      {versionTitle(version)}
+                      {version.is_current && <Tag color="red">Aktiv</Tag>}
+                      {isVisible && <Tag color="green">Sichtbar</Tag>}
+                    </Space>
+                    {versionMetadata(version)}
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <Radio value={version.id} disabled={isBusy}>
+                        {isVisible
+                          ? "Auf Karte sichtbar"
+                          : "Auf Karte anzeigen"}
+                      </Radio>
+                      {!version.is_current && (
+                        <Space wrap size="small">
+                          <Popconfirm
+                            title="Diese Version archivieren?"
+                            description="Sie wird ausgeblendet, bleibt aber vollständig erhalten und kann wiederhergestellt werden."
+                            okText="Archivieren"
+                            cancelText="Abbrechen"
+                            onConfirm={() => onArchive(version.id)}
+                          >
+                            <Button
+                              size="small"
+                              icon={<InboxOutlined />}
+                              disabled={isBusy}
+                            >
+                              Archivieren
+                            </Button>
+                          </Popconfirm>
+                          <Popconfirm
+                            title="Diese Version als aktive Warnkarte veröffentlichen?"
+                            description="Die bisherige Version bleibt erhalten und kann erneut veröffentlicht werden."
+                            okText="Veröffentlichen"
+                            cancelText="Abbrechen"
+                            onConfirm={() => onPublish(version.id)}
+                          >
+                            <Button
+                              size="small"
+                              type="primary"
+                              danger
+                              disabled={isBusy}
+                            >
+                              Veröffentlichen
+                            </Button>
+                          </Popconfirm>
+                        </Space>
+                      )}
+                    </div>
+                  </div>
+                </List.Item>
+              );
+            }}
+          />
+        </Radio.Group>
+      )}
+
+      {archivedVersions.length > 0 && (
+        <Collapse
+          ghost
+          size="small"
+          items={[
+            {
+              key: "archived",
+              label: `Archiviert (${archivedVersions.length})`,
+              children: (
+                <List
+                  dataSource={archivedVersions}
+                  renderItem={(version) => (
+                    <List.Item
+                      className="!block !px-0"
+                      data-testid={`priwa-warnkarte-archived-${version.id}`}
                     >
-                      <Button
-                        size="small"
-                        type="primary"
-                        danger
-                        disabled={isBusy}
-                      >
-                        Veröffentlichen
-                      </Button>
-                    </Popconfirm>
+                      <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                        {versionTitle(version)}
+                        {versionMetadata(version)}
+                        <Button
+                          size="small"
+                          icon={<UndoOutlined />}
+                          disabled={isBusy}
+                          onClick={() => onRestore(version.id)}
+                        >
+                          Wiederherstellen
+                        </Button>
+                      </div>
+                    </List.Item>
                   )}
-                </div>
-              </div>
-            </List.Item>
-          );
-        }}
-      />
-    </Radio.Group>
+                />
+              ),
+            },
+          ]}
+        />
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/PriwaField/usePriwaWarnkarte.ts
+++ b/frontend/src/components/PriwaField/usePriwaWarnkarte.ts
@@ -2,11 +2,13 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
 import {
+  archivePriwaWarnkarteVersion,
   fetchActivePriwaWarnkarte,
   fetchPriwaWarnkarteVersionOverlay,
   fetchPriwaWarnkarteVersions,
   importPriwaWarnkarte,
   publishPriwaWarnkarteVersion,
+  restorePriwaWarnkarteVersion,
   validatePriwaWarnkarte,
   type IPriwaWarnkarteOverlay,
 } from "../../api/priwaWarnkarte";
@@ -91,6 +93,27 @@ export function usePriwaWarnkarte(projectId: string, canManage: boolean) {
     }
   };
 
+  const archiveVersion = async (versionId: string) => {
+    const request = ++selectedOverlayRequest.current;
+    await archivePriwaWarnkarteVersion(versionId, requireToken());
+    await queryClient.invalidateQueries({
+      queryKey: ["priwa-warnkarte", projectId, "versions"],
+    });
+    if (
+      request === selectedOverlayRequest.current &&
+      selectedOverlay?.version_id === versionId
+    ) {
+      setSelectedOverlay(null);
+    }
+  };
+
+  const restoreVersion = async (versionId: string) => {
+    await restorePriwaWarnkarteVersion(versionId, requireToken());
+    await queryClient.invalidateQueries({
+      queryKey: ["priwa-warnkarte", projectId, "versions"],
+    });
+  };
+
   const clearSelectedVersion = useCallback(() => {
     selectedOverlayRequest.current += 1;
     setSelectedOverlay(null);
@@ -108,6 +131,8 @@ export function usePriwaWarnkarte(projectId: string, canManage: boolean) {
     clearSelectedVersion,
     toggleVisibility: () => setVisible((visible) => !visible),
     importFile,
+    archiveVersion,
+    restoreVersion,
     showVersion,
     publishVersion,
     validateFile,

--- a/frontend/src/pages/PriwaField.tsx
+++ b/frontend/src/pages/PriwaField.tsx
@@ -85,6 +85,8 @@ export default function PriwaField() {
                 onImport={warnkarte.importFile}
                 onShowVersion={warnkarte.showVersion}
                 onPublish={warnkarte.publishVersion}
+                onArchive={warnkarte.archiveVersion}
+                onRestore={warnkarte.restoreVersion}
                 onClose={closeWarnkarteAdmin}
               />
             ),
@@ -96,10 +98,12 @@ export default function PriwaField() {
       closeWarnkarteAdmin,
       isWarnkarteAdminOpen,
       warnkarte.importFile,
+      warnkarte.archiveVersion,
       warnkarte.isLoadingVersions,
       warnkarte.selectedOverlay?.version_id,
       warnkarte.showVersion,
       warnkarte.publishVersion,
+      warnkarte.restoreVersion,
       warnkarte.validateFile,
       warnkarte.versions,
       warnkarte.versionsError,

--- a/supabase/migrations/20260810100000_add_priwa_warnkarte_archiving.sql
+++ b/supabase/migrations/20260810100000_add_priwa_warnkarte_archiving.sql
@@ -1,0 +1,298 @@
+create table public.priwa_warnkarte_archive_events (
+    id bigint generated always as identity primary key,
+    project_id uuid not null references public.priwa_projects(id) on update cascade on delete cascade,
+    version_id uuid not null,
+    action text not null,
+    acted_by uuid not null references auth.users(id) on update cascade,
+    acted_at timestamp with time zone not null default now(),
+    constraint priwa_warnkarte_archive_events_version_project_fkey
+        foreign key (version_id, project_id)
+        references public.priwa_warnkarte_versions(id, project_id)
+        on delete cascade,
+    constraint priwa_warnkarte_archive_events_action_check
+        check (action in ('archive', 'restore'))
+);
+
+create index priwa_warnkarte_archive_events_version_acted_idx
+    on public.priwa_warnkarte_archive_events (version_id, acted_at desc, id desc);
+create index priwa_warnkarte_archive_events_project_acted_idx
+    on public.priwa_warnkarte_archive_events (project_id, acted_at desc, id desc);
+create index priwa_warnkarte_archive_events_acted_by_idx
+    on public.priwa_warnkarte_archive_events (acted_by);
+
+alter table public.priwa_warnkarte_archive_events enable row level security;
+
+create policy "PRIWA admins can read Warnkarte archive events"
+on public.priwa_warnkarte_archive_events
+for select to authenticated
+using ((select public.priwa_is_project_admin(project_id)));
+
+grant select on public.priwa_warnkarte_archive_events to authenticated;
+grant all on public.priwa_warnkarte_archive_events to service_role;
+grant usage, select on sequence public.priwa_warnkarte_archive_events_id_seq to service_role;
+
+create or replace view public.priwa_warnkarte_archive_states
+with (security_invoker = true)
+as
+select distinct on (event.version_id)
+    event.project_id,
+    event.version_id,
+    event.action = 'archive' as is_archived
+from public.priwa_warnkarte_archive_events event
+order by event.version_id, event.acted_at desc, event.id desc;
+
+grant select on public.priwa_warnkarte_archive_states to authenticated, service_role;
+
+create or replace function internal.priwa_archive_warnkarte(p_version_id uuid)
+returns bigint
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+    actor uuid := (select auth.uid());
+    version_project_id uuid;
+    current_version_id uuid;
+    latest_event_id bigint;
+    latest_action text;
+begin
+    select version.project_id
+    into version_project_id
+    from public.priwa_warnkarte_versions version
+    where version.id = p_version_id;
+
+    if version_project_id is null then
+        raise exception 'Warnkarte version not found' using errcode = 'P0002';
+    end if;
+
+    if actor is null or not public.priwa_is_project_admin(version_project_id) then
+        raise exception 'PRIWA project admin access is required' using errcode = '42501';
+    end if;
+
+    perform 1
+    from public.priwa_projects project
+    where project.id = version_project_id
+    for update;
+
+    select publication.version_id
+    into current_version_id
+    from public.priwa_warnkarte_publications publication
+    where publication.project_id = version_project_id
+    order by publication.published_at desc, publication.id desc
+    limit 1;
+
+    if current_version_id = p_version_id then
+        raise exception 'Warnkarte current version cannot be archived' using errcode = '55000';
+    end if;
+
+    select event.id, event.action
+    into latest_event_id, latest_action
+    from public.priwa_warnkarte_archive_events event
+    where event.version_id = p_version_id
+    order by event.acted_at desc, event.id desc
+    limit 1;
+
+    if latest_action = 'archive' then
+        return latest_event_id;
+    end if;
+
+    insert into public.priwa_warnkarte_archive_events (
+        project_id,
+        version_id,
+        action,
+        acted_by
+    ) values (
+        version_project_id,
+        p_version_id,
+        'archive',
+        actor
+    ) returning id into latest_event_id;
+
+    return latest_event_id;
+end;
+$$;
+
+create or replace function public.priwa_archive_warnkarte(p_version_id uuid)
+returns bigint
+language sql
+volatile
+set search_path = ''
+as $$
+    select internal.priwa_archive_warnkarte(p_version_id);
+$$;
+
+create or replace function internal.priwa_restore_warnkarte(p_version_id uuid)
+returns bigint
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+    actor uuid := (select auth.uid());
+    version_project_id uuid;
+    latest_event_id bigint;
+    latest_action text;
+begin
+    select version.project_id
+    into version_project_id
+    from public.priwa_warnkarte_versions version
+    where version.id = p_version_id;
+
+    if version_project_id is null then
+        raise exception 'Warnkarte version not found' using errcode = 'P0002';
+    end if;
+
+    if actor is null or not public.priwa_is_project_admin(version_project_id) then
+        raise exception 'PRIWA project admin access is required' using errcode = '42501';
+    end if;
+
+    perform 1
+    from public.priwa_projects project
+    where project.id = version_project_id
+    for update;
+
+    select event.id, event.action
+    into latest_event_id, latest_action
+    from public.priwa_warnkarte_archive_events event
+    where event.version_id = p_version_id
+    order by event.acted_at desc, event.id desc
+    limit 1;
+
+    if latest_action is distinct from 'archive' then
+        return coalesce(latest_event_id, 0);
+    end if;
+
+    insert into public.priwa_warnkarte_archive_events (
+        project_id,
+        version_id,
+        action,
+        acted_by
+    ) values (
+        version_project_id,
+        p_version_id,
+        'restore',
+        actor
+    ) returning id into latest_event_id;
+
+    return latest_event_id;
+end;
+$$;
+
+create or replace function public.priwa_restore_warnkarte(p_version_id uuid)
+returns bigint
+language sql
+volatile
+set search_path = ''
+as $$
+    select internal.priwa_restore_warnkarte(p_version_id);
+$$;
+
+create or replace function internal.priwa_publish_warnkarte(p_version_id uuid)
+returns bigint
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+    actor uuid := (select auth.uid());
+    version_project_id uuid;
+    latest_archive_action text;
+    publication_id bigint;
+begin
+    select version.project_id
+    into version_project_id
+    from public.priwa_warnkarte_versions version
+    where version.id = p_version_id;
+
+    if version_project_id is null then
+        raise exception 'Warnkarte version not found' using errcode = 'P0002';
+    end if;
+
+    if actor is null or not public.priwa_is_project_admin(version_project_id) then
+        raise exception 'PRIWA project admin access is required' using errcode = '42501';
+    end if;
+
+    perform 1
+    from public.priwa_projects project
+    where project.id = version_project_id
+    for update;
+
+    select event.action
+    into latest_archive_action
+    from public.priwa_warnkarte_archive_events event
+    where event.version_id = p_version_id
+    order by event.acted_at desc, event.id desc
+    limit 1;
+
+    if latest_archive_action = 'archive' then
+        raise exception 'Warnkarte archived version cannot be published' using errcode = '55000';
+    end if;
+
+    insert into public.priwa_warnkarte_publications (
+        project_id,
+        version_id,
+        published_by
+    ) values (
+        version_project_id,
+        p_version_id,
+        actor
+    ) returning id into publication_id;
+
+    return publication_id;
+end;
+$$;
+
+create or replace function internal.priwa_warnkarte_version_overlay(
+    p_project_id uuid,
+    p_version_id uuid
+)
+returns table (payload jsonb)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+    select jsonb_build_object(
+        'version_id', version.id,
+        'source_date', version.source_date,
+        'type', 'FeatureCollection',
+        'features', jsonb_agg(
+            jsonb_build_object(
+                'type', 'Feature',
+                'geometry', public.st_asgeojson(polygon.geom)::jsonb,
+                'properties', jsonb_build_object('probability', polygon.probability)
+            )
+            order by polygon.source_fid
+        )
+    )
+    from public.priwa_warnkarte_versions version
+    join public.priwa_warnkarte_polygons polygon on polygon.version_id = version.id
+    where version.id = p_version_id
+      and version.project_id = p_project_id
+      and public.priwa_is_project_admin(p_project_id)
+      and not exists (
+          select 1
+          from public.priwa_warnkarte_archive_states archive_state
+          where archive_state.version_id = version.id
+            and archive_state.is_archived
+      )
+    group by version.id, version.source_date;
+$$;
+
+revoke all on function internal.priwa_archive_warnkarte(uuid) from public, anon;
+revoke all on function internal.priwa_restore_warnkarte(uuid) from public, anon;
+grant execute on function internal.priwa_archive_warnkarte(uuid) to authenticated, service_role;
+grant execute on function internal.priwa_restore_warnkarte(uuid) to authenticated, service_role;
+
+revoke all on function public.priwa_archive_warnkarte(uuid) from public, anon;
+revoke all on function public.priwa_restore_warnkarte(uuid) from public, anon;
+grant execute on function public.priwa_archive_warnkarte(uuid) to authenticated, service_role;
+grant execute on function public.priwa_restore_warnkarte(uuid) to authenticated, service_role;
+
+comment on table public.priwa_warnkarte_archive_events
+is 'Append-only admin archive and restore history for PRIWA Warnkarte versions.';
+comment on view public.priwa_warnkarte_archive_states
+is 'Latest archive state per PRIWA Warnkarte version, visible only through underlying admin RLS.';


### PR DESCRIPTION
## Briefing

PRIWA administrators can now archive outdated Warnkarte versions without deleting immutable imports or publication history. Archived versions leave the normal selection list and can be restored later; the currently published version remains protected so members never lose the active map accidentally.

## What changed

- Record archive and restore actions as an append-only, admin-only lifecycle history with RLS-protected state projection.
- Reject archiving the currently published version and publishing or previewing an archived version at the database and API boundaries.
- Add structured archive/restore API operations and German error messages.
- Separate available and archived versions in the desktop management panel, with confirmation, restore, and automatic fallback to the published overlay.
- Keep ordinary member/mobile behavior and the safe active overlay projection unchanged.

## Validation

- `17 passed` — focused Warnkarte router and real isolated Postgres/RLS/RPC tests.
- `6 passed` — focused desktop/mobile Playwright scenarios in the isolated worktree environment.
- `9 passed` — focused Warnkarte frontend Vitest suite.
- `288 passed, 1 skipped` — repository API smoke suite against the isolated worktree Supabase environment.
- Frontend ESLint and production build passed.
- Python runtime lint and DeadTrees AST guardrails passed.
- Supabase migration applied from the pending migration set; local DB lint reported only pre-existing extension/project warnings and no new Warnkarte findings.

## Risk and limitations

This adds a forward-only database migration and new API routes. Archiving is deliberately reversible and unavailable for the current publication; administrators must restore an archived version before previewing or republishing it.
