### PR TITLE
fix(frontend): handle missing orthomosaic size

### DIFF
--- a/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
+++ b/frontend/src/components/DatasetDetailsMap/DatasetInfoSidebar.tsx
@@ -4,7 +4,7 @@ import type { IDataset } from "../../types/dataset";
 import { IDataAccess } from "../../types/dataset";
 import type { PhenologyMetadata } from "../../types/phenology";
 import countryList from "../../utils/countryList";
-import { isGeonadirDataset, getTruncatedAuthorDisplay } from "../../utils/datasetUtils";
+import { formatOrthoFileSize, isGeonadirDataset, getTruncatedAuthorDisplay } from "../../utils/datasetUtils";
 import { sanitizeText } from "../../utils/textUtils";
 import PublicationLink from "../PublicationLink";
 import PhenologyBar from "../PhenologyBar/PhenologyBar";
@@ -300,11 +300,7 @@ export default function DatasetInfoSidebar({
           <Tag color="blue" style={{ margin: 0 }}>{dataset.license || "Not specified"}</Tag>
         </InfoRow>
         <InfoRow label="File Size" tooltip="Size of the orthomosaic file.">
-          <Typography.Text>
-            {dataset.ortho_file_size >= 1024
-              ? `${(dataset.ortho_file_size / 1024).toFixed(1)} GB`
-              : `${dataset.ortho_file_size.toFixed(0)} MB`}
-          </Typography.Text>
+          <Typography.Text>{formatOrthoFileSize(dataset.ortho_file_size)}</Typography.Text>
         </InfoRow>
         {showPrivacyIndicator && (
           <InfoRow label="Visibility" tooltip="Whether this dataset is publicly visible or restricted.">

--- a/frontend/src/types/dataset.ts
+++ b/frontend/src/types/dataset.ts
@@ -58,7 +58,7 @@ export interface IDataset {
   citation_doi: string | null;
   archived: boolean;
   ortho_file_name: string | null;
-  ortho_file_size: number;
+  ortho_file_size: number | null;
   bbox: string | null;
   sha256: string;
   current_status: string;

--- a/frontend/src/utils/datasetUtils.test.ts
+++ b/frontend/src/utils/datasetUtils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOrthoFileSize } from "./datasetUtils";
+
+describe("formatOrthoFileSize", () => {
+  it("shows an unavailable state when failed processing produced no orthomosaic", () => {
+    expect(formatOrthoFileSize(null)).toBe("Not available");
+  });
+
+  it("formats orthomosaic sizes stored in megabytes", () => {
+    expect(formatOrthoFileSize(768)).toBe("768 MB");
+    expect(formatOrthoFileSize(1536)).toBe("1.5 GB");
+  });
+});

--- a/frontend/src/utils/datasetUtils.ts
+++ b/frontend/src/utils/datasetUtils.ts
@@ -1,6 +1,14 @@
 import { IDataset } from "../types/dataset";
 import { fixAuthorNamesEncoding } from "./textUtils";
 
+export const formatOrthoFileSize = (sizeMb: number | null): string => {
+  if (sizeMb === null) return "Not available";
+
+  return sizeMb >= 1024
+    ? `${(sizeMb / 1024).toFixed(1)} GB`
+    : `${sizeMb.toFixed(0)} MB`;
+};
+
 /**
  * Checks if a dataset is from GeoNadir provider
  * @param dataset - The dataset to check


### PR DESCRIPTION
## Briefing

Failed datasets can legitimately have no orthomosaic file size, but the dataset detail sidebar treated that value as always numeric and crashed while formatting it. This change keeps failed dataset details usable by rendering an explicit unavailable state while preserving the existing MB and GB formatting for completed orthomosaics.

## What changed

- Model orthomosaic file size as nullable to match the production dataset view.
- Render `Not available` when processing produced no orthomosaic.
- Preserve existing MB and GB display behavior for numeric sizes.
- Add regression coverage for both the null and numeric cases.

## Validation

- `npm --prefix frontend test`: 58 files passed, 297 tests passed.
- `npm --prefix frontend run lint`: passed.
- `npm --prefix frontend run build`: passed with the existing Vite chunk-size warning.
- Local frontend using the production profile: dataset 11597 rendered its detail page, showed `Not available` for File Size, and displayed no Vite error overlay.

## Risk and limitations

Low-risk presentation fix with no database, API, migration, or processing behavior changes.