### PR TITLE
fix(ops): version holiday tunnel refresh

### DIFF
--- a/docs/playbooks/database-backups.md
+++ b/docs/playbooks/database-backups.md
@@ -237,7 +237,9 @@ stale SSH forwarding session cannot survive into the database stage:
 
 Install the tracked helper as `remote-backup`, preserve the prior crontab under
 `/home/remote-backup/.local/state/borgmatic/`, and keep cron mail enabled. The
-helper terminates only the current main process of
+helper first acquires the same non-blocking lock as `deadtrees-database-backup`;
+if a manual or overlong backup is active, it leaves the tunnel untouched and
+exits non-zero. After acquiring the lock, it terminates only the current main process of
 `reverse-tunnel@data2.deadtrees.earth.service`; the existing `Restart=always`
 policy must replace it with a distinct active PID within 30 seconds. It is silent
 on success and exits non-zero with a diagnostic on failure. After a five-second

--- a/docs/playbooks/database-backups.md
+++ b/docs/playbooks/database-backups.md
@@ -248,6 +248,11 @@ succeed. The helper also fails closed unless the service is owned by the invokin
 user, so it cannot be carried into the dedicated `deadtrees-db-tunnel` deployment
 accidentally.
 
+The lifecycle helper keeps `tunnel-status` solely for this temporary guard. Its
+default `/tmp/borg.sock` path matches the retained production listener; tests may
+override the path and command boundaries. Remove the guard before the dedicated
+runtime-directory socket replaces this legacy path.
+
 This is a time-limited reliability guard, not security hardening. It does not
 change the shared socket permissions or replace the dedicated transport design
 documented above. Review and remove the 01:50 cron entry after 2 September 2026,

--- a/docs/playbooks/database-backups.md
+++ b/docs/playbooks/database-backups.md
@@ -86,6 +86,7 @@ The tracked sources map to these production locations:
 | `scripts/backup/deadtrees-db-borg-archive` | `/home/borg/.local/bin/deadtrees-db-borg-archive` |
 | `scripts/backup/deadtrees-borg-rsh` | `/home/borg/.local/bin/deadtrees-borg-rsh` |
 | `scripts/backup/deadtrees-borg-tunnel-guard` | `/home/borg/.local/bin/deadtrees-borg-tunnel-guard` |
+| `scripts/backup/deadtrees-refresh-database-tunnel` | `/home/remote-backup/.local/bin/deadtrees-refresh-database-tunnel` |
 | `scripts/backup/database_dump_direct.yaml` | `/home/remote-backup/.config/borgmatic/database_dump_direct.yaml` |
 | `scripts/backup/systemd/database-backup-borg.socket` | `/etc/systemd/system/database-backup-borg.socket` |
 | `scripts/backup/systemd/database-backup-borg@.service` | `/etc/systemd/system/database-backup-borg@.service` |
@@ -219,6 +220,35 @@ legacy simultaneous cron entries be replaced by one serialized entry:
 
 Preserve the old crontab before cutover. Do not remove old repositories during
 this migration.
+
+### Temporary holiday tunnel refresh
+
+The production cutover on 12 August 2026 retained the existing
+`remote-backup`-owned shared reverse socket while the least-privilege transport
+remains uninstalled. That tunnel had previously stayed active at the systemd
+level while its remote socket refused a nightly archive connection. Until
+2 September 2026, refresh the tunnel shortly before the serialized backup so a
+stale SSH forwarding session cannot survive into the database stage:
+
+```cron
+50 1 * * * /home/remote-backup/.local/bin/deadtrees-refresh-database-tunnel
+0 2 * * * /home/remote-backup/.local/bin/deadtrees-nightly-backups
+```
+
+Install the tracked helper as `remote-backup`, preserve the prior crontab under
+`/home/remote-backup/.local/state/borgmatic/`, and keep cron mail enabled. The
+helper terminates only the current main process of
+`reverse-tunnel@data2.deadtrees.earth.service`; the existing `Restart=always`
+policy must replace it with a distinct active PID within 30 seconds. It is silent
+on success and exits non-zero with a diagnostic on failure. It also fails closed
+unless the service is owned by the invoking user, so it cannot be carried into
+the dedicated `deadtrees-db-tunnel` deployment accidentally.
+
+This is a time-limited reliability guard, not security hardening. It does not
+change the shared socket permissions or replace the dedicated transport design
+documented above. Review and remove the 01:50 cron entry after 2 September 2026,
+then remove the helper after confirming the normal nightly path remains healthy.
+Remove this guard before installing the dedicated tunnel identity and unit.
 
 ## Validation
 

--- a/docs/playbooks/database-backups.md
+++ b/docs/playbooks/database-backups.md
@@ -240,9 +240,13 @@ Install the tracked helper as `remote-backup`, preserve the prior crontab under
 helper terminates only the current main process of
 `reverse-tunnel@data2.deadtrees.earth.service`; the existing `Restart=always`
 policy must replace it with a distinct active PID within 30 seconds. It is silent
-on success and exits non-zero with a diagnostic on failure. It also fails closed
-unless the service is owned by the invoking user, so it cannot be carried into
-the dedicated `deadtrees-db-tunnel` deployment accidentally.
+on success and exits non-zero with a diagnostic on failure. After a five-second
+settle window, it requires the same process to remain active and invokes the
+database lifecycle key's `tunnel-status` command. That forced command verifies
+the remote Unix socket exists and is an active listener before the refresh can
+succeed. The helper also fails closed unless the service is owned by the invoking
+user, so it cannot be carried into the dedicated `deadtrees-db-tunnel` deployment
+accidentally.
 
 This is a time-limited reliability guard, not security hardening. It does not
 change the shared socket permissions or replace the dedicated transport design

--- a/scripts/backup/deadtrees-db-backup-remote
+++ b/scripts/backup/deadtrees-db-backup-remote
@@ -8,6 +8,9 @@ readonly stage="${DEADTREES_DB_BACKUP_STAGE:-/var/lib/postgresql/data/.deadtrees
 readonly docker_bin="${DEADTREES_DOCKER_BIN:-docker}"
 readonly capacity_percent="${DEADTREES_DB_BACKUP_CAPACITY_PERCENT:-300}"
 readonly reserve_bytes="${DEADTREES_DB_BACKUP_RESERVE_BYTES:-53687091200}"
+readonly socket_path="${DEADTREES_DB_BACKUP_SOCKET_PATH:-/tmp/borg.sock}"
+readonly socket_test_bin="${DEADTREES_DB_BACKUP_SOCKET_TEST_BIN:-/usr/bin/test}"
+readonly ss_bin="${DEADTREES_DB_BACKUP_SS_BIN:-/usr/bin/ss}"
 readonly command="${SSH_ORIGINAL_COMMAND:-}"
 readonly preserve_marker="$stage/.deadtrees-preserve"
 
@@ -62,6 +65,11 @@ case "$command" in
 		;;
 	space-status)
 		assert_dump_capacity
+		;;
+	tunnel-status)
+		"$socket_test_bin" -S "$socket_path"
+		"$ss_bin" -xlH | grep -Fq -- "$socket_path"
+		printf 'ready\n'
 		;;
 	verify)
 		"$docker_bin" exec --user postgres "$container" test -f "$stage/toc.dat"

--- a/scripts/backup/deadtrees-refresh-database-tunnel
+++ b/scripts/backup/deadtrees-refresh-database-tunnel
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly unit="${DEADTREES_TUNNEL_REFRESH_UNIT:-reverse-tunnel@data2.deadtrees.earth.service}"
+readonly timeout_seconds="${DEADTREES_TUNNEL_REFRESH_TIMEOUT_SECONDS:-30}"
+readonly systemctl_bin="${DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN:-/usr/bin/systemctl}"
+readonly kill_bin="${DEADTREES_TUNNEL_REFRESH_KILL_BIN:-/usr/bin/kill}"
+readonly sleep_bin="${DEADTREES_TUNNEL_REFRESH_SLEEP_BIN:-/usr/bin/sleep}"
+readonly current_user="${DEADTREES_TUNNEL_REFRESH_CURRENT_USER:-$(/usr/bin/id -un)}"
+
+if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+	printf 'Invalid tunnel refresh timeout: %s.\n' "$timeout_seconds" >&2
+	exit 64
+fi
+
+service_user="$($systemctl_bin show --property User --value "$unit")"
+if [[ -z "$service_user" || "$service_user" != "$current_user" ]]; then
+	printf "Cannot refresh %s: service user '%s' does not match current user '%s'.\n" \
+		"$unit" "$service_user" "$current_user" >&2
+	exit 1
+fi
+
+old_pid="$($systemctl_bin show --property MainPID --value "$unit")"
+if [[ ! "$old_pid" =~ ^[0-9]+$ ]] || ((old_pid <= 1)); then
+	printf "Cannot refresh %s: invalid current MainPID '%s'.\n" "$unit" "$old_pid" >&2
+	exit 1
+fi
+
+"$kill_bin" -TERM "$old_pid"
+
+for ((second = 1; second <= timeout_seconds; second++)); do
+	"$sleep_bin" 1
+	new_pid="$($systemctl_bin show --property MainPID --value "$unit")"
+	if "$systemctl_bin" is-active --quiet "$unit" \
+		&& [[ "$new_pid" =~ ^[0-9]+$ ]] \
+		&& ((new_pid > 1)) \
+		&& [[ "$new_pid" != "$old_pid" ]]; then
+		if [[ "${DEADTREES_TUNNEL_REFRESH_VERBOSE:-0}" == '1' ]]; then
+			printf 'Refreshed %s: %s -> %s.\n' "$unit" "$old_pid" "$new_pid"
+		fi
+		exit 0
+	fi
+done
+
+printf 'Failed to refresh %s within %ss.\n' "$unit" "$timeout_seconds" >&2
+exit 1

--- a/scripts/backup/deadtrees-refresh-database-tunnel
+++ b/scripts/backup/deadtrees-refresh-database-tunnel
@@ -8,6 +8,8 @@ readonly systemctl_bin="${DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN:-/usr/bin/syste
 readonly kill_bin="${DEADTREES_TUNNEL_REFRESH_KILL_BIN:-/usr/bin/kill}"
 readonly sleep_bin="${DEADTREES_TUNNEL_REFRESH_SLEEP_BIN:-/usr/bin/sleep}"
 readonly ssh_bin="${DEADTREES_TUNNEL_REFRESH_SSH_BIN:-/usr/bin/ssh}"
+readonly flock_bin="${DEADTREES_TUNNEL_REFRESH_FLOCK_BIN:-/usr/bin/flock}"
+readonly lock_file="${DEADTREES_TUNNEL_REFRESH_LOCK_FILE:-/home/remote-backup/.cache/deadtrees-database-backup.lock}"
 readonly current_user="${DEADTREES_TUNNEL_REFRESH_CURRENT_USER:-$(/usr/bin/id -un)}"
 readonly probe_identity="${DEADTREES_TUNNEL_REFRESH_PROBE_IDENTITY:-/home/remote-backup/.ssh/id_ed25519}"
 readonly probe_remote="${DEADTREES_TUNNEL_REFRESH_PROBE_REMOTE:-dendro@data2.deadtrees.earth}"
@@ -17,6 +19,12 @@ if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ || ! "$settle_seconds" =~ ^[1-9][0-9
 	printf 'Invalid tunnel refresh timing: timeout=%s settle=%s.\n' \
 		"$timeout_seconds" "$settle_seconds" >&2
 	exit 64
+fi
+
+exec 9>"$lock_file"
+if ! "$flock_bin" -n 9; then
+	printf 'Cannot refresh %s: a database backup is active.\n' "$unit" >&2
+	exit 75
 fi
 
 service_user="$($systemctl_bin show --property User --value "$unit")"

--- a/scripts/backup/deadtrees-refresh-database-tunnel
+++ b/scripts/backup/deadtrees-refresh-database-tunnel
@@ -3,13 +3,19 @@ set -Eeuo pipefail
 
 readonly unit="${DEADTREES_TUNNEL_REFRESH_UNIT:-reverse-tunnel@data2.deadtrees.earth.service}"
 readonly timeout_seconds="${DEADTREES_TUNNEL_REFRESH_TIMEOUT_SECONDS:-30}"
+readonly settle_seconds="${DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS:-5}"
 readonly systemctl_bin="${DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN:-/usr/bin/systemctl}"
 readonly kill_bin="${DEADTREES_TUNNEL_REFRESH_KILL_BIN:-/usr/bin/kill}"
 readonly sleep_bin="${DEADTREES_TUNNEL_REFRESH_SLEEP_BIN:-/usr/bin/sleep}"
+readonly ssh_bin="${DEADTREES_TUNNEL_REFRESH_SSH_BIN:-/usr/bin/ssh}"
 readonly current_user="${DEADTREES_TUNNEL_REFRESH_CURRENT_USER:-$(/usr/bin/id -un)}"
+readonly probe_identity="${DEADTREES_TUNNEL_REFRESH_PROBE_IDENTITY:-/home/remote-backup/.ssh/id_ed25519}"
+readonly probe_remote="${DEADTREES_TUNNEL_REFRESH_PROBE_REMOTE:-dendro@data2.deadtrees.earth}"
+readonly probe_command="${DEADTREES_TUNNEL_REFRESH_PROBE_COMMAND:-tunnel-status}"
 
-if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
-	printf 'Invalid tunnel refresh timeout: %s.\n' "$timeout_seconds" >&2
+if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ || ! "$settle_seconds" =~ ^[1-9][0-9]*$ ]]; then
+	printf 'Invalid tunnel refresh timing: timeout=%s settle=%s.\n' \
+		"$timeout_seconds" "$settle_seconds" >&2
 	exit 64
 fi
 
@@ -28,6 +34,7 @@ fi
 
 "$kill_bin" -TERM "$old_pid"
 
+replacement_pid=''
 for ((second = 1; second <= timeout_seconds; second++)); do
 	"$sleep_bin" 1
 	new_pid="$($systemctl_bin show --property MainPID --value "$unit")"
@@ -35,12 +42,38 @@ for ((second = 1; second <= timeout_seconds; second++)); do
 		&& [[ "$new_pid" =~ ^[0-9]+$ ]] \
 		&& ((new_pid > 1)) \
 		&& [[ "$new_pid" != "$old_pid" ]]; then
-		if [[ "${DEADTREES_TUNNEL_REFRESH_VERBOSE:-0}" == '1' ]]; then
-			printf 'Refreshed %s: %s -> %s.\n' "$unit" "$old_pid" "$new_pid"
-		fi
-		exit 0
+		replacement_pid="$new_pid"
+		break
 	fi
 done
 
-printf 'Failed to refresh %s within %ss.\n' "$unit" "$timeout_seconds" >&2
-exit 1
+if [[ -z "$replacement_pid" ]]; then
+	printf 'Failed to refresh %s within %ss.\n' "$unit" "$timeout_seconds" >&2
+	exit 1
+fi
+
+"$sleep_bin" "$settle_seconds"
+settled_pid="$($systemctl_bin show --property MainPID --value "$unit")"
+if ! "$systemctl_bin" is-active --quiet "$unit" || [[ "$settled_pid" != "$replacement_pid" ]]; then
+	printf 'Replacement process %s for %s did not remain active during the %ss settle window.\n' \
+		"$replacement_pid" "$unit" "$settle_seconds" >&2
+	exit 1
+fi
+
+if ! "$ssh_bin" \
+	-i "$probe_identity" \
+	-o BatchMode=yes \
+	-o ConnectTimeout=15 \
+	-o IdentitiesOnly=yes \
+	-o ServerAliveInterval=30 \
+	-o ServerAliveCountMax=4 \
+	-o StrictHostKeyChecking=yes \
+	"$probe_remote" "$probe_command" >/dev/null; then
+	printf 'Refreshed %s, but the remote socket listener probe failed.\n' "$unit" >&2
+	exit 1
+fi
+
+if [[ "${DEADTREES_TUNNEL_REFRESH_VERBOSE:-0}" == '1' ]]; then
+	printf 'Refreshed %s: %s -> %s; remote socket listener ready.\n' \
+		"$unit" "$old_pid" "$replacement_pid"
+fi

--- a/scripts/tests/test_database_backup_scripts.py
+++ b/scripts/tests/test_database_backup_scripts.py
@@ -710,6 +710,8 @@ def test_tunnel_refresh_restarts_the_active_service(tmp_path):
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
 	ssh = tmp_path / 'ssh'
+	socket_test = tmp_path / 'socket-test'
+	ss = tmp_path / 'ss'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -737,7 +739,16 @@ printf 'new' >"$FAKE_STATE"
 """,
 	)
 	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
-	_write_executable(ssh, '#!/usr/bin/env bash\nprintf \'ssh:%s\\n\' "$*" >>"$FAKE_COMMAND_LOG"\n')
+	_write_executable(
+		ssh,
+		"""#!/usr/bin/env bash
+printf 'ssh:%s\n' "$*" >>"$FAKE_COMMAND_LOG"
+export SSH_ORIGINAL_COMMAND=tunnel-status
+exec "$FAKE_REMOTE_HELPER"
+""",
+	)
+	_write_executable(socket_test, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(ss, "#!/usr/bin/env bash\nprintf 'u_str LISTEN /tmp/borg.sock\\n'\n")
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
@@ -749,6 +760,9 @@ printf 'new' >"$FAKE_STATE"
 		'DEADTREES_TUNNEL_REFRESH_VERBOSE': '1',
 		'FAKE_COMMAND_LOG': str(command_log),
 		'FAKE_STATE': str(state),
+		'FAKE_REMOTE_HELPER': str(DATABASE_BACKUP_REMOTE),
+		'DEADTREES_DB_BACKUP_SOCKET_TEST_BIN': str(socket_test),
+		'DEADTREES_DB_BACKUP_SS_BIN': str(ss),
 	}
 
 	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
@@ -852,6 +866,8 @@ def test_tunnel_refresh_fails_if_remote_listener_probe_fails(tmp_path):
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
 	ssh = tmp_path / 'ssh'
+	socket_test = tmp_path / 'socket-test'
+	ss = tmp_path / 'ss'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -865,7 +881,15 @@ exit 0
 	)
 	_write_executable(kill, '#!/usr/bin/env bash\nprintf new >"$FAKE_STATE"\n')
 	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
-	_write_executable(ssh, '#!/usr/bin/env bash\nexit 23\n')
+	_write_executable(
+		ssh,
+		"""#!/usr/bin/env bash
+export SSH_ORIGINAL_COMMAND=tunnel-status
+exec "$FAKE_REMOTE_HELPER"
+""",
+	)
+	_write_executable(socket_test, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(ss, '#!/usr/bin/env bash\nexit 0\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
@@ -875,6 +899,9 @@ exit 0
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'FAKE_STATE': str(state),
+		'FAKE_REMOTE_HELPER': str(DATABASE_BACKUP_REMOTE),
+		'DEADTREES_DB_BACKUP_SOCKET_TEST_BIN': str(socket_test),
+		'DEADTREES_DB_BACKUP_SS_BIN': str(ss),
 	}
 
 	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)

--- a/scripts/tests/test_database_backup_scripts.py
+++ b/scripts/tests/test_database_backup_scripts.py
@@ -5,7 +5,6 @@ import subprocess
 import time
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[2]
 DATABASE_BACKUP = ROOT / 'scripts' / 'backup' / 'deadtrees-database-backup'
 DATABASE_BACKUP_REMOTE = ROOT / 'scripts' / 'backup' / 'deadtrees-db-backup-remote'
@@ -13,6 +12,7 @@ DATABASE_BACKUP_STREAM = ROOT / 'scripts' / 'backup' / 'deadtrees-db-backup-stre
 DATABASE_BORG_ARCHIVE = ROOT / 'scripts' / 'backup' / 'deadtrees-db-borg-archive'
 DATABASE_BORG_RSH = ROOT / 'scripts' / 'backup' / 'deadtrees-borg-rsh'
 DATABASE_BORG_TUNNEL_GUARD = ROOT / 'scripts' / 'backup' / 'deadtrees-borg-tunnel-guard'
+DATABASE_TUNNEL_REFRESH = ROOT / 'scripts' / 'backup' / 'deadtrees-refresh-database-tunnel'
 BACKUP_SYSTEMD = ROOT / 'scripts' / 'backup' / 'systemd'
 BACKUP_SSHD_CONFIG = ROOT / 'scripts' / 'backup' / 'sshd_config.d' / 'deadtrees-borg.conf'
 BACKUP_TMPFILES = ROOT / 'scripts' / 'backup' / 'tmpfiles.d'
@@ -702,6 +702,117 @@ def test_tunnel_guard_denies_arbitrary_remote_command():
 	assert result.stderr == 'Command denied.\n'
 
 
+def test_tunnel_refresh_restarts_the_active_service(tmp_path):
+	state = tmp_path / 'state'
+	state.write_text('old')
+	command_log = tmp_path / 'commands.log'
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	sleep = tmp_path / 'sleep'
+	_write_executable(
+		systemctl,
+		"""#!/usr/bin/env bash
+set -eu
+if [[ "$1" == show ]]; then
+	if [[ "$*" == *User* ]]; then
+		printf 'remote-backup\n'
+		exit 0
+	fi
+	[[ "$(cat "$FAKE_STATE")" == old ]] && printf '101\n' || printf '202\n'
+	exit 0
+fi
+if [[ "$1" == is-active && "$(cat "$FAKE_STATE")" == new ]]; then
+	exit 0
+fi
+exit 1
+""",
+	)
+	_write_executable(
+		kill,
+		"""#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >>"$FAKE_COMMAND_LOG"
+printf 'new' >"$FAKE_STATE"
+""",
+	)
+	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_VERBOSE': '1',
+		'FAKE_COMMAND_LOG': str(command_log),
+		'FAKE_STATE': str(state),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 0, result.stderr
+	assert command_log.read_text() == '-TERM 101\n'
+	assert '101 -> 202' in result.stdout
+
+
+def test_tunnel_refresh_fails_if_service_does_not_restart(tmp_path):
+	command_log = tmp_path / 'commands.log'
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	sleep = tmp_path / 'sleep'
+	_write_executable(
+		systemctl,
+		"""#!/usr/bin/env bash
+[[ "$*" == *User* ]] && printf 'remote-backup\n' && exit 0
+[[ "$1" == show ]] && printf '101\n' && exit 0
+exit 1
+""",
+	)
+	_write_executable(kill, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >>"$FAKE_COMMAND_LOG"\n')
+	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_TIMEOUT_SECONDS': '2',
+		'FAKE_COMMAND_LOG': str(command_log),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 1
+	assert command_log.read_text() == '-TERM 101\n'
+	assert 'Failed to refresh' in result.stderr
+
+
+def test_tunnel_refresh_refuses_a_service_owned_by_another_user(tmp_path):
+	kill_marker = tmp_path / 'kill-ran'
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	_write_executable(
+		systemctl,
+		"""#!/usr/bin/env bash
+[[ "$*" == *User* ]] && printf 'deadtrees-db-tunnel\n' && exit 0
+printf '101\n'
+""",
+	)
+	_write_executable(kill, '#!/usr/bin/env bash\ntouch "$FAKE_KILL_MARKER"\n')
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'FAKE_KILL_MARKER': str(kill_marker),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 1
+	assert 'does not match current user' in result.stderr
+	assert not kill_marker.exists()
+
+
 def test_systemd_units_and_sshd_policy_restrict_reverse_transport():
 	socket = (BACKUP_SYSTEMD / 'database-backup-borg.socket').read_text()
 	server = (BACKUP_SYSTEMD / 'database-backup-borg@.service').read_text()
@@ -739,7 +850,10 @@ def test_systemd_units_and_sshd_policy_restrict_reverse_transport():
 	assert repository_tmpfiles == (
 		'd /run/deadtrees-database-backup-repository 0750 remote-backup deadtrees-db-tunnel -\n'
 	)
-	assert 'from="BACKUP_HOST_SOURCE_ADDRESS",restrict,command="/home/dendro/.local/bin/deadtrees-db-backup-remote"' in playbook
+	assert (
+		'from="BACKUP_HOST_SOURCE_ADDRESS",restrict,command="/home/dendro/.local/bin/deadtrees-db-backup-remote"'
+		in playbook
+	)
 	assert 'from="127.0.0.1",restrict,command=' in playbook
 
 

--- a/scripts/tests/test_database_backup_scripts.py
+++ b/scripts/tests/test_database_backup_scripts.py
@@ -709,6 +709,7 @@ def test_tunnel_refresh_restarts_the_active_service(tmp_path):
 	systemctl = tmp_path / 'systemctl'
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
+	ssh = tmp_path / 'ssh'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -736,12 +737,15 @@ printf 'new' >"$FAKE_STATE"
 """,
 	)
 	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(ssh, '#!/usr/bin/env bash\nprintf \'ssh:%s\\n\' "$*" >>"$FAKE_COMMAND_LOG"\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'DEADTREES_TUNNEL_REFRESH_VERBOSE': '1',
 		'FAKE_COMMAND_LOG': str(command_log),
 		'FAKE_STATE': str(state),
@@ -750,8 +754,12 @@ printf 'new' >"$FAKE_STATE"
 	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
 
 	assert result.returncode == 0, result.stderr
-	assert command_log.read_text() == '-TERM 101\n'
+	commands = command_log.read_text().splitlines()
+	assert commands[0] == '-TERM 101'
+	assert commands[1].startswith('ssh:-i /home/remote-backup/.ssh/id_ed25519 ')
+	assert commands[1].endswith('dendro@data2.deadtrees.earth tunnel-status')
 	assert '101 -> 202' in result.stdout
+	assert 'remote socket listener ready' in result.stdout
 
 
 def test_tunnel_refresh_fails_if_service_does_not_restart(tmp_path):
@@ -775,6 +783,7 @@ exit 1
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'DEADTREES_TUNNEL_REFRESH_TIMEOUT_SECONDS': '2',
 		'FAKE_COMMAND_LOG': str(command_log),
 	}
@@ -784,6 +793,94 @@ exit 1
 	assert result.returncode == 1
 	assert command_log.read_text() == '-TERM 101\n'
 	assert 'Failed to refresh' in result.stderr
+
+
+def test_tunnel_refresh_fails_if_replacement_dies_during_settle(tmp_path):
+	state = tmp_path / 'state'
+	state.write_text('old')
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	sleep = tmp_path / 'sleep'
+	ssh = tmp_path / 'ssh'
+	_write_executable(
+		systemctl,
+		"""#!/usr/bin/env bash
+if [[ "$*" == *User* ]]; then printf 'remote-backup\n'; exit 0; fi
+if [[ "$1" == show ]]; then
+	case "$(cat "$FAKE_STATE")" in
+	old) printf '101\n' ;;
+	new) printf '202\n' ;;
+	failed) printf '0\n' ;;
+	esac
+	exit 0
+fi
+[[ "$(cat "$FAKE_STATE")" != failed ]]
+""",
+	)
+	_write_executable(kill, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(
+		sleep,
+		"""#!/usr/bin/env bash
+if [[ "$1" == 1 ]]; then printf 'new' >"$FAKE_STATE"; else printf 'failed' >"$FAKE_STATE"; fi
+""",
+	)
+	_write_executable(ssh, '#!/usr/bin/env bash\ntouch "$FAKE_SSH_MARKER"\n')
+	ssh_marker = tmp_path / 'ssh-ran'
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
+		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '5',
+		'FAKE_STATE': str(state),
+		'FAKE_SSH_MARKER': str(ssh_marker),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 1
+	assert 'did not remain active' in result.stderr
+	assert not ssh_marker.exists()
+
+
+def test_tunnel_refresh_fails_if_remote_listener_probe_fails(tmp_path):
+	state = tmp_path / 'state'
+	state.write_text('old')
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	sleep = tmp_path / 'sleep'
+	ssh = tmp_path / 'ssh'
+	_write_executable(
+		systemctl,
+		"""#!/usr/bin/env bash
+[[ "$*" == *User* ]] && printf 'remote-backup\n' && exit 0
+if [[ "$1" == show ]]; then
+	[[ "$(cat "$FAKE_STATE")" == old ]] && printf '101\n' || printf '202\n'
+	exit 0
+fi
+exit 0
+""",
+	)
+	_write_executable(kill, '#!/usr/bin/env bash\nprintf new >"$FAKE_STATE"\n')
+	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(ssh, '#!/usr/bin/env bash\nexit 23\n')
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
+		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
+		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
+		'FAKE_STATE': str(state),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 1
+	assert 'remote socket listener probe failed' in result.stderr
 
 
 def test_tunnel_refresh_refuses_a_service_owned_by_another_user(tmp_path):

--- a/scripts/tests/test_database_backup_scripts.py
+++ b/scripts/tests/test_database_backup_scripts.py
@@ -710,6 +710,7 @@ def test_tunnel_refresh_restarts_the_active_service(tmp_path):
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
 	ssh = tmp_path / 'ssh'
+	flock = tmp_path / 'flock'
 	socket_test = tmp_path / 'socket-test'
 	ss = tmp_path / 'ss'
 	_write_executable(
@@ -749,12 +750,15 @@ exec "$FAKE_REMOTE_HELPER"
 	)
 	_write_executable(socket_test, '#!/usr/bin/env bash\nexit 0\n')
 	_write_executable(ss, "#!/usr/bin/env bash\nprintf 'u_str LISTEN /tmp/borg.sock\\n'\n")
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 0\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
 		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'DEADTREES_TUNNEL_REFRESH_VERBOSE': '1',
@@ -781,6 +785,7 @@ def test_tunnel_refresh_fails_if_service_does_not_restart(tmp_path):
 	systemctl = tmp_path / 'systemctl'
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
+	flock = tmp_path / 'flock'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -791,11 +796,14 @@ exit 1
 	)
 	_write_executable(kill, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >>"$FAKE_COMMAND_LOG"\n')
 	_write_executable(sleep, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 0\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'DEADTREES_TUNNEL_REFRESH_TIMEOUT_SECONDS': '2',
@@ -816,6 +824,7 @@ def test_tunnel_refresh_fails_if_replacement_dies_during_settle(tmp_path):
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
 	ssh = tmp_path / 'ssh'
+	flock = tmp_path / 'flock'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -839,6 +848,7 @@ if [[ "$1" == 1 ]]; then printf 'new' >"$FAKE_STATE"; else printf 'failed' >"$FA
 """,
 	)
 	_write_executable(ssh, '#!/usr/bin/env bash\ntouch "$FAKE_SSH_MARKER"\n')
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 0\n')
 	ssh_marker = tmp_path / 'ssh-ran'
 	env = {
 		**os.environ,
@@ -846,6 +856,8 @@ if [[ "$1" == 1 ]]; then printf 'new' >"$FAKE_STATE"; else printf 'failed' >"$FA
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
 		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '5',
 		'FAKE_STATE': str(state),
@@ -866,6 +878,7 @@ def test_tunnel_refresh_fails_if_remote_listener_probe_fails(tmp_path):
 	kill = tmp_path / 'kill'
 	sleep = tmp_path / 'sleep'
 	ssh = tmp_path / 'ssh'
+	flock = tmp_path / 'flock'
 	socket_test = tmp_path / 'socket-test'
 	ss = tmp_path / 'ss'
 	_write_executable(
@@ -890,12 +903,15 @@ exec "$FAKE_REMOTE_HELPER"
 	)
 	_write_executable(socket_test, '#!/usr/bin/env bash\nexit 0\n')
 	_write_executable(ss, '#!/usr/bin/env bash\nexit 0\n')
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 0\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
 		'DEADTREES_TUNNEL_REFRESH_SLEEP_BIN': str(sleep),
 		'DEADTREES_TUNNEL_REFRESH_SSH_BIN': str(ssh),
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'DEADTREES_TUNNEL_REFRESH_SETTLE_SECONDS': '1',
 		'FAKE_STATE': str(state),
@@ -914,6 +930,7 @@ def test_tunnel_refresh_refuses_a_service_owned_by_another_user(tmp_path):
 	kill_marker = tmp_path / 'kill-ran'
 	systemctl = tmp_path / 'systemctl'
 	kill = tmp_path / 'kill'
+	flock = tmp_path / 'flock'
 	_write_executable(
 		systemctl,
 		"""#!/usr/bin/env bash
@@ -922,10 +939,13 @@ printf '101\n'
 """,
 	)
 	_write_executable(kill, '#!/usr/bin/env bash\ntouch "$FAKE_KILL_MARKER"\n')
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 0\n')
 	env = {
 		**os.environ,
 		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
 		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
 		'DEADTREES_TUNNEL_REFRESH_CURRENT_USER': 'remote-backup',
 		'FAKE_KILL_MARKER': str(kill_marker),
 	}
@@ -934,6 +954,33 @@ printf '101\n'
 
 	assert result.returncode == 1
 	assert 'does not match current user' in result.stderr
+	assert not kill_marker.exists()
+
+
+def test_tunnel_refresh_leaves_tunnel_untouched_when_backup_lock_is_held(tmp_path):
+	flock = tmp_path / 'flock'
+	systemctl = tmp_path / 'systemctl'
+	kill = tmp_path / 'kill'
+	systemctl_marker = tmp_path / 'systemctl-ran'
+	kill_marker = tmp_path / 'kill-ran'
+	_write_executable(flock, '#!/usr/bin/env bash\nexit 1\n')
+	_write_executable(systemctl, '#!/usr/bin/env bash\ntouch "$FAKE_SYSTEMCTL_MARKER"\n')
+	_write_executable(kill, '#!/usr/bin/env bash\ntouch "$FAKE_KILL_MARKER"\n')
+	env = {
+		**os.environ,
+		'DEADTREES_TUNNEL_REFRESH_FLOCK_BIN': str(flock),
+		'DEADTREES_TUNNEL_REFRESH_LOCK_FILE': str(tmp_path / 'backup.lock'),
+		'DEADTREES_TUNNEL_REFRESH_SYSTEMCTL_BIN': str(systemctl),
+		'DEADTREES_TUNNEL_REFRESH_KILL_BIN': str(kill),
+		'FAKE_SYSTEMCTL_MARKER': str(systemctl_marker),
+		'FAKE_KILL_MARKER': str(kill_marker),
+	}
+
+	result = subprocess.run([DATABASE_TUNNEL_REFRESH], env=env, text=True, capture_output=True, check=False)
+
+	assert result.returncode == 75
+	assert 'a database backup is active' in result.stderr
+	assert not systemctl_marker.exists()
 	assert not kill_marker.exists()
 
 


### PR DESCRIPTION
## Briefing

Versions the temporary pre-backup tunnel refresh that is already protecting the current DeadTrees production backup during the three-week holiday window. The guard serializes against active backups, replaces a stale reverse-SSH session before the nightly run, waits for the replacement to settle, and verifies the database-host Unix socket is actively listening. This is reliability mitigation for the current shared-socket transport, not the pending least-privilege transport rollout.

## What changed

- Acquire the canonical database-backup lock before inspecting or signaling the tunnel; leave it untouched when a backup is active.
- Add a silent-on-success helper that terminates only the active reverse-tunnel main process and requires systemd to replace it with a distinct active PID.
- Require the replacement PID to survive a five-second settle window and pass the lifecycle key's remote `tunnel-status` listener probe.
- Version the forced lifecycle helper's temporary `tunnel-status` contract, requiring both the legacy socket and an active `ss` listener.
- Refuse to act when the service owner differs from the invoking user, preventing accidental use after the dedicated tunnel identity is installed.
- Document the 01:50 guard, 02:00 backup ordering, September 2 expiry, installation boundary, and rollback requirement.

## Validation

- `PYTHONPATH=. uv run --no-project --with pytest pytest -q scripts/tests/test_database_backup_scripts.py` — 34 passed locally on macOS, including held-lock no-signal coverage.
- Bash syntax for both changed helpers — passed locally.
- `scripts/lint-python.sh` — passed locally.
- `scripts/lint-ast-grep.sh` — passed locally.
- Targeted Ruff check and format check plus `git diff --check` — passed locally.
- Read-only production compatibility check — service and invoking user are both `remote-backup`, `/usr/bin/kill` and the canonical backup lock path are available, tunnel active.
- Read-only production listener probe using the helper's exact SSH options and forced `tunnel-status` command — returned `ready`.
- Existing live equivalent was exercised before this PR: tunnel PID changed, replacement database archive committed with exit 0, Borg maintenance/check passed, and staging plus dump sessions were absent.

## Risk and limitations

The helper intentionally supports only the temporary `remote-backup`-owned service and must be removed before installing the tracked dedicated `deadtrees-db-tunnel` unit. Its remote probe verifies the database-host socket is an active listener; it does not change the current shared socket permissions or provide the long-term least-privilege hardening.
