### PR TITLE
fix(processor): refresh auth during long geotiff jobs

### DIFF
--- a/processor/src/process_geotiff.py
+++ b/processor/src/process_geotiff.py
@@ -15,10 +15,15 @@ from shared.hash import get_file_identifier
 from shared.logging import LogContext, LogCategory
 
 
-def process_geotiff(task: QueueTask, temp_dir: Path):
+def _refresh_processor_session(task: QueueTask):
 	token, user = login_verified(settings.PROCESSOR_USERNAME, settings.PROCESSOR_PASSWORD)
 	if not user:
 		raise AuthenticationError('Invalid processor token', token=token, task_id=task.id)
+	return token, user
+
+
+def process_geotiff(task: QueueTask, temp_dir: Path):
+	token, user = _refresh_processor_session(task)
 
 	# Update initial status
 	update_status(token, dataset_id=task.dataset_id, current_status=StatusEnum.ortho_processing)
@@ -67,6 +72,7 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 			ortho_info = cog_info(str(temp_ortho_path))
 
 			# Update ortho entry with fresh metadata
+			token, user = _refresh_processor_session(task)
 			ortho = upsert_ortho_entry(
 				dataset_id=task.dataset_id,
 				file_path=temp_ortho_path,
@@ -122,6 +128,7 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 			ortho_info = cog_info(str(temp_ortho_path))
 
 			# Create ortho entry
+			token, user = _refresh_processor_session(task)
 			ortho = upsert_ortho_entry(
 				dataset_id=task.dataset_id,
 				file_path=temp_ortho_path,
@@ -140,6 +147,7 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 			temp_ortho_path.unlink()
 
 	except Exception as e:
+		token, _ = _refresh_processor_session(task)
 		update_status(
 			token,
 			dataset_id=task.dataset_id,
@@ -202,6 +210,9 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 		sha256 = get_file_identifier(path_converted)
 		processed_info = cog_info(str(path_converted))
 
+		# Conversion and hashing can outlive a Supabase access token. Refresh
+		# immediately before persisting the processed result.
+		token, user = _refresh_processor_session(task)
 		upsert_processed_ortho_entry(
 			dataset_id=ortho.dataset_id,
 			file_path=path_converted,
@@ -231,6 +242,7 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 
 	except Exception as e:
 		# Update error status
+		token, _ = _refresh_processor_session(task)
 		update_status(token, dataset_id=ortho.dataset_id, has_error=True, error_message=str(e))
 		# Clean up files on error
 		if 'path_original' in locals() and path_original.exists():
@@ -253,9 +265,6 @@ def process_geotiff(task: QueueTask, temp_dir: Path):
 			),
 		)
 		raise ProcessingError(str(e), task_type='convert', task_id=task.id, dataset_id=ortho.dataset_id)
-
-	# Update final status
-	update_status(token, dataset_id=ortho.dataset_id, current_status=StatusEnum.idle, is_ortho_done=True)
 
 	logger.info(
 		f'Finished converting dataset {ortho.dataset_id}',

--- a/processor/src/processor.py
+++ b/processor/src/processor.py
@@ -364,14 +364,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_odm(task, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'ODM processing failed: {str(e)}',
 					LogContext(
 						category=LogCategory.ODM,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 						extra={'error': str(e)},
 					),
 				)
@@ -389,14 +389,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_geotiff(task, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'GeoTIFF conversion failed: {str(e)}',
 					LogContext(
 						category=LogCategory.ORTHO,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 						extra={'error': str(e)},
 					),
 				)
@@ -414,11 +414,11 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_metadata(task, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Metadata processing failed: {str(e)}',
 					LogContext(
-						category=LogCategory.METADATA, dataset_id=task.dataset_id, user_id=task.user_id, token=error_token
+						category=LogCategory.METADATA, dataset_id=task.dataset_id, user_id=task.user_id, token=token
 					),
 				)
 				raise ProcessingError(str(e), task_type='metadata', task_id=task.id, dataset_id=task.dataset_id)
@@ -433,11 +433,11 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_cog(task, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'COG processing failed: {str(e)}',
 					LogContext(
-						category=LogCategory.COG, dataset_id=task.dataset_id, user_id=task.user_id, token=error_token
+						category=LogCategory.COG, dataset_id=task.dataset_id, user_id=task.user_id, token=token
 					),
 				)
 				raise ProcessingError(str(e), task_type='cog', task_id=task.id, dataset_id=task.dataset_id)
@@ -454,14 +454,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_thumbnail(task, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Thumbnail processing failed: {str(e)}',
 					LogContext(
 						category=LogCategory.THUMBNAIL,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(str(e), task_type='thumbnail', task_id=task.id, dataset_id=task.dataset_id)
@@ -478,14 +478,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_deadwood_segmentation(task, token, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Deadwood segmentation failed: {str(e)}',
 					LogContext(
 						category=LogCategory.DEADWOOD,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(
@@ -504,14 +504,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_treecover_segmentation(task, token, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Tree cover segmentation failed: {str(e)}',
 					LogContext(
 						category=LogCategory.TREECOVER,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(
@@ -530,14 +530,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_deadwood_treecover_combined_v2(task, token, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Combined segmentation failed: {str(e)}',
 					LogContext(
 						category=LogCategory.DEADWOOD,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(
@@ -557,14 +557,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_aoi_segmentation(task, token, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'AOI segmentation failed: {str(e)}',
 					LogContext(
 						category=LogCategory.AOI,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(str(e), task_type='aoi_segmentation', task_id=task.id, dataset_id=task.dataset_id)
@@ -582,14 +582,14 @@ def process_task(task: QueueTask, token: str):
 				)
 				process_embeddings(task, token, settings.processing_path)
 			except Exception as e:
-				error_token = refresh_processor_token(task, token)
+				token = refresh_processor_token(task, token)
 				logger.error(
 					f'Tile embedding failed: {str(e)}',
 					LogContext(
 						category=LogCategory.EMBEDDINGS,
 						dataset_id=task.dataset_id,
 						user_id=task.user_id,
-						token=error_token,
+						token=token,
 					),
 				)
 				raise ProcessingError(str(e), task_type='embedding_processing', task_id=task.id, dataset_id=task.dataset_id)

--- a/processor/tests/test_processor_auth_refresh.py
+++ b/processor/tests/test_processor_auth_refresh.py
@@ -1,0 +1,150 @@
+from types import SimpleNamespace
+
+import pytest
+
+import processor.src.process_geotiff as geotiff_module
+import processor.src.processor as processor_module
+from processor.src.exceptions import ProcessingError
+from shared.models import Ortho, QueueTask, TaskTypeEnum
+from shared.settings import settings
+
+
+pytestmark = pytest.mark.unit
+
+
+def _geotiff_task() -> QueueTask:
+	return QueueTask(
+		id=123,
+		dataset_id=456,
+		user_id='processor-user',
+		priority=4,
+		is_processing=True,
+		claimed_by='worker-a',
+		current_position=1,
+		estimated_time=0.0,
+		task_types=[TaskTypeEnum.geotiff],
+	)
+
+
+def test_process_geotiff_refreshes_auth_before_post_work_database_writes(monkeypatch, tmp_path):
+	task = _geotiff_task()
+	login_tokens = iter(['stage-token', 'ortho-write-token', 'processed-write-token'])
+	ortho_write_tokens = []
+	processed_write_tokens = []
+	status_updates = []
+
+	class _Query:
+		def select(self, fields):
+			return self
+
+		def eq(self, field, value):
+			return self
+
+		def execute(self):
+			return SimpleNamespace(data=[])
+
+	class _Client:
+		def table(self, name):
+			assert name == settings.orthos_table
+			return _Query()
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, exc_type, exc, tb):
+			return False
+
+	def fake_pull(source, destination, token, dataset_id):
+		assert dataset_id == task.dataset_id
+		with open(destination, 'wb') as output:
+			output.write(b'geotiff')
+
+	def fake_standardise(source, destination, token, dataset_id):
+		assert token == 'ortho-write-token'
+		with open(destination, 'wb') as output:
+			output.write(b'processed-geotiff')
+		return True
+
+	def fake_upsert_ortho_entry(**kwargs):
+		ortho_write_tokens.append(kwargs['token'])
+		return Ortho(
+			dataset_id=task.dataset_id,
+			ortho_file_name=f'{task.dataset_id}_ortho.tif',
+			ortho_file_size=1,
+			version=1,
+		)
+
+	def fake_upsert_processed_ortho_entry(**kwargs):
+		processed_write_tokens.append(kwargs['token'])
+
+	monkeypatch.setattr(
+		geotiff_module,
+		'login_verified',
+		lambda username, password: (next(login_tokens), SimpleNamespace(id=task.user_id)),
+	)
+	monkeypatch.setattr(geotiff_module, 'use_client', lambda token: _Client())
+	monkeypatch.setattr(geotiff_module, 'pull_file_from_storage_server', fake_pull)
+	monkeypatch.setattr(geotiff_module, 'get_file_identifier', lambda path: 'sha256')
+	monkeypatch.setattr(geotiff_module, 'cog_info', lambda path: SimpleNamespace(model_dump=lambda: {}))
+	monkeypatch.setattr(geotiff_module, 'standardise_geotiff', fake_standardise)
+	monkeypatch.setattr(geotiff_module, 'verify_geotiff', lambda *args: True)
+	monkeypatch.setattr(geotiff_module, 'upsert_ortho_entry', fake_upsert_ortho_entry)
+	monkeypatch.setattr(geotiff_module, 'upsert_processed_ortho_entry', fake_upsert_processed_ortho_entry)
+	monkeypatch.setattr(
+		geotiff_module,
+		'update_status',
+		lambda token, **kwargs: status_updates.append((token, kwargs)),
+	)
+	monkeypatch.setattr(geotiff_module.logger, 'info', lambda *args, **kwargs: None)
+	monkeypatch.setattr(geotiff_module.logger, 'error', lambda *args, **kwargs: None)
+
+	geotiff_module.process_geotiff(task, tmp_path)
+
+	assert ortho_write_tokens == ['ortho-write-token']
+	assert processed_write_tokens == ['processed-write-token']
+	assert status_updates[0][0] == 'stage-token'
+	assert status_updates[-1][0] == 'processed-write-token'
+	assert status_updates[-1][1]['is_ortho_done'] is True
+
+
+def test_process_task_keeps_refreshed_token_for_failure_bookkeeping(monkeypatch):
+	task = _geotiff_task()
+	refresh_tokens = iter(['stage-token', 'failure-token'])
+	status_updates = []
+	deleted_tasks = []
+
+	monkeypatch.setattr(processor_module, 'verify_token', lambda token: SimpleNamespace(id=task.user_id))
+	monkeypatch.setattr(processor_module, 'refresh_processor_token', lambda task, token=None: next(refresh_tokens))
+	monkeypatch.setattr(
+		processor_module,
+		'process_geotiff',
+		lambda task, processing_path: (_ for _ in ()).throw(RuntimeError('stage failed')),
+	)
+	monkeypatch.setattr(
+		processor_module,
+		'update_status',
+		lambda token, **kwargs: status_updates.append((token, kwargs)),
+	)
+	monkeypatch.setattr(processor_module, 'create_processing_failure_issue', lambda **kwargs: None)
+	monkeypatch.setattr(processor_module, '_notify_processing_result_safely', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module, 'login', lambda username, password: 'delete-token')
+	monkeypatch.setattr(
+		processor_module,
+		'delete_queue_task',
+		lambda token, task: deleted_tasks.append((token, task.id)),
+	)
+	monkeypatch.setattr(processor_module.logger, 'info', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'error', lambda *args, **kwargs: None)
+	monkeypatch.setattr(processor_module.logger, 'warning', lambda *args, **kwargs: None)
+
+	with pytest.raises(ProcessingError, match='stage failed'):
+		processor_module.process_task(task, 'initial-token')
+
+	assert len(status_updates) == 1
+	status_token, status_fields = status_updates[0]
+	assert status_token == 'failure-token'
+	assert status_fields['dataset_id'] == task.dataset_id
+	assert status_fields['current_status'] == processor_module.StatusEnum.idle
+	assert status_fields['has_error'] is True
+	assert 'stage failed' in status_fields['error_message']
+	assert deleted_tasks == [('delete-token', task.id)]


### PR DESCRIPTION
## Briefing

Long-running GeoTIFF jobs could reuse a Supabase access token after it expired, causing deterministic `PGRST303: JWT expired` failures during database persistence. This refreshes processor authentication at the write boundaries that follow expensive transfer, conversion, and hashing work, and preserves the refreshed token for outer failure bookkeeping.

## What changed

- Refresh the verified processor session before persisting original and processed orthomosaic metadata.
- Refresh authentication before GeoTIFF error-status writes.
- Carry stage-error refreshes forward so final status, notification, and queue cleanup do not fall back to the stale token.
- Add CPU-safe regression tests for post-work database writes and failure bookkeeping.

## Validation

- `python -m pytest -q -m unit processor/tests` in the processor test image: 176 passed, 117 deselected.
- `PYTHON=venv/bin/python scripts/lint-python.sh`: passed.
- `scripts/lint-ast-grep.sh`: passed.
- `git diff --check`: passed.

## Risk and limitations

This adds a small number of authentication calls around long-running GeoTIFF persistence and error paths. It does not change database schemas or processing outputs; failed production datasets still require an explicit requeue after deployment.

## Tracking

Related to DT-856 and DT-857.